### PR TITLE
fix: Fixed a bug where the Obsidian tab title was not properly updati…

### DIFF
--- a/src/views/reader-view.ts
+++ b/src/views/reader-view.ts
@@ -174,6 +174,30 @@ export class ReaderView extends ItemView {
     return "file-text";
   }
 
+  private getEffectiveReaderTitle(): string {
+    if (!this.currentItem) {
+      return "RSS reader";
+    }
+
+    return (
+      this.currentReaderTitle ||
+      this.currentDisplayTitle ||
+      this.currentItem.title
+    );
+  }
+
+  private syncReaderTitle(): void {
+    if (this.titleElement) {
+      this.titleElement.setText(this.getEffectiveReaderTitle());
+    }
+
+    (
+      this.leaf as WorkspaceLeaf & {
+        updateHeader?: () => void;
+      }
+    ).updateHeader?.();
+  }
+
   onOpen(): Promise<void> {
     this.contentEl.empty();
     this.contentEl.addClass("rss-reader-view");
@@ -593,10 +617,7 @@ export class ReaderView extends ItemView {
       ? this.formatNitterReaderTitle(item)
       : undefined;
     this.currentContentIsFullArticle = false;
-
-    if (this.titleElement) {
-      this.titleElement.setText(this.currentReaderTitle || item.title);
-    }
+    this.syncReaderTitle();
 
     // Update toggle button states
     this.updateToggleButtons();
@@ -660,12 +681,7 @@ export class ReaderView extends ItemView {
       this.currentFullContent = fullContent;
       this.currentDisplayTitle = displayTitle || undefined;
       this.currentContentIsFullArticle = hasFullArticleContent;
-
-      if (this.titleElement) {
-        this.titleElement.setText(
-          this.currentReaderTitle || this.currentDisplayTitle || item.title,
-        );
-      }
+      this.syncReaderTitle();
       await this.displayArticle(item, fullContent);
     }
   }
@@ -728,9 +744,11 @@ export class ReaderView extends ItemView {
 
     const onEpisodeSelected = (selectedEpisode: FeedItem) => {
       this.currentItem = selectedEpisode;
-      if (this.titleElement) {
-        this.titleElement.setText(selectedEpisode.title);
-      }
+      this.currentDisplayTitle = undefined;
+      this.currentReaderTitle = this.isTweetLikeItem(selectedEpisode)
+        ? this.formatNitterReaderTitle(selectedEpisode)
+        : undefined;
+      this.syncReaderTitle();
       this.updateToggleButtons();
       this.closeTagsDropdown();
       void this.syncDashboardSelectionFromPlayer(selectedEpisode);
@@ -2019,9 +2037,7 @@ export class ReaderView extends ItemView {
   }
 
   private resetTitle(): void {
-    if (this.titleElement) {
-      this.titleElement.setText("RSS reader");
-    }
+    this.syncReaderTitle();
   }
 
   private checkSavedFileExists(item: FeedItem): boolean {

--- a/test_files/stubs/obsidian.ts
+++ b/test_files/stubs/obsidian.ts
@@ -405,6 +405,8 @@ export class WorkspaceLeaf {
   constructor(app: App) {
     this.app = app;
   }
+
+  updateHeader(): void {}
 }
 
 export class ItemView {

--- a/test_files/unit/views/reader-view-tab-title-sync.test.ts
+++ b/test_files/unit/views/reader-view-tab-title-sync.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReaderView } from "../../../src/views/reader-view";
+import {
+  DEFAULT_SETTINGS,
+  FeedItem,
+  RssDashboardSettings,
+} from "../../../src/types/types";
+import { installObsidianDomPolyfills } from "../test-dom-polyfills";
+
+installObsidianDomPolyfills();
+
+class MockLeaf {
+  app: any;
+  view: any;
+
+  constructor(app: any) {
+    this.app = app;
+  }
+
+  detach = vi.fn();
+  updateHeader = vi.fn();
+}
+
+function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    title: "Article A",
+    link: "https://example.com/article-a",
+    description: "<p>Fallback description</p>",
+    content: "",
+    pubDate: "2026-04-01T10:00:00.000Z",
+    guid: "guid-a",
+    read: false,
+    starred: false,
+    tags: [],
+    feedTitle: "Example Feed",
+    feedUrl: "https://example.com/rss.xml",
+    coverImage: "",
+    mediaType: "article",
+    saved: false,
+    ...overrides,
+  };
+}
+
+describe("ReaderView tab title sync", () => {
+  let readerView: ReaderView;
+  let mockLeaf: MockLeaf;
+  let mockSettings: RssDashboardSettings;
+
+  beforeEach(async () => {
+    const mockApp = {
+      workspace: {
+        getLeavesOfType: vi.fn().mockReturnValue([]),
+        setActiveLeaf: vi.fn(),
+        revealLeaf: vi.fn(),
+      },
+      vault: {
+        getAbstractFileByPath: vi.fn(),
+      },
+    };
+
+    mockLeaf = new MockLeaf(mockApp);
+    mockSettings = { ...DEFAULT_SETTINGS, useWebViewer: false };
+
+    readerView = new ReaderView(
+      mockLeaf as any,
+      mockSettings,
+      { saveArticle: vi.fn() } as any,
+      vi.fn(),
+      vi.fn(),
+    );
+
+    (readerView as any).contentEl = document.createElement("div");
+    await readerView.onOpen();
+  });
+
+  it("refreshes the tab title when reusing the same reader view for another article", async () => {
+    const itemA = makeItem();
+    const itemB = makeItem({
+      title: "Article B",
+      link: "https://example.com/article-b",
+      guid: "guid-b",
+    });
+
+    (readerView as any).fetchFullArticleContent = vi
+      .fn()
+      .mockResolvedValue("");
+
+    await readerView.displayItem(itemA);
+    expect(readerView.getDisplayText()).toBe("Article A");
+    expect(mockLeaf.updateHeader).toHaveBeenCalledTimes(2);
+
+    await readerView.displayItem(itemB);
+
+    expect(readerView.getDisplayText()).toBe("Article B");
+    expect(mockLeaf.updateHeader).toHaveBeenCalledTimes(4);
+  });
+
+  it("refreshes the tab title again when fetched full article content provides a better title", async () => {
+    const item = makeItem({
+      title: "Feed Title",
+      link: "https://example.com/full-article",
+      guid: "guid-full",
+    });
+
+    (readerView as any).fetchFullArticleContent = vi.fn().mockResolvedValue(`
+      <h1>Fetched Full Article Title</h1>
+      <p>${"x".repeat(260)}</p>
+    `);
+
+    await readerView.displayItem(item);
+
+    expect(readerView.getDisplayText()).toBe("Fetched Full Article Title");
+    expect(mockLeaf.updateHeader).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
 Fixed a bug where the Obsidian tab title was not properly updating when switching between feeds.

The reader now uses a shared syncReaderTitle() helper to keep the visible header and Obsidian’s tab title aligned whenever the active article changes, including reused reader tabs, async full-article title upgrades, and podcast episode switches.

I also added a focused regression spec in reader-view-tab-title-sync.test.ts and updated the Obsidian stub in obsidian.ts with updateHeader() so the behavior is testable.