### PR TITLE
Fix: saved articles losing their status and reference to a note after Obsidian restart

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -163,10 +163,11 @@ export default class RssDashboardPlugin extends Plugin {
         this.applyMobileOptimizations();
       }
 
-      const allArticles = this.getAllArticles();
-      await this.articleSaver.fixSavedFilePaths(allArticles);
-
-      await this.validateSavedArticles();
+      this.app.workspace.onLayoutReady(async () => {
+        const allArticles = this.getAllArticles();
+        await this.articleSaver.fixSavedFilePaths(allArticles);
+        await this.validateSavedArticles();
+      });
 
       this.registerView(
         RSS_DASHBOARD_VIEW_TYPE,

--- a/main.ts
+++ b/main.ts
@@ -166,6 +166,7 @@ export default class RssDashboardPlugin extends Plugin {
       this.app.workspace.onLayoutReady(async () => {
         const allArticles = this.getAllArticles();
         await this.articleSaver.fixSavedFilePaths(allArticles);
+
         await this.validateSavedArticles();
       });
 

--- a/main.ts
+++ b/main.ts
@@ -1681,24 +1681,7 @@ export default class RssDashboardPlugin extends Plugin {
   }
 
   private checkSavedFileExists(item: FeedItem): boolean {
-    try {
-      const folder =
-        this.settings.articleSaving.defaultFolder || "RSS articles";
-      const filename = this.sanitizeFilename(item.title);
-      const filePath = folder ? `${folder}/${filename}.md` : `${filename}.md`;
-
-      return this.app.vault.getAbstractFileByPath(filePath) !== null;
-    } catch {
-      return false;
-    }
-  }
-
-  private sanitizeFilename(name: string): string {
-    return name
-      .replace(/[/\\:*?"<>|]/g, "_")
-      .replace(/\s+/g, "_")
-      .replace(/_+/g, "_")
-      .substring(0, 100);
+    return this.articleSaver.checkSavedFileExists(item);
   }
 
   private getAllArticles(): FeedItem[] {

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -4,6 +4,16 @@ import TurndownService from "turndown";
 import { Readability } from "@mozilla/readability";
 import { ensureUtf8Meta } from '../utils/platform-utils';
 
+export function sanitizeFilename(name: string): string {
+    const sanitized = name
+        .replace(/[/\\:*?"<>|]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    const words = sanitized.split(' ');
+    const shortened = words.slice(0, 5).join(' ');
+    return shortened.substring(0, 50);
+}
+
 export class ArticleSaver {
     private app: App;
     private settings: ArticleSavingSettings;
@@ -133,17 +143,22 @@ guid: "{{guid}}"
     }
     
     
-    private sanitizeFilename(name: string): string {
-        
-        const sanitized = name
-            .replace(/[/\\:*?"<>|]/g, '') 
-            .replace(/\s+/g, ' ') 
-            .trim(); 
+    checkSavedFileExists(item: FeedItem): boolean {
+        try {
+            if (item.savedFilePath) {
+                return this.app.vault.getAbstractFileByPath(item.savedFilePath) !== null;
+            }
+            const folder = this.settings.defaultFolder || "";
+            const filename = sanitizeFilename(item.title);
+            const filePath = folder.trim() ? `${folder}/${filename}.md` : `${filename}.md`;
+            return this.app.vault.getAbstractFileByPath(filePath) !== null;
+        } catch {
+            return false;
+        }
+    }
 
-        
-        const words = sanitized.split(' ');
-        const shortened = words.slice(0, 5).join(' ');
-        return shortened.substring(0, 50);
+    private sanitizeFilename(name: string): string {
+        return sanitizeFilename(name);
     }
     
     

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -143,24 +143,22 @@ guid: "{{guid}}"
     }
     
     
-    checkSavedFileExists(item: FeedItem): boolean {
+    findSavedArticleFile(item: FeedItem): TFile | null {
         try {
-            if (item.savedFilePath) {
-                return this.app.vault.getAbstractFileByPath(item.savedFilePath) !== null;
-            }
-            const folder = this.settings.defaultFolder || "";
+            const folder = this.normalizePath(this.settings.defaultFolder || "");
             const filename = sanitizeFilename(item.title);
-            const filePath = folder.trim() ? `${folder}/${filename}.md` : `${filename}.md`;
-            return this.app.vault.getAbstractFileByPath(filePath) !== null;
+            const filePath = folder ? `${folder}/${filename}.md` : `${filename}.md`;
+            const file = this.app.vault.getAbstractFileByPath(filePath);
+            return file instanceof TFile ? file : null;
         } catch {
-            return false;
+            return null;
         }
     }
 
-    private sanitizeFilename(name: string): string {
-        return sanitizeFilename(name);
+    checkSavedFileExists(item: FeedItem): boolean {
+        return this.findSavedArticleFile(item) !== null;
     }
-    
+
     
     private applyTemplate(item: FeedItem, template: string, rawContent?: string): string {
         
@@ -526,7 +524,7 @@ guid: "{{guid}}"
             }
             
             
-            const filename = this.sanitizeFilename(item.title);
+            const filename = sanitizeFilename(item.title);
             const filePath = folder && folder.trim() !== '' ? `${folder}/${filename}.md` : `${filename}.md`;
            
             
@@ -605,7 +603,7 @@ guid: "{{guid}}"
                             
                             try {
                                 const normalizedFolder = this.normalizePath(this.settings.defaultFolder || '');
-                                const filename = this.sanitizeFilename(article.title);
+                                const filename = sanitizeFilename(article.title);
                                 const newName = `${filename}.md`;
 
                                 const newPath =

--- a/src/services/web-viewer-integration.ts
+++ b/src/services/web-viewer-integration.ts
@@ -1,5 +1,6 @@
 import { App, Notice, TFile, setIcon, Setting } from "obsidian";
 import { FeedItem, ArticleSavingSettings } from "../types/types";
+import { sanitizeFilename } from "./article-saver";
 
 interface WebViewerPlugin {
     openWebpage?(url: string, title: string): Promise<void>;
@@ -257,7 +258,7 @@ export class WebViewerIntegration {
         }
             
             
-            const filename = this.sanitizeFilename(item.title);
+            const filename = sanitizeFilename(item.title);
             const filePath = folder ? `${folder}/${filename}.md` : `${filename}.md`;
             
             
@@ -329,15 +330,6 @@ guid: "{{guid}}"
             .replace(/{{guid}}/g, item.guid.replace(/"/g, '\\"'));
             
         return frontmatter;
-    }
-    
-    
-    private sanitizeFilename(name: string): string {
-        return name
-            .replace(/[/\\:*?"<>|]/g, '_')
-            .replace(/\s+/g, '_')
-            .replace(/_+/g, '_')
-            .substring(0, 100); 
     }
     
     

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -1379,7 +1379,7 @@ export class RssDashboardView extends ItemView {
     if (article.saved) {
       const loadingNotice = new Notice("Opening saved article...", 0);
       try {
-        const savedFile = this.findSavedArticleFile(article);
+        const savedFile = await this.findSavedArticleFile(article);
         if (savedFile) {
           await this.openSavedArticleFile(savedFile);
           loadingNotice.hide();
@@ -2194,11 +2194,15 @@ export class RssDashboardView extends ItemView {
     }
   }
 
-  private findSavedArticleFile(article: FeedItem): TFile | null {
+  private async findSavedArticleFile(article: FeedItem): Promise<TFile | null> {
     if (!article.saved) {
       return null;
     }
-    return this.saver.findSavedArticleFile(article);
+    const file = this.saver.findSavedArticleFile(article);
+    if (file === null) {
+      await this.updateArticleStatus(article, { saved: false }, false);
+    }
+    return file;
   }
 
   private async openSavedArticleFile(file: TFile): Promise<void> {
@@ -2223,7 +2227,7 @@ export class RssDashboardView extends ItemView {
     const loadingNotice = new Notice("Opening saved article...", 0);
 
     try {
-      const savedFile = this.findSavedArticleFile(article);
+      const savedFile = await this.findSavedArticleFile(article);
       if (savedFile) {
         await this.openSavedArticleFile(savedFile);
         loadingNotice.hide();

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -22,7 +22,7 @@ import type {
 } from "../../main";
 import { Sidebar } from "../components/sidebar";
 import { ArticleList } from "../components/article-list";
-import { ArticleSaver, sanitizeFilename } from "../services/article-saver";
+import { ArticleSaver } from "../services/article-saver";
 import { ReaderView, RSS_READER_VIEW_TYPE } from "./reader-view";
 import { FeedManagerModal } from "../modals/feed-manager-modal";
 import { MobileNavigationModal } from "../modals/mobile-navigation-modal";
@@ -1379,7 +1379,7 @@ export class RssDashboardView extends ItemView {
     if (article.saved) {
       const loadingNotice = new Notice("Opening saved article...", 0);
       try {
-        const savedFile = await this.findSavedArticleFile(article);
+        const savedFile = this.findSavedArticleFile(article);
         if (savedFile) {
           await this.openSavedArticleFile(savedFile);
           loadingNotice.hide();
@@ -2194,57 +2194,11 @@ export class RssDashboardView extends ItemView {
     }
   }
 
-  private async findSavedArticleFile(article: FeedItem): Promise<TFile | null> {
+  private findSavedArticleFile(article: FeedItem): TFile | null {
     if (!article.saved) {
       return null;
     }
-
-    if (article.savedFilePath) {
-      try {
-        const file = this.app.vault.getAbstractFileByPath(
-          article.savedFilePath,
-        );
-        if (file !== null) {
-          if (file instanceof TFile) {
-            return file;
-          }
-        } else {
-          await this.updateArticleStatus(
-            article,
-            { saved: false, savedFilePath: undefined },
-            false,
-          );
-          return null;
-        }
-      } catch {
-        // File path check failed, continue with filename search
-      }
-    }
-
-    const filename = sanitizeFilename(article.title);
-    const folder = this.settings.articleSaving.defaultFolder || "";
-    const expectedPath =
-      folder && folder.trim() !== ""
-        ? `${folder}/${filename}.md`
-        : `${filename}.md`;
-
-    try {
-      const file = this.app.vault.getAbstractFileByPath(expectedPath);
-      if (file !== null) {
-        if (file instanceof TFile) {
-          await this.updateArticleStatus(
-            article,
-            { savedFilePath: expectedPath },
-            false,
-          );
-          return file;
-        }
-      }
-    } catch {
-      // File lookup failed
-    }
-
-    return null;
+    return this.saver.findSavedArticleFile(article);
   }
 
   private async openSavedArticleFile(file: TFile): Promise<void> {
@@ -2269,7 +2223,7 @@ export class RssDashboardView extends ItemView {
     const loadingNotice = new Notice("Opening saved article...", 0);
 
     try {
-      const savedFile = await this.findSavedArticleFile(article);
+      const savedFile = this.findSavedArticleFile(article);
       if (savedFile) {
         await this.openSavedArticleFile(savedFile);
         loadingNotice.hide();

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -22,7 +22,7 @@ import type {
 } from "../../main";
 import { Sidebar } from "../components/sidebar";
 import { ArticleList } from "../components/article-list";
-import { ArticleSaver } from "../services/article-saver";
+import { ArticleSaver, sanitizeFilename } from "../services/article-saver";
 import { ReaderView, RSS_READER_VIEW_TYPE } from "./reader-view";
 import { FeedManagerModal } from "../modals/feed-manager-modal";
 import { MobileNavigationModal } from "../modals/mobile-navigation-modal";
@@ -2221,7 +2221,7 @@ export class RssDashboardView extends ItemView {
       }
     }
 
-    const filename = this.sanitizeFilename(article.title);
+    const filename = sanitizeFilename(article.title);
     const folder = this.settings.articleSaving.defaultFolder || "";
     const expectedPath =
       folder && folder.trim() !== ""
@@ -2258,17 +2258,6 @@ export class RssDashboardView extends ItemView {
       const message = error instanceof Error ? error.message : String(error);
       new Notice(`Error opening saved article: ${message}`);
     }
-  }
-
-  private sanitizeFilename(name: string): string {
-    const sanitized = name
-      .replace(/[/\\:*?"<>|]/g, "")
-      .replace(/\s+/g, " ")
-      .trim();
-
-    const words = sanitized.split(" ");
-    const shortened = words.slice(0, 5).join(" ");
-    return shortened.substring(0, 50);
   }
 
   private async handleOpenSavedArticle(article: FeedItem): Promise<void> {

--- a/src/views/reader-view.ts
+++ b/src/views/reader-view.ts
@@ -1582,24 +1582,7 @@ export class ReaderView extends ItemView {
   }
 
   private checkSavedFileExists(item: FeedItem): boolean {
-    try {
-      const folder =
-        this.settings.articleSaving.defaultFolder || "RSS articles";
-      const filename = this.sanitizeFilename(item.title);
-      const filePath = folder ? `${folder}/${filename}.md` : `${filename}.md`;
-
-      return this.app.vault.getAbstractFileByPath(filePath) !== null;
-    } catch {
-      return false;
-    }
-  }
-
-  private sanitizeFilename(name: string): string {
-    return name
-      .replace(/[/\\:*?"<>|]/g, "_")
-      .replace(/\s+/g, "_")
-      .replace(/_+/g, "_")
-      .substring(0, 100);
+    return this.articleSaver.checkSavedFileExists(item);
   }
 
   private async displayVideoPodcast(item: FeedItem): Promise<void> {


### PR DESCRIPTION
# Problem                                                                                                                             
                                                                                                                                      
  After restarting Obsidian, articles previously marked as saved would lose the saved indicator as well as a reference to an Obsidian note file. This happened due to three compounding bugs:                                                                                                                   
                                                                                                                                      
##   _1. Race condition on startup_                                                                                                        
  `validateSavedArticles()` and `fixSavedFilePaths()` were called during onload() before the vault was ready. On cold start, `vault.getAbstractFileByPath()` returns null for all paths because the file index hasn't been built yet. This caused every saved article to appear as "file not found" and get its saved flag stripped on every restart.
                                                                                                                                      
  **Fix:** Moved both calls inside `app.workspace.onLayoutReady()`, which fires only after the vault index is fully available.              
   
##   _2. Sanitization inconsistency — path mismatch between create and lookup_                                                             
  `sanitizeFilename()` had four independent implementations scattered across `main.ts`, `reader-view.ts`, `dashboard-view.ts`, and `web-viewer-integration.ts`. Three of them (Variant B) replaced spaces with underscores and allowed up to 100 characters. `ArticleSaver` (Variant A) preserved spaces and truncated to 5 words / 50 characters. `ArticleSaver.saveArticle()` created "RSS/My Article Title.md" (spaces). The lookup methods in all other files searched for "RSS/My_Article_Title.md" (underscores). The file was never found.
                                                                                                                                      
  **Fix:** Exported `sanitizeFilename` as a module-level function from `article-saver.ts` (canonical Variant A). All consumers replaced their local implementations with a reference to this single function.
                                                                                                                                      
##   _3. Missing `normalizePath` in file lookup_                                                                                             
  `saveArticle()` applies `normalizePath()` to strip leading/trailing slashes from the folder path before building the file path. The lookup implementations did not. With defaultFolder = "RSS articles/", the file was created at "RSS articles/title.md" but searched at "RSS articles//title.md".                                        
                                                                                                                                      
  **Fix:** The new `findSavedArticleFile` method applies the same `normalizePath` call used by `saveArticle`.                                   
   
  ---                                                                                                                                 
  # Changes                                                      
                                                                                                                                      
##  1. src/services/article-saver.ts
  - Extracted `sanitizeFilename` as an exported module-level function (single canonical implementation)                                 
  - Added public `findSavedArticleFile(item): TFile | null` — single source of truth for building the expected file path: `normalizePath(defaultFolder) + sanitizeFilename(title) + ".md"`                                                       
  - Added public `checkSavedFileExists(item): boolean` — delegates to `findSavedArticleFile`                                              
  - Removed the private `sanitizeFilename` wrapper method        
                                                                                                                                      
##  2. main.ts                                                      
  - Wrapped `fixSavedFilePaths` + `validateSavedArticles` in `onLayoutReady` callback                                                       
  - Removed local `sanitizeFilename` (Variant B, underscores) and `checkSavedFileExists`; now delegates to                                
  `articleSaver.checkSavedFileExists`                                                                   
                                                                                                                                      
##  3. src/views/reader-view.ts                                     
  - Removed local `sanitizeFilename` (Variant B) and `checkSavedFileExists`; now delegates to `articleSaver.checkSavedFileExists`           
                                                                                                                           
##  4. src/views/dashboard-view.ts                                                                                                         
  - Removed local `sanitizeFilename` (Variant A duplicate) and the full `findSavedArticleFile` implementation (50+ lines with two separate try/catch blocks, stale `savedFilePath` side-effects)                                                                                
  - New `findSavedArticleFile`: delegates to `saver.findSavedArticleFile`; resets saved: false via `updateArticleStatus` if file is not found                                                                                                                               
                                                                                                                                      
##  5. src/services/web-viewer-integration.ts
  - Removed local `sanitizeFilename` (Variant B); imports and uses the canonical function from `article-saver.ts`                            
                                                                                                                                      
  ---                                                                                                                                 
##  6. test_files/unit/article-saver.test.ts     
Tests are not pushed as they are ignored                                                                            
                                                                                                                                      
  35 tests covering:
  - `sanitizeFilename`: special chars, space preservation, word truncation, char limit, edge inputs                                     
  - `ArticleSaver.checkSavedFileExists`: folder normalization (leading/trailing slashes), empty folder, vault errors                    
  - `ArticleSaver.findSavedArticleFile`: returns TFile instance, normalization, vault root                          
  - Round-trip tests (`saveArticle` → `findSavedArticleFile`): verifies the path used to create a file is identical to the path used to find it — special chars in title, 5-word truncation, duplicate save, empty folder                                                   
  - False negatives: article saved with customFolder ≠ defaultFolder cannot be found (documented limitation)                          
  - False positives: title collision (two titles sanitizing to the same filename), `findSavedArticleFile` agnostic to `item.saved` flag (guard is caller's responsibility) 