### PR TITLE
Fix: existing items that drop off feed reappear as unread

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -30,7 +30,7 @@ import {
   RSS_SMALLWEB_VIEW_TYPE,
 } from "./src/views/kagi-smallweb-view";
 import { ReaderView, RSS_READER_VIEW_TYPE } from "./src/views/reader-view";
-import { FeedParser } from "./src/services/feed-parser";
+import { FeedParser, setSimulateEmptyFetch, getSimulateEmptyFetch } from "./src/services/feed-parser";
 import { ArticleSaver } from "./src/services/article-saver";
 import { OpmlManager } from "./src/services/opml-manager";
 import { MediaService } from "./src/services/media-service";
@@ -271,6 +271,16 @@ export default class RssDashboardPlugin extends Plugin {
         name: "Apply feed limits to all feeds",
         callback: () => {
           void this.applyFeedLimitsToAllFeeds();
+        },
+      });
+
+      this.addCommand({
+        id: "toggle-simulate-empty-fetch",
+        name: "Debug: toggle simulate empty feed response",
+        callback: () => {
+          const newValue = !getSimulateEmptyFetch();
+          setSimulateEmptyFetch(newValue);
+          new Notice(`Simulate empty fetch: ${newValue ? "ON" : "OFF"}`);
         },
       });
 

--- a/src/services/feed-parser.ts
+++ b/src/services/feed-parser.ts
@@ -340,7 +340,21 @@ async function discoverFeedUrl(baseUrl: string): Promise<string | null> {
   return null;
 }
 
+let simulateEmptyFetch = false;
+
+export function setSimulateEmptyFetch(value: boolean): void {
+  simulateEmptyFetch = value;
+}
+
+export function getSimulateEmptyFetch(): boolean {
+  return simulateEmptyFetch;
+}
+
 export async function fetchFeedXml(url: string): Promise<string> {
+  if (simulateEmptyFetch) {
+    console.warn("[RSS Debug] simulateEmptyFetch is ON — returning empty feed for:", url);
+    return `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>Empty (simulated)</title></channel></rss>`;
+  }
   const isAndroid = Platform.isAndroidApp;
 
   async function tryFetch(targetUrl: string): Promise<string> {

--- a/src/services/feed-parser.ts
+++ b/src/services/feed-parser.ts
@@ -2450,6 +2450,7 @@ export class FeedParser {
 
     const newItems: FeedItem[] = [];
     const updatedItems: FeedItem[] = [];
+    const matchedExistingGuids = new Set<string>();
 
     parsed.items.forEach((item: ParsedItem) => {
       const isAudioEnclosure = item.enclosure?.type?.startsWith("audio/");
@@ -2479,6 +2480,7 @@ export class FeedParser {
       const existingItem = existingItems.get(itemGuid);
 
       if (existingItem) {
+        matchedExistingGuids.add(existingItem.guid);
         let coverImage = existingItem.coverImage;
         if (isPodcast) {
           coverImage =
@@ -2660,12 +2662,7 @@ export class FeedParser {
 
     if (existingFeed) {
       existingFeed.items.forEach((item) => {
-        const itemGuid = this.convertToAbsoluteUrl(
-          item.guid || item.link || "",
-          url,
-        );
-
-        if (!existingItems.has(itemGuid)) {
+        if (!matchedExistingGuids.has(item.guid)) {
           allItems.push(item);
         }
       });


### PR DESCRIPTION
## Summary
- Includes a debug command ("simulate empty feed response") to reproduce the issue
- You don't need to merge both commits, if you prefer just cherry pick the first commit (fixing the bug)

### Main bug
The merge logic in parseFeed was supposed to preserve existing items that are no longer in the feed XML (e.g., older items that
dropped off). However, the check !existingItems.has(itemGuid) compared against the map of all existing items (built from the
same collection), making it essentially a no-op. Existing items not in the current fetch were silently discarded.

When those items later reappeared in the feed (e.g., YouTube feed order changed), they were treated as brand-new entries with
read: false.

Fix: Track which existing items were matched by parsed items using matchedExistingGuids. Then preserve existing items whose GUID
was not matched by any parsed item, instead of using the broken self-referencing check.


## Test plan
- [ ] Enable the debug command to simulate an empty feed response
- [ ] Update one of the feeds
- [ ] Disable the debug command to simulate an empty feed response
- [ ] Update the same feed

Previously all items from that feed would re-appear as "unread", with this fix they stay "read".

I was able to restart the obsidian after simulating the empty response, and my fix still works.