### PR TITLE
feat: Sort feeds by unread count

### DIFF
--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -2472,6 +2472,16 @@ export class Sidebar {
       );
       menu.addItem((item) =>
         item
+          .setTitle("Unread count (high to low)")
+          .onClick(() => void this.sortAllFeeds("unreadCount", false)),
+      );
+      menu.addItem((item) =>
+        item
+          .setTitle("Unread count (low to high)")
+          .onClick(() => void this.sortAllFeeds("unreadCount", true)),
+      );
+      menu.addItem((item) =>
+        item
           .setTitle("Folder name (a to z)")
           .onClick(() => void this.sortFolders("name", true)),
       );
@@ -2630,6 +2640,16 @@ export class Sidebar {
       menu.addItem((item) =>
         item.setTitle("Feed name (z to a)").onClick(() => {
           void this.sortAllFeeds("name", false);
+        }),
+      );
+      menu.addItem((item) =>
+        item.setTitle("Unread count (high to low)").onClick(() => {
+          void this.sortAllFeeds("unreadCount", false);
+        }),
+      );
+      menu.addItem((item) =>
+        item.setTitle("Unread count (low to high)").onClick(() => {
+          void this.sortAllFeeds("unreadCount", true);
         }),
       );
       menu.addItem((item) =>
@@ -3092,7 +3112,7 @@ export class Sidebar {
 
   private async sortFeedsInFolder(
     folderPath: string,
-    by: "name" | "created" | "itemCount",
+    by: "name" | "created" | "itemCount" | "unreadCount",
     ascending: boolean,
   ) {
     let feedsInFolder: Feed[];
@@ -3147,7 +3167,7 @@ export class Sidebar {
   private applyFeedSortOrder(
     feeds: Feed[],
     sortOrder: {
-      by: "name" | "created" | "itemCount" | "custom";
+      by: "name" | "created" | "itemCount" | "unreadCount" | "custom";
       ascending: boolean;
     },
   ): Feed[] {
@@ -3155,7 +3175,7 @@ export class Sidebar {
   }
 
   private async sortAllFeeds(
-    by: "name" | "created" | "itemCount",
+    by: "name" | "created" | "itemCount" | "unreadCount",
     ascending: boolean,
   ) {
     if (!this.settings.folderFeedSortOrders) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -313,12 +313,12 @@ export interface RssDashboardSettings {
     ascending: boolean;
   };
   feedSortOrder?: {
-    by: "name" | "created" | "itemCount" | "custom";
+    by: "name" | "created" | "itemCount" | "unreadCount" | "custom";
     ascending: boolean;
   };
   folderFeedSortOrders?: {
     [folderPath: string]: {
-      by: "name" | "created" | "itemCount" | "custom";
+      by: "name" | "created" | "itemCount" | "unreadCount" | "custom";
       ascending: boolean;
     };
   };

--- a/src/utils/sidebar-sort-utils.ts
+++ b/src/utils/sidebar-sort-utils.ts
@@ -1,6 +1,11 @@
 import type { Feed } from "../types/types";
 
-export type FeedSortBy = "name" | "created" | "itemCount" | "custom";
+export type FeedSortBy =
+  | "name"
+  | "created"
+  | "itemCount"
+  | "unreadCount"
+  | "custom";
 
 export interface FeedSortOrder {
   by: FeedSortBy;
@@ -36,6 +41,10 @@ export function applyFeedSortOrder(
       case "itemCount":
         valA = a.items.length;
         valB = b.items.length;
+        break;
+      case "unreadCount":
+        valA = a.items.filter((item) => !item.read).length;
+        valB = b.items.filter((item) => !item.read).length;
         break;
       default:
         return 0;

--- a/test_files/unit/views/sidebar-sort.test.ts
+++ b/test_files/unit/views/sidebar-sort.test.ts
@@ -101,6 +101,78 @@ describe("Sidebar Feed Sorting", () => {
     });
   });
 
+  describe("Unread Count Sorting", () => {
+    it("sorts lowest to highest unread count (ascending)", () => {
+      const feedWithOneUnread = makeFeedWithItems("One Unread", 1000, 4);
+      feedWithOneUnread.items[1].read = true;
+      feedWithOneUnread.items[2].read = true;
+      feedWithOneUnread.items[3].read = true;
+
+      const feedWithTwoUnread = makeFeedWithItems("Two Unread", 1000, 3);
+      feedWithTwoUnread.items[2].read = true;
+
+      const feedWithZeroUnread = makeFeedWithItems("Zero Unread", 1000, 2);
+      feedWithZeroUnread.items.forEach((item) => {
+        item.read = true;
+      });
+
+      const sorted = applyFeedSortOrder(
+        [feedWithOneUnread, feedWithTwoUnread, feedWithZeroUnread],
+        { by: "unreadCount", ascending: true },
+      );
+
+      expect(sorted.map((feed) => feed.title)).toEqual([
+        "Zero Unread",
+        "One Unread",
+        "Two Unread",
+      ]);
+    });
+
+    it("sorts highest to lowest unread count (descending)", () => {
+      const feedWithThreeUnread = makeFeedWithItems("Three Unread", 1000, 3);
+
+      const feedWithTwoUnread = makeFeedWithItems("Two Unread", 1000, 3);
+      feedWithTwoUnread.items[2].read = true;
+
+      const feedWithOneUnread = makeFeedWithItems("One Unread", 1000, 4);
+      feedWithOneUnread.items[1].read = true;
+      feedWithOneUnread.items[2].read = true;
+      feedWithOneUnread.items[3].read = true;
+
+      const sorted = applyFeedSortOrder(
+        [feedWithOneUnread, feedWithTwoUnread, feedWithThreeUnread],
+        { by: "unreadCount", ascending: false },
+      );
+
+      expect(sorted.map((feed) => feed.title)).toEqual([
+        "Three Unread",
+        "Two Unread",
+        "One Unread",
+      ]);
+    });
+
+    it("does not misorder feeds that have equal unread counts", () => {
+      const first = makeFeedWithItems("First", 1000, 2);
+      const second = makeFeedWithItems("Second", 1000, 2);
+      const third = makeFeedWithItems("Third", 1000, 2);
+
+      first.items[1].read = true;
+      second.items[1].read = true;
+      third.items[1].read = true;
+
+      const sorted = applyFeedSortOrder([first, second, third], {
+        by: "unreadCount",
+        ascending: true,
+      });
+
+      expect(sorted.map((feed) => feed.title)).toEqual([
+        "First",
+        "Second",
+        "Third",
+      ]);
+    });
+  });
+
   describe("Stability on Equal Values", () => {
     it("maintains order when sorting by a property that is equal", () => {
       const f1 = makeFeedWithItems("A", 1000, 2);


### PR DESCRIPTION
- **Sort feeds by unread count**
  - Added a new option to the 'Sort' icon which organizes feeds by unread count. 
  - Two options: High to Low / Low to High
