### PR TITLE
Fix: auto-deleted items reappearing as unread on refresh

### DIFF
--- a/src/services/feed-parser.ts
+++ b/src/services/feed-parser.ts
@@ -2976,6 +2976,15 @@ export class FeedParser {
     const updatedItems: FeedItem[] = [];
     const seenGuids = new Set<string>();
 
+    // Compute auto-delete cutoff so we can skip "new" items that are actually
+    // old entries re-appearing in the feed after being auto-deleted.
+    const autoDeleteDays =
+      typeof newFeed.autoDeleteDuration === "number"
+        ? newFeed.autoDeleteDuration
+        : 0;
+    const autoDeleteCutoffMs =
+      autoDeleteDays > 0 ? Date.now() - autoDeleteDays * 24 * 60 * 60 * 1000 : 0;
+
     for (const item of parsed.items) {
       const isAudioEnclosure = item.enclosure?.type?.startsWith("audio/");
       const isAudioLink = !!(item.link && item.link.includes(".mp3"));
@@ -3079,6 +3088,16 @@ export class FeedParser {
         };
         updatedItems.push(updatedItem);
       } else {
+        // Skip items older than the auto-delete cutoff during refresh.
+        // These were likely auto-deleted previously and should not reappear as unread.
+        if (
+          existingFeed &&
+          autoDeleteCutoffMs > 0 &&
+          getPubDateMs(item.pubDate) <= autoDeleteCutoffMs
+        ) {
+          continue;
+        }
+
         let coverImage = "";
         if (isPodcast) {
           coverImage = this.extractPodcastCoverImage(item, parsed.image, url);

--- a/test_files/unit/services/feed-parser.test.ts
+++ b/test_files/unit/services/feed-parser.test.ts
@@ -515,6 +515,65 @@ describe("FeedParser.parseFeed", () => {
 
     requestUrlSpy.mockRestore();
   });
+
+  it("skips new items older than autoDeleteDuration cutoff during refresh", async () => {
+    const feedUrl = "https://example.com/feed.xml";
+
+    // Feed contains one recent item and one very old item
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Recent Article</title>
+      <link>https://example.com/recent</link>
+      <description>recent desc</description>
+      <pubDate>Mon, 30 Mar 2026 00:00:00 GMT</pubDate>
+      <guid>https://example.com/recent</guid>
+    </item>
+    <item>
+      <title>Old Article</title>
+      <link>https://example.com/old</link>
+      <description>old desc</description>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+      <guid>https://example.com/old</guid>
+    </item>
+  </channel>
+</rss>`;
+
+    const requestUrlSpy = vi.spyOn(obsidian, "requestUrl");
+    requestUrlSpy.mockResolvedValueOnce({
+      status: 200,
+      headers: {},
+      arrayBuffer: new ArrayBuffer(0),
+      json: {},
+      text: xml,
+    });
+
+    const parser = new FeedParser(mediaSettings, []);
+
+    // Simulate an existing feed (refresh scenario) with autoDeleteDuration of 365 days.
+    // The old article (Jan 2024) is beyond the cutoff and not in the existing items,
+    // meaning it was previously auto-deleted. It should NOT reappear as unread.
+    const existingFeed: Feed = {
+      title: "Test Feed",
+      url: feedUrl,
+      folder: "Uncategorized",
+      items: [],
+      lastUpdated: Date.now(),
+      autoDeleteDuration: 365,
+    };
+
+    const result = await parser.parseFeed(feedUrl, existingFeed);
+
+    // Only the recent article should be present; the old one should be skipped
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].guid).toBe("https://example.com/recent");
+    expect(result.items[0].read).toBe(false);
+
+    requestUrlSpy.mockRestore();
+  });
 });
 
 describe("applyFeedRetentionLimits", () => {


### PR DESCRIPTION
## Summary
- Fixes a bug where feed items older than the `autoDeleteDuration` cutoff reappear as unread after every refresh
- Root cause: auto-delete removes read items from local cache, but they still exist in the feed XML — on next refresh they're treated as new unread items, creating an infinite cycle
- Fix: during refresh, skip new items whose `pubDate` is older than the auto-delete cutoff (they were likely auto-deleted previously)

## Test plan
- [x] Added unit test covering the scenario (old item beyond cutoff skipped during refresh)
- [x] All 419 existing tests pass
- [x] Build and lint pass cleanly
- [x] I have some youtube subscriptions such as "Algorithmic Simplicity" https://www.youtube.com/feeds/videos.xml?channel_id=UC3sH8ShnMyB5MxavG1DaklA and they don't re-appear after reload