### PR TITLE
Add option to disable load of summary from internet and support opml xml files

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -539,7 +539,8 @@ export default class RssDashboardPlugin extends Plugin {
         input.type = "file";
         input.onchange = async () => {
             const file = input.files?.[0];
-            if (file && file.name.endsWith('.opml')) {
+            const allowedExtensions = ['.opml', '.opml.xml'];
+            if (file && allowedExtensions.some(ext => file.name.endsWith(ext))) {
                 const content = await file.text();
                 try {
                     

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -257,20 +257,37 @@ export class RssDashboardSettingTab extends PluginSettingTab {
                     })
             );
 
-            new Setting(containerEl)
-            .setName("Use Domain Favicons")
-            .setDesc("Show domain-specific favicons instead of generic RSS icons for feeds")
-            .addToggle((toggle) =>
-                toggle
-                    .setValue(this.plugin.settings.display.useDomainFavicons)
-                    .onChange(async (value) => {
-                        this.plugin.settings.display.useDomainFavicons = value;
-                        await this.plugin.saveSettings();
-                        if (this.plugin.view?.sidebar) {
-                            this.plugin.view.sidebar.render();
-                        }
-                    })
-            );
+        new Setting(containerEl)
+        .setName("Use Domain Favicons")
+        .setDesc("Show domain-specific favicons instead of generic RSS icons for feeds")
+        .addToggle((toggle) =>
+            toggle
+                .setValue(this.plugin.settings.display.useDomainFavicons)
+                .onChange(async (value) => {
+                    this.plugin.settings.display.useDomainFavicons = value;
+                    await this.plugin.saveSettings();
+                    if (this.plugin.view?.sidebar) {
+                        this.plugin.view.sidebar.render();
+                    }
+                })
+        );
+
+        new Setting(containerEl)
+        .setName("Fetch Full article text")
+        .setDesc("On opening an article, fetches the full content instead of what is present in the feed")
+        .addToggle((toggle) =>
+            toggle
+                .setValue(this.plugin.settings.display.fetchFullArticleText)
+                .onChange(async (value) => {
+                    this.plugin.settings.display.fetchFullArticleText = value;
+                    await this.plugin.saveSettings();
+                    if (this.plugin.view?.sidebar) {
+                        this.plugin.view.sidebar.render();
+                    }
+                })
+        );
+        
+            
 
         new Setting(containerEl)
             .setName("Filter Display Style")

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -139,6 +139,7 @@ export interface DisplaySettings {
     defaultFilter: "all" | "starred" | "unread" | "read" | "saved" | "videos" | "podcasts";
     hiddenFilters: string[];
     useDomainFavicons: boolean;
+    fetchFullArticleText: boolean;
 }
 
 
@@ -273,6 +274,7 @@ guid: "{{guid}}"
         filterDisplayStyle: "inline",
         defaultFilter: "all",
         hiddenFilters: [],
-        useDomainFavicons: true
+        useDomainFavicons: true,
+        fetchFullArticleText: true
     }
 };

--- a/src/views/reader-view.ts
+++ b/src/views/reader-view.ts
@@ -274,7 +274,12 @@ export class ReaderView extends ItemView {
             }
             this.displayPodcast(item);
         } else {
-            const fullContent = await this.fetchFullArticleContent(item.link);
+            let fullContent = "";
+            if(this.settings.display.fetchFullArticleText){
+                fullContent = await this.fetchFullArticleContent(item.link);
+            } else {
+                fullContent = !!(item?.content) ? item?.content : await this.fetchFullArticleContent(item.link);
+            }
             this.currentFullContent = fullContent;
             this.displayArticle(item, fullContent);
         }


### PR DESCRIPTION
In some articles the fetch summary from the links is messy, but the field in the content of rss is good.

Example of feeds like this - Reddit RSS feeds