### PR TITLE
Fix: saved articles losing their status and reference to a note after Obsidian restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 
 - Fixed the Manage Feeds workflow so the modal now closes after the user initiates an OPML import instead of remaining open behind the import flow.
 
+- Saved articles now persist across vault reloads (PR#106)
+
 ### Improvements
 
 - Optimized the feed refresh process to reduce unnecessary network requests.

--- a/docs/bugs/saved-articles-status-loss.md
+++ b/docs/bugs/saved-articles-status-loss.md
@@ -1,0 +1,177 @@
+# Saved Articles Lose `saved` Status While File Still Exists In Vault
+
+Last updated: April 24, 2026
+
+## Summary
+
+This bug is now understood and fixed locally.
+
+The article save itself was succeeding, `savedFilePath` was being persisted to `data.json`, and the saved markdown file still existed in the vault. The actual failure happened later during plugin startup: `validateSavedArticles()` ran too early in `onload()`, before saved article files could be resolved reliably, and it cleared valid saved state. That bad cleared state was then written back to `data.json`.
+
+The validated local fix is to defer startup saved-article reconciliation until Obsidian layout is ready.
+
+## User-Observed Reproduction
+
+Original repro:
+
+1. Save an article from the plugin.
+2. Verify the markdown file exists in the Obsidian vault.
+3. Close Obsidian.
+4. Reopen Obsidian.
+5. The article file is still present, but RSS Dashboard no longer shows the article as saved.
+
+This reproduced even when waiting much longer before closing and reopening Obsidian, which weakened the original “closed too fast before `data.json` wrote” theory.
+
+## What PR `#106` Had
+
+The other user's PR addressed real contributing issues, but not the final root cause.
+
+Work that PR and follow-up investigation covered:
+
+- preserve `savedFilePath` more consistently during save flows
+- preserve `savedFilePath` across feed refresh / merge behavior
+- add regression coverage around those persistence and refresh theories
+
+Why that was not enough:
+
+- a clean repro of branch `crazyrokr/fix-saved-articles` still failed in real Obsidian usage
+- runtime tracing later showed the saved state survived save and persistence, then was cleared on startup validation
+
+Conclusion:
+
+- PR `#106` improved part of the problem space
+- but it did not fix the startup timing bug that was actually clearing saved state after reload
+
+## What We Proved
+
+Using temporary targeted runtime logging for one saved Ars article, we observed:
+
+1. `ArticleSaver.saveArticle()` created the markdown file successfully.
+2. `saveSettings()` completed successfully.
+3. `data.json` contained:
+   - `saved: true`
+   - the correct `savedFilePath`
+4. On the next Obsidian restart, `loadSettings()` still loaded the correct saved state from `data.json`.
+5. `fixSavedFilePaths()` did not clear the article.
+6. `validateSavedArticles()` was the first code path that flipped the article from saved to unsaved.
+
+The important trace sequence was:
+
+- `loadSettings:afterLoadData` -> still saved
+- `loadSettings:afterNormalize` -> still saved
+- `loadSettings:afterDedupe` -> still saved
+- `onload:afterFixSavedFilePaths` -> still saved
+- `validateSavedArticles:beforeClear` -> lookup failed
+- `validateSavedArticles:afterClear` -> saved state removed
+
+That proved the bug was not:
+
+- save-time persistence loss
+- `data.json` write failure
+- reload-time settings loss
+
+It was specifically:
+
+- startup validation clearing correct saved state because file lookup happened too early during plugin startup
+
+## Root Cause
+
+Before the fix, startup did this inside `onload()`:
+
+1. load settings
+2. immediately run `fixSavedFilePaths()`
+3. immediately run `validateSavedArticles()`
+
+For some saved articles, that early validation happened before file resolution was reliable, so `checkSavedFileExists()` returned false even though the vault file really existed. `validateSavedArticles()` then:
+
+- set `saved = false`
+- cleared `savedFilePath`
+- removed the `Saved` tag
+- persisted the cleared state back to `data.json`
+
+## Local Fix That Worked
+
+Implemented in [main.ts](/c:/Obsidian/Obsidian_Main/.obsidian/plugins/obsidian-rss-dashboard/main.ts:201).
+
+What changed:
+
+- extracted startup saved-article reconciliation into `reconcileSavedArticlesOnStartup()`
+- scheduled that reconciliation through `workspace.onLayoutReady(...)`
+- prevented duplicate startup validation with a one-time guard
+
+Behaviorally, the fix is:
+
+- do not validate saved articles immediately during early `onload()`
+- wait until Obsidian layout is ready
+- then run `fixSavedFilePaths()` and `validateSavedArticles()`
+
+This local fix was manually validated: the saved article now stays marked saved after restart.
+
+## Regression Coverage Added
+
+Regression coverage was added so startup validation is no longer allowed to run too early.
+
+Relevant test:
+
+- [test_files/unit/main/plugin-lifecycle.test.ts](/c:/Obsidian/Obsidian_Main/.obsidian/plugins/obsidian-rss-dashboard/test_files/unit/main/plugin-lifecycle.test.ts:454)
+
+Supporting test-stub update:
+
+- [test_files/stubs/obsidian.ts](/c:/Obsidian/Obsidian_Main/.obsidian/plugins/obsidian-rss-dashboard/test_files/stubs/obsidian.ts:249)
+
+The new regression verifies:
+
+- `onload()` does not immediately run saved-article startup validation
+- validation runs only after simulated layout readiness
+
+## Temporary Diagnostic Work Completed
+
+Temporary trace logging was added to prove the lifecycle behavior around:
+
+- `ArticleSaver.saveArticle()`
+- `saveSettings()`
+- `loadSettings()`
+- `validateSavedArticles()`
+- refresh merge behavior
+
+Those diagnostics were useful to prove the root cause, but they are temporary investigation code and should be removed once the fix is finalized and no longer needs live tracing.
+
+## Remaining Follow-Up: Truncated Saved Article Titles
+
+This is a separate bug and should be addressed next.
+
+Current behavior in [article-saver.ts](/c:/Obsidian/Obsidian_Main/.obsidian/plugins/obsidian-rss-dashboard/src/services/article-saver.ts:10):
+
+- filename generation keeps only the first 5 words
+- then truncates to 50 characters
+
+Current code:
+
+- `const words = sanitized.split(" ");`
+- `const shortened = words.slice(0, 5).join(" ");`
+- `return shortened.substring(0, 50);`
+
+Why this is still a bug:
+
+- the saved article filename does not preserve the real article title
+- fallback path reconstruction depends on that truncated filename behavior
+- this creates brittleness and can make saved article lookup harder to reason about
+- it was part of the context around the original PR, but it is not fixed by the startup-validation change
+
+Recommended next task:
+
+- redesign saved article filename generation so it does not arbitrarily truncate to the first 5 words
+- update any lookup / fallback logic and regression tests to match the new filename policy
+
+## Status
+
+Saved-state-loss bug:
+
+- root cause confirmed
+- local fix implemented
+- manually validated as fixed
+
+Truncated-title bug:
+
+- still open
+- recommended next follow-up

--- a/main.ts
+++ b/main.ts
@@ -1693,24 +1693,7 @@ export default class RssDashboardPlugin extends Plugin {
   }
 
   private checkSavedFileExists(item: FeedItem): boolean {
-    try {
-      const folder =
-        this.settings.articleSaving.defaultFolder || "RSS articles";
-      const filename = this.sanitizeFilename(item.title);
-      const filePath = folder ? `${folder}/${filename}.md` : `${filename}.md`;
-
-      return this.app.vault.getAbstractFileByPath(filePath) !== null;
-    } catch {
-      return false;
-    }
-  }
-
-  private sanitizeFilename(name: string): string {
-    return name
-      .replace(/[/\\:*?"<>|]/g, "_")
-      .replace(/\s+/g, "_")
-      .replace(/_+/g, "_")
-      .substring(0, 100);
+    return this.articleSaver.checkSavedFileExists(item);
   }
 
   private getAllArticles(): FeedItem[] {

--- a/main.ts
+++ b/main.ts
@@ -1667,7 +1667,7 @@ export default class RssDashboardPlugin extends Plugin {
     for (const feed of this.settings.feeds) {
       for (const item of feed.items) {
         if (item.saved) {
-          const fileExists = this.checkSavedFileExists(item);
+          const fileExists = this.articleSaver.checkSavedFileExists(item);
           if (!fileExists) {
             item.saved = false;
 
@@ -1691,10 +1691,6 @@ export default class RssDashboardPlugin extends Plugin {
         view.render();
       }
     }
-  }
-
-  private checkSavedFileExists(item: FeedItem): boolean {
-    return this.articleSaver.checkSavedFileExists(item);
   }
 
   private getAllArticles(): FeedItem[] {

--- a/main.ts
+++ b/main.ts
@@ -379,10 +379,11 @@ export default class RssDashboardPlugin extends Plugin {
         this.applyMobileOptimizations();
       }
 
-      const allArticles = this.getAllArticles();
-      await this.articleSaver.fixSavedFilePaths(allArticles);
-
-      await this.validateSavedArticles();
+      this.app.workspace.onLayoutReady(async () => {
+        const allArticles = this.getAllArticles();
+        await this.articleSaver.fixSavedFilePaths(allArticles);
+        await this.validateSavedArticles();
+      });
 
       this.registerView(
         RSS_DASHBOARD_VIEW_TYPE,

--- a/main.ts
+++ b/main.ts
@@ -379,11 +379,19 @@ export default class RssDashboardPlugin extends Plugin {
         this.applyMobileOptimizations();
       }
 
-      this.app.workspace.onLayoutReady(async () => {
+      const fixSavedArticlesAfterLayout = async () => {
         const allArticles = this.getAllArticles();
         await this.articleSaver.fixSavedFilePaths(allArticles);
         await this.validateSavedArticles();
-      });
+      };
+
+      if (typeof this.app.workspace.onLayoutReady === "function") {
+        this.app.workspace.onLayoutReady(() => {
+          void fixSavedArticlesAfterLayout();
+        });
+      } else {
+        await fixSavedArticlesAfterLayout();
+      }
 
       this.registerView(
         RSS_DASHBOARD_VIEW_TYPE,

--- a/main.ts
+++ b/main.ts
@@ -85,6 +85,7 @@ export default class RssDashboardPlugin extends Plugin {
   private isMultiFeedRefreshRunning = false;
   public vaultAbsolutePath = "";
   private _beforeUnloadHandler: (() => void) | null = null;
+  private hasCompletedStartupSavedArticleValidation = false;
   private static readonly FEED_REFRESH_CONCURRENCY = 4;
   private static readonly FEED_REFRESH_RENDER_THROTTLE_MS = 250;
 
@@ -191,6 +192,35 @@ export default class RssDashboardPlugin extends Plugin {
     }
 
     return normalizedMinutes * 60 * 1000;
+  }
+
+  private async reconcileSavedArticlesOnStartup(): Promise<void> {
+    if (this.hasCompletedStartupSavedArticleValidation) {
+      return;
+    }
+
+    this.hasCompletedStartupSavedArticleValidation = true;
+
+    const allArticles = this.getAllArticles();
+    await this.articleSaver.fixSavedFilePaths(allArticles);
+
+    await this.validateSavedArticles();
+  }
+
+  private scheduleStartupSavedArticleValidation(): void {
+    const workspaceWithLayoutReady = this.app
+      .workspace as typeof this.app.workspace & {
+      onLayoutReady?: (callback: () => void) => void;
+    };
+
+    if (typeof workspaceWithLayoutReady.onLayoutReady === "function") {
+      workspaceWithLayoutReady.onLayoutReady(() => {
+        void this.reconcileSavedArticlesOnStartup();
+      });
+      return;
+    }
+
+    void this.reconcileSavedArticlesOnStartup();
   }
 
   public async getActiveDashboardView(): Promise<RssDashboardView | null> {
@@ -379,19 +409,7 @@ export default class RssDashboardPlugin extends Plugin {
         this.applyMobileOptimizations();
       }
 
-      const fixSavedArticlesAfterLayout = async () => {
-        const allArticles = this.getAllArticles();
-        await this.articleSaver.fixSavedFilePaths(allArticles);
-        await this.validateSavedArticles();
-      };
-
-      if (typeof this.app.workspace.onLayoutReady === "function") {
-        this.app.workspace.onLayoutReady(() => {
-          void fixSavedArticlesAfterLayout();
-        });
-      } else {
-        await fixSavedArticlesAfterLayout();
-      }
+      this.scheduleStartupSavedArticleValidation();
 
       this.registerView(
         RSS_DASHBOARD_VIEW_TYPE,
@@ -651,6 +669,7 @@ export default class RssDashboardPlugin extends Plugin {
         const originalItem = feed.items.find((i) => i.guid === item.guid);
         if (originalItem) {
           originalItem.saved = true;
+          originalItem.savedFilePath = item.savedFilePath;
 
           if (this.settings.articleSaving.addSavedTag) {
             if (!originalItem.tags) {
@@ -678,12 +697,14 @@ export default class RssDashboardPlugin extends Plugin {
             item.feedUrl,
             {
               saved: true,
+              savedFilePath: originalItem.savedFilePath,
               tags: originalItem.tags ? [...originalItem.tags] : [],
             },
             false,
           );
           await this.syncReaderArticleUpdate(item.guid, {
             saved: true,
+            savedFilePath: originalItem.savedFilePath,
             tags: originalItem.tags ? [...originalItem.tags] : [],
           });
         }
@@ -1678,13 +1699,13 @@ export default class RssDashboardPlugin extends Plugin {
           const fileExists = this.articleSaver.checkSavedFileExists(item);
           if (!fileExists) {
             item.saved = false;
+            item.savedFilePath = undefined;
 
             if (item.tags) {
               item.tags = item.tags.filter(
                 (tag) => tag.name.toLowerCase() !== "saved",
               );
             }
-
             updatedCount++;
           }
         }

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -655,7 +655,10 @@ export class ArticleSaver {
     try {
       await this.updateArticleStatus(
         article,
-        { saved: (file instanceof TFile), savedFilePath: file === null ? undefined : expectedPath },
+        {
+          saved: (file instanceof TFile),
+          savedFilePath: (file && expectedPath || undefined)
+        },
         false,
       );
     } catch (e) {

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -7,14 +7,14 @@ import { ensureUtf8Meta } from "../utils/platform-utils";
 import { withSavedTagName } from "../utils/tag-utils";
 
 export function sanitizeFilename(name: string): string {
-    const sanitized = name
-      .replace(/[\\/:*?"<>|#^[\]]/g, "")
-      .replace(/\s+/g, " ")
-      .trim();
+  const sanitized = name
+    .replace(/[/\\:*?"<>|]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 
-    const words = sanitized.split(" ");
-    const shortened = words.slice(0, 5).join(" ");
-    return shortened.substring(0, 50);
+  const words = sanitized.split(" ");
+  const shortened = words.slice(0, 5).join(" ");
+  return shortened.substring(0, 50);
 }
 
 export class ArticleSaver {
@@ -135,6 +135,10 @@ export class ArticleSaver {
     return frontmatter.endsWith("\n") ? frontmatter : `${frontmatter}\n`;
   }
 
+  private sanitizeFilename(name: string): string {
+    return sanitizeFilename(name);
+  }
+
   private formatMoment(date: Date, formatStr: string): string {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
     return (moment as any)(date).format(formatStr);
@@ -157,9 +161,12 @@ export class ArticleSaver {
       .replace(/{{isoDateTime}}/g, isoDateTime);
 
     // Handle dynamic formats: {{date:FORMAT}}
-    replaced = replaced.replace(/{{date:(.+?)}}/g, (_match: string, format: string) => {
-      return this.formatMoment(validDate, format);
-    });
+    replaced = replaced.replace(
+      /{{date:(.+?)}}/g,
+      (_match: string, format: string) => {
+        return this.formatMoment(validDate, format);
+      },
+    );
 
     return replaced;
   }
@@ -615,56 +622,77 @@ export class ArticleSaver {
   }
 
   checkSavedFileExists(item: FeedItem): boolean {
-    if (!item.title) return false;
+    if (!item.saved) {
+      return false;
+    }
+
     try {
-      const filePath = this.buildSavedArticleFilePath(item);
-      return this.app.vault.getAbstractFileByPath(filePath) !== null;
+      const savedPath = this.normalizePath(item.savedFilePath || "");
+      if (savedPath) {
+        const savedFile = this.app.vault.getAbstractFileByPath(savedPath);
+        if (savedFile instanceof TFile) {
+          if (item.savedFilePath !== savedPath) {
+            item.savedFilePath = savedPath;
+          }
+          return true;
+        }
+      }
+
+      const fallbackPath = this.buildSavedArticleFilePath(item);
+      if (!fallbackPath) {
+        return false;
+      }
+
+      const fallbackFile = this.app.vault.getAbstractFileByPath(fallbackPath);
+      if (fallbackFile instanceof TFile) {
+        item.savedFilePath = fallbackPath;
+        return true;
+      }
+
+      return false;
     } catch {
       return false;
     }
-  }
-
-  private buildSavedArticleFilePath(item: FeedItem): string {
-    const folder = this.normalizePath(this.settings.defaultFolder || "");
-    const filename = sanitizeFilename(item.title);
-    return folder && folder.trim() !== ""
-        ? `${folder}/${filename}.md`
-        : `${filename}.md`;
-  }
-
-  private async updateArticleStatus(
-    article: FeedItem,
-    updates: Partial<FeedItem>,
-    _shouldRerender: boolean = true,
-  ): Promise<void> {
-    Object.assign(article, updates);
-    if (updates.saved === false && article.tags) {
-      article.tags = article.tags.filter(
-        (t) => t.name.toLowerCase() !== "saved",
-      );
-    }
-    return Promise.resolve();
   }
 
   async findSavedArticleFile(article: FeedItem): Promise<TFile | null> {
     if (!article.saved) {
       return null;
     }
-    const expectedPath = article.savedFilePath || this.buildSavedArticleFilePath(article);
-    const file = this.app.vault.getAbstractFileByPath(expectedPath);
-    const savedFile = file instanceof TFile ? file : null;
-    try {
-      await this.updateArticleStatus(
-        article,
-        {
-          saved: savedFile !== null,
-          savedFilePath: savedFile ? expectedPath : undefined,
-        },
-        false,
-      );
-    } catch {
-      // Update failed
+
+    const savedPath = this.normalizePath(article.savedFilePath || "");
+    if (savedPath) {
+      const savedFile = this.app.vault.getAbstractFileByPath(savedPath);
+      if (savedFile instanceof TFile) {
+        if (article.savedFilePath !== savedPath) {
+          article.savedFilePath = savedPath;
+        }
+        return savedFile;
+      }
     }
-    return savedFile;
+
+    const fallbackPath = this.buildSavedArticleFilePath(article);
+    if (!fallbackPath) {
+      return null;
+    }
+
+    const fallbackFile = this.app.vault.getAbstractFileByPath(fallbackPath);
+    if (fallbackFile instanceof TFile) {
+      article.savedFilePath = fallbackPath;
+      return fallbackFile;
+    }
+
+    return null;
+  }
+
+  private buildSavedArticleFilePath(item: FeedItem): string {
+    const folder = this.normalizePath(this.settings.defaultFolder || "");
+    const filename = this.sanitizeFilename(item.title);
+
+    if (!filename) {
+      return "";
+    }
+
+    return folder ? `${folder}/${filename}.md` : `${filename}.md`;
   }
 }

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -6,6 +6,17 @@ import { fetchWithProxyFallback } from "../utils/fetch-helpers";
 import { ensureUtf8Meta } from "../utils/platform-utils";
 import { withSavedTagName } from "../utils/tag-utils";
 
+export function sanitizeFilename(name: string): string {
+    const sanitized = name
+      .replace(/[/\\:*?"<>|]/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    const words = sanitized.split(" ");
+    const shortened = words.slice(0, 5).join(" ");
+    return shortened.substring(0, 50);
+}
+
 export class ArticleSaver {
   private app: App;
   private settings: ArticleSavingSettings;
@@ -122,17 +133,6 @@ export class ArticleSaver {
     }
 
     return frontmatter.endsWith("\n") ? frontmatter : `${frontmatter}\n`;
-  }
-
-  private sanitizeFilename(name: string): string {
-    const sanitized = name
-      .replace(/[/\\:*?"<>|]/g, "")
-      .replace(/\s+/g, " ")
-      .trim();
-
-    const words = sanitized.split(" ");
-    const shortened = words.slice(0, 5).join(" ");
-    return shortened.substring(0, 50);
   }
 
   private formatMoment(date: Date, formatStr: string): string {
@@ -478,7 +478,7 @@ export class ArticleSaver {
         await this.ensureFolderExists(folder);
       }
 
-      const filename = this.sanitizeFilename(item.title);
+      const filename = sanitizeFilename(item.title);
       const filePath =
         folder && folder.trim() !== ""
           ? `${folder}/${filename}.md`
@@ -556,7 +556,7 @@ export class ArticleSaver {
         const normalizedFolder = this.normalizePath(
           this.settings.defaultFolder || "",
         );
-        const filename = this.sanitizeFilename(article.title);
+        const filename = sanitizeFilename(article.title);
         const newName = `${filename}.md`;
         const newPath =
           normalizedFolder && normalizedFolder.trim() !== ""

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -8,7 +8,7 @@ import { withSavedTagName } from "../utils/tag-utils";
 
 export function sanitizeFilename(name: string): string {
     const sanitized = name
-      .replace(/[/\\:*?"<>|]/g, "")
+      .replace(/[\\/:*?"<>|!@#$%^&()+=~`{}[\];:'",.<>]/g, "")
       .replace(/\s+/g, " ")
       .trim();
 
@@ -202,7 +202,10 @@ export class ArticleSaver {
       return "";
     }
 
-    return path.replace(/^\/+|\/+$/g, "");
+    return path
+      .replace(/[\\:*?"<>|]/g, "")
+      .replace(/\s+/g, " ")
+      .replace(/^[/\s]+|[/\s]+$/g, "");
   }
 
   private async ensureFolderExists(folderPath: string): Promise<void> {
@@ -609,5 +612,90 @@ export class ArticleSaver {
       .forEach((article) => {
         this.verifySavedArticle(article);
       });
+  }
+
+  checkSavedFileExists(item: FeedItem): boolean {
+    if (!item.title) return false;
+    try {
+      const folder = this.normalizePath(
+        this.settings.defaultFolder || "",
+      );
+      const filename = sanitizeFilename(item.title);
+      const filePath =
+        folder && folder.trim() !== ""
+          ? `${folder}/${filename}.md`
+          : `${filename}.md`;
+
+      return this.app.vault.getAbstractFileByPath(filePath) !== null;
+    } catch {
+      return false;
+    }
+  }
+
+  private async updateArticleStatus(
+    article: FeedItem,
+    updates: Partial<FeedItem>,
+    _shouldRerender: boolean = true,
+  ): Promise<void> {
+    Object.assign(article, updates);
+    if (updates.saved === false && article.tags) {
+      article.tags = article.tags.filter(
+        (t) => t.name.toLowerCase() !== "saved",
+      );
+    }
+    return Promise.resolve();
+  }
+
+  async findSavedArticleFile(article: FeedItem): Promise<TFile | null> {
+    if (!article.saved) {
+      return null;
+    }
+
+    if (article.savedFilePath) {
+      try {
+        const file = this.app.vault.getAbstractFileByPath(
+          article.savedFilePath,
+        );
+        if (file !== null) {
+          if (file instanceof TFile) {
+            return file;
+          }
+        } else {
+          await this.updateArticleStatus(
+            article,
+            { saved: false, savedFilePath: undefined },
+            false,
+          );
+          return null;
+        }
+      } catch {
+        // File path check failed, continue with filename search
+      }
+    }
+
+    const filename = sanitizeFilename(article.title);
+    const folder = this.normalizePath(this.settings.defaultFolder || "");
+    const expectedPath =
+      folder && folder.trim() !== ""
+        ? `${folder}/${filename}.md`
+        : `${filename}.md`;
+
+    try {
+      const file = this.app.vault.getAbstractFileByPath(expectedPath);
+      if (file !== null) {
+        if (file instanceof TFile) {
+          await this.updateArticleStatus(
+            article,
+            { savedFilePath: expectedPath },
+            false,
+          );
+          return file;
+        }
+      }
+    } catch {
+      // File lookup failed
+    }
+
+    return null;
   }
 }

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -617,19 +617,19 @@ export class ArticleSaver {
   checkSavedFileExists(item: FeedItem): boolean {
     if (!item.title) return false;
     try {
-      const folder = this.normalizePath(
-        this.settings.defaultFolder || "",
-      );
-      const filename = sanitizeFilename(item.title);
-      const filePath =
-        folder && folder.trim() !== ""
-          ? `${folder}/${filename}.md`
-          : `${filename}.md`;
-
+      const filePath = this.buildSavedArticleFilePath(item);
       return this.app.vault.getAbstractFileByPath(filePath) !== null;
     } catch {
       return false;
     }
+  }
+
+  private buildSavedArticleFilePath(item: FeedItem): string {
+    const folder = this.normalizePath(this.settings.defaultFolder || "");
+    const filename = sanitizeFilename(item.title);
+    return folder && folder.trim() !== ""
+        ? `${folder}/${filename}.md`
+        : `${filename}.md`;
   }
 
   private async updateArticleStatus(
@@ -650,52 +650,17 @@ export class ArticleSaver {
     if (!article.saved) {
       return null;
     }
-
-    if (article.savedFilePath) {
-      try {
-        const file = this.app.vault.getAbstractFileByPath(
-          article.savedFilePath,
-        );
-        if (file !== null) {
-          if (file instanceof TFile) {
-            return file;
-          }
-        } else {
-          await this.updateArticleStatus(
-            article,
-            { saved: false, savedFilePath: undefined },
-            false,
-          );
-          return null;
-        }
-      } catch {
-        // File path check failed, continue with filename search
-      }
-    }
-
-    const filename = sanitizeFilename(article.title);
-    const folder = this.normalizePath(this.settings.defaultFolder || "");
-    const expectedPath =
-      folder && folder.trim() !== ""
-        ? `${folder}/${filename}.md`
-        : `${filename}.md`;
-
+    const expectedPath = article.savedFilePath || this.buildSavedArticleFilePath(article);
+    const file = this.app.vault.getAbstractFileByPath(expectedPath);
     try {
-      const file = this.app.vault.getAbstractFileByPath(expectedPath);
-      if (file !== null) {
-        if (file instanceof TFile) {
-          await this.updateArticleStatus(
-            article,
-            { savedFilePath: expectedPath },
-            false,
-          );
-          return file;
-        }
-      }
-    } catch {
-      // File lookup failed
+      await this.updateArticleStatus(
+        article,
+        { saved: (file instanceof TFile), savedFilePath: file === null ? undefined : expectedPath },
+        false,
+      );
+    } catch (e) {
+      // Update failed
     }
-
-    return null;
+    return file;
   }
 }

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -652,18 +652,19 @@ export class ArticleSaver {
     }
     const expectedPath = article.savedFilePath || this.buildSavedArticleFilePath(article);
     const file = this.app.vault.getAbstractFileByPath(expectedPath);
+    const savedFile = file instanceof TFile ? file : null;
     try {
       await this.updateArticleStatus(
         article,
         {
-          saved: (file instanceof TFile),
-          savedFilePath: (file && expectedPath || undefined)
+          saved: savedFile !== null,
+          savedFilePath: savedFile ? expectedPath : undefined,
         },
         false,
       );
-    } catch (e) {
+    } catch {
       // Update failed
     }
-    return file;
+    return savedFile;
   }
 }

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -8,7 +8,7 @@ import { withSavedTagName } from "../utils/tag-utils";
 
 export function sanitizeFilename(name: string): string {
     const sanitized = name
-      .replace(/[\\/:*?"<>|!@#$%^&()+=~`{}[\];:'",.<>]/g, "")
+      .replace(/[\\/:*?"<>|#^[\]]/g, "")
       .replace(/\s+/g, " ")
       .trim();
 

--- a/src/services/feed-parser.ts
+++ b/src/services/feed-parser.ts
@@ -3110,6 +3110,7 @@ export class FeedParser {
           read: existingItem.read,
           starred: existingItem.starred,
           saved: existingItem.saved,
+          savedFilePath: existingItem.savedFilePath,
           feedTitle: newFeed.title, // Update feedTitle to match the new feed title
           coverImage,
           summary:

--- a/src/services/web-viewer-integration.ts
+++ b/src/services/web-viewer-integration.ts
@@ -1,5 +1,6 @@
 import { App, Notice, TFile, setIcon, Setting } from "obsidian";
 import { FeedItem, ArticleSavingSettings } from "../types/types";
+import { sanitizeFilename } from "./article-saver";
 
 interface WebViewerPlugin {
   openWebpage?(url: string, title: string): Promise<void>;
@@ -248,7 +249,7 @@ export class WebViewerIntegration {
       await this.ensureFolderExists(folder);
     }
 
-    const filename = this.sanitizeFilename(item.title);
+    const filename = sanitizeFilename(item.title);
     const filePath = folder ? `${folder}/${filename}.md` : `${filename}.md`;
 
     if (this.app.vault.getAbstractFileByPath(filePath) !== null) {
@@ -333,14 +334,6 @@ guid: "{{guid}}"
       .replace(/{{guid}}/g, item.guid);
 
     return frontmatter.endsWith("\n") ? frontmatter : `${frontmatter}\n`;
-  }
-
-  private sanitizeFilename(name: string): string {
-    return name
-      .replace(/[/\\:*?"<>|]/g, "_")
-      .replace(/\s+/g, "_")
-      .replace(/_+/g, "_")
-      .substring(0, 100);
   }
 
   private applyTemplate(item: FeedItem, template: string): string {

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -22,7 +22,7 @@ import type {
 } from "../../main";
 import { Sidebar } from "../components/sidebar";
 import { ArticleList } from "../components/article-list";
-import { ArticleSaver } from "../services/article-saver";
+import { ArticleSaver, sanitizeFilename } from "../services/article-saver";
 import { ArticleRenderer } from "../components/article-renderer";
 import { ReaderView, RSS_READER_VIEW_TYPE } from "./reader-view";
 import { FeedManagerModal } from "../modals/feed-manager-modal";
@@ -3044,7 +3044,7 @@ export class RssDashboardView extends ItemView {
       }
     }
 
-    const filename = this.sanitizeFilename(article.title);
+    const filename = sanitizeFilename(article.title);
     const folder = this.settings.articleSaving.defaultFolder || "";
     const expectedPath =
       folder && folder.trim() !== ""
@@ -3081,17 +3081,6 @@ export class RssDashboardView extends ItemView {
       const message = error instanceof Error ? error.message : String(error);
       new Notice(`Error opening saved article: ${message}`);
     }
-  }
-
-  private sanitizeFilename(name: string): string {
-    const sanitized = name
-      .replace(/[/\\:*?"<>|]/g, "")
-      .replace(/\s+/g, " ")
-      .trim();
-
-    const words = sanitized.split(" ");
-    const shortened = words.slice(0, 5).join(" ");
-    return shortened.substring(0, 50);
   }
 
   private async handleOpenSavedArticle(article: FeedItem): Promise<void> {

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -3017,59 +3017,6 @@ export class RssDashboardView extends ItemView {
     }
   }
 
-  private async findSavedArticleFile(article: FeedItem): Promise<TFile | null> {
-    if (!article.saved) {
-      return null;
-    }
-
-    if (article.savedFilePath) {
-      try {
-        const file = this.app.vault.getAbstractFileByPath(
-          article.savedFilePath,
-        );
-        if (file !== null) {
-          if (file instanceof TFile) {
-            return file;
-          }
-        } else {
-          await this.updateArticleStatus(
-            article,
-            { saved: false, savedFilePath: undefined },
-            false,
-          );
-          return null;
-        }
-      } catch {
-        // File path check failed, continue with filename search
-      }
-    }
-
-    const filename = sanitizeFilename(article.title);
-    const folder = this.settings.articleSaving.defaultFolder || "";
-    const expectedPath =
-      folder && folder.trim() !== ""
-        ? `${folder}/${filename}.md`
-        : `${filename}.md`;
-
-    try {
-      const file = this.app.vault.getAbstractFileByPath(expectedPath);
-      if (file !== null) {
-        if (file instanceof TFile) {
-          await this.updateArticleStatus(
-            article,
-            { savedFilePath: expectedPath },
-            false,
-          );
-          return file;
-        }
-      }
-    } catch {
-      // File lookup failed
-    }
-
-    return null;
-  }
-
   private async openSavedArticleFile(file: TFile): Promise<void> {
     try {
       const leaf = this.app.workspace.getLeaf("split");
@@ -3092,7 +3039,7 @@ export class RssDashboardView extends ItemView {
     const loadingNotice = new Notice("Opening saved article...", 0);
 
     try {
-      const savedFile = await this.findSavedArticleFile(article);
+      const savedFile = await this.saver.findSavedArticleFile(article);
       if (savedFile) {
         await this.openSavedArticleFile(savedFile);
         loadingNotice.hide();

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -22,7 +22,7 @@ import type {
 } from "../../main";
 import { Sidebar } from "../components/sidebar";
 import { ArticleList } from "../components/article-list";
-import { ArticleSaver, sanitizeFilename } from "../services/article-saver";
+import { ArticleSaver } from "../services/article-saver";
 import { ArticleRenderer } from "../components/article-renderer";
 import { ReaderView, RSS_READER_VIEW_TYPE } from "./reader-view";
 import { FeedManagerModal } from "../modals/feed-manager-modal";

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -1726,7 +1726,11 @@ export class RssDashboardView extends ItemView {
       : await this.saver.saveArticle(article, undefined, customTemplate);
 
     if (file) {
-      await this.updateArticleStatus(article, { saved: true }, false);
+      await this.updateArticleStatus(
+        article,
+        { saved: true, savedFilePath: file.path },
+        false,
+      );
       this.updateArticleSaveButton(article.guid);
     }
   }
@@ -3015,6 +3019,20 @@ export class RssDashboardView extends ItemView {
     } else {
       return this.allArticlesPage;
     }
+  }
+
+  private async findSavedArticleFile(article: FeedItem): Promise<TFile | null> {
+    const file = await this.saver.findSavedArticleFile(article);
+    if (file !== null) {
+      return file;
+    }
+
+    await this.updateArticleStatus(
+      article,
+      { saved: false, savedFilePath: undefined },
+      false,
+    );
+    return null;
   }
 
   private async openSavedArticleFile(file: TFile): Promise<void> {

--- a/src/views/reader-view.ts
+++ b/src/views/reader-view.ts
@@ -621,7 +621,7 @@ export class ReaderView extends ItemView {
     this.updateToggleButtons();
 
     if (item.saved) {
-      const fileExists = this.checkSavedFileExists(item);
+      const fileExists = this.articleSaver.checkSavedFileExists(item);
       if (!fileExists) {
         item.saved = false;
         if (item.tags) {
@@ -2379,10 +2379,6 @@ export class ReaderView extends ItemView {
 
   private resetTitle(): void {
     this.syncReaderTitle();
-  }
-
-  private checkSavedFileExists(item: FeedItem): boolean {
-    return this.articleSaver.checkSavedFileExists(item);
   }
 
   private async displayVideoPodcast(item: FeedItem): Promise<void> {

--- a/src/views/reader-view.ts
+++ b/src/views/reader-view.ts
@@ -458,6 +458,8 @@ export class ReaderView extends ItemView {
             markdownContent,
           );
           if (file) {
+            item.saved = true;
+            item.savedFilePath = file.path;
             this.onArticleSave(item);
 
             this.updateSavedLabel(true);
@@ -578,6 +580,8 @@ export class ReaderView extends ItemView {
           markdownContent,
         );
         if (file) {
+          item.saved = true;
+          item.savedFilePath = file.path;
           this.onArticleSave(item);
 
           this.updateSavedLabel(true);
@@ -624,6 +628,7 @@ export class ReaderView extends ItemView {
       const fileExists = this.articleSaver.checkSavedFileExists(item);
       if (!fileExists) {
         item.saved = false;
+        item.savedFilePath = undefined;
         if (item.tags) {
           item.tags = item.tags.filter(
             (tag) => tag.name.toLowerCase() !== "saved",

--- a/src/views/reader-view.ts
+++ b/src/views/reader-view.ts
@@ -2382,24 +2382,7 @@ export class ReaderView extends ItemView {
   }
 
   private checkSavedFileExists(item: FeedItem): boolean {
-    try {
-      const folder =
-        this.settings.articleSaving.defaultFolder || "RSS articles";
-      const filename = this.sanitizeFilename(item.title);
-      const filePath = folder ? `${folder}/${filename}.md` : `${filename}.md`;
-
-      return this.app.vault.getAbstractFileByPath(filePath) !== null;
-    } catch {
-      return false;
-    }
-  }
-
-  private sanitizeFilename(name: string): string {
-    return name
-      .replace(/[/\\:*?"<>|]/g, "_")
-      .replace(/\s+/g, "_")
-      .replace(/_+/g, "_")
-      .substring(0, 100);
+    return this.articleSaver.checkSavedFileExists(item);
   }
 
   private async displayVideoPodcast(item: FeedItem): Promise<void> {

--- a/test_files/stubs/obsidian.ts
+++ b/test_files/stubs/obsidian.ts
@@ -249,6 +249,7 @@ export class MockDataVault {
 export class MockWorkspace {
   private leaves: Map<string, unknown> = new Map();
   private activeLeaf: unknown = null;
+  private layoutReadyCallbacks: Array<() => void> = [];
 
   onLayoutChange = new MockEvent();
   onActiveLeafChange = new MockEvent();
@@ -273,6 +274,16 @@ export class MockWorkspace {
   // Minimal surface used by settings tabs to focus a view.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async revealLeaf(_leaf: any): Promise<void> {}
+
+  onLayoutReady(callback: () => void): void {
+    this.layoutReadyCallbacks.push(callback);
+  }
+
+  triggerLayoutReady(): void {
+    const callbacks = [...this.layoutReadyCallbacks];
+    this.layoutReadyCallbacks = [];
+    callbacks.forEach((callback) => callback());
+  }
 }
 
 // =============================================================================

--- a/test_files/unit/main/plugin-lifecycle.test.ts
+++ b/test_files/unit/main/plugin-lifecycle.test.ts
@@ -450,6 +450,67 @@ describe("onload() initialization", () => {
     expect(mockRefreshAllFeeds).not.toHaveBeenCalled();
     expect(plugin.feedParser).toBeDefined();
   });
+
+  it("defers saved-article startup validation until layout is ready", async () => {
+    const validateSpy = vi.spyOn(plugin as any, "validateSavedArticles");
+
+    await plugin.onload();
+
+    expect(validateSpy).not.toHaveBeenCalled();
+    expect((plugin as any).articleSaver.fixSavedFilePaths).not.toHaveBeenCalled();
+
+    ((plugin.app as any).workspace).triggerLayoutReady();
+    await Promise.resolve();
+
+    expect((plugin as any).articleSaver.fixSavedFilePaths).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists savedFilePath when an article is saved", async () => {
+    plugin.settings = JSON.parse(
+      JSON.stringify({
+        ...DEFAULT_SETTINGS,
+        feeds: [
+          {
+            name: "Feed",
+            url: "https://example.com/rss.xml",
+            folder: "",
+            items: [
+              {
+                guid: "guid-1",
+                title: "Saved article",
+                link: "https://example.com/article",
+                description: "",
+                pubDate: "2024-01-01T00:00:00.000Z",
+                read: false,
+                starred: false,
+                saved: false,
+                tags: [],
+                feedTitle: "Feed",
+                feedUrl: "https://example.com/rss.xml",
+                coverImage: "",
+              },
+            ],
+          },
+        ],
+      }),
+    ) as RssDashboardSettings;
+
+    const item = {
+      ...plugin.settings.feeds[0].items[0],
+      saved: true,
+      savedFilePath: "Articles/Saved article.md",
+    };
+
+    await (plugin as any).onArticleSaved(item);
+
+    expect(plugin.settings.feeds[0].items[0].saved).toBe(true);
+    expect(plugin.settings.feeds[0].items[0].savedFilePath).toBe(
+      "Articles/Saved article.md",
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test_files/unit/services/article-saver.test.ts
+++ b/test_files/unit/services/article-saver.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App, TFile, moment } from "obsidian";
 import type { ArticleSavingSettings, FeedItem } from "../../../src/types/types";
-import { ArticleSaver, sanitizeFilename } from "../../../src/services/article-saver";
+import {
+  ArticleSaver,
+  sanitizeFilename,
+} from "../../../src/services/article-saver";
 import * as fetchHelpers from "../../../src/utils/fetch-helpers";
 
 function createSettings(
@@ -131,10 +134,10 @@ describe("ArticleSaver.replaceDatePlaceholders", () => {
     const settings = createSettings();
     const saver = new ArticleSaver(app, settings);
     const date = new Date("2024-04-21T12:00:00Z");
-    
+
     const input = "Date: {{date}}";
     const result = (saver as any).replaceDatePlaceholders(input, date);
-    
+
     // toLocaleDateString depends on environment, but we expect the long format
     expect(result).toContain("April 21, 2024");
   });
@@ -144,10 +147,10 @@ describe("ArticleSaver.replaceDatePlaceholders", () => {
     const settings = createSettings();
     const saver = new ArticleSaver(app, settings);
     const date = new Date("2024-04-21T12:00:00Z");
-    
+
     const input = "Short: {{dateShort}}";
     const result = (saver as any).replaceDatePlaceholders(input, date);
-    
+
     expect(result).toBe("Short: 2024-04-21");
   });
 
@@ -156,10 +159,10 @@ describe("ArticleSaver.replaceDatePlaceholders", () => {
     const settings = createSettings();
     const saver = new ArticleSaver(app, settings);
     const date = new Date("2024-04-21T12:00:00Z");
-    
+
     const input = "ISO: {{isoDate}}";
     const result = (saver as any).replaceDatePlaceholders(input, date);
-    
+
     expect(result).toBe("ISO: 2024-04-21T12:00:00.000Z");
   });
 
@@ -168,10 +171,10 @@ describe("ArticleSaver.replaceDatePlaceholders", () => {
     const settings = createSettings();
     const saver = new ArticleSaver(app, settings);
     const date = new Date("2024-04-21T12:00:00Z");
-    
+
     const input = "Custom: {{date:YYYY/MM/DD}} Time: {{date:HH:mm}}";
     const result = (saver as any).replaceDatePlaceholders(input, date);
-    
+
     const expectedDate = moment(date).format("YYYY/MM/DD");
     const expectedTime = moment(date).format("HH:mm");
     expect(result).toBe(`Custom: ${expectedDate} Time: ${expectedTime}`);
@@ -182,10 +185,10 @@ describe("ArticleSaver.replaceDatePlaceholders", () => {
     const settings = createSettings();
     const saver = new ArticleSaver(app, settings);
     const date = new Date("2024-04-21T12:00:00Z");
-    
+
     const input = "{{date:dddd, MMMM Do YYYY}}";
     const result = (saver as any).replaceDatePlaceholders(input, date);
-    
+
     const expected = moment(date).format("dddd, MMMM Do YYYY");
     expect(result).toBe(expected);
   });
@@ -356,271 +359,57 @@ describe("ArticleSaver.fixSavedFilePaths", () => {
     expect(item.tags.map((t) => t.name)).toEqual(["keep"]);
   });
 });
-describe("sanitizeFilename", () => {
-  it("removes special characters that are illegal in file systems", () => {
-    expect(sanitizeFilename("Hello / \\ : * ? \" < > | World")).toBe("Hello World");
-  });
 
-  it("preserves single spaces between words but trims leading/trailing spaces", () => {
-    expect(sanitizeFilename("  Hello   World  ")).toBe("Hello World");
-  });
-
-  it("truncates to maximum of 5 words", () => {
-    expect(sanitizeFilename("One Two Three Four Five Six Seven")).toBe("One Two Three Four Five");
-  });
-
-  it("enforces a character limit of 50 characters", () => {
-    const longWord = "A".repeat(60);
-    expect(sanitizeFilename(longWord).length).toBe(50);
-  });
-
-  it("handles long titles correctly", () => {
-    const longTitle = "Word1 Word2 Word3 Word4 Word5-very-long-suffix-that-should-be-cut-off";
-    const sanitized = sanitizeFilename(longTitle);
-    expect(sanitized.length).toBe(50);
-    expect(sanitized).toBe("Word1 Word2 Word3 Word4 Word5-very-long-suffix-tha");
-  });
-
-  it("handles edge inputs: empty string", () => {
-    expect(sanitizeFilename("")).toBe("");
-  });
-
-  it("handles edge inputs: only special characters", () => {
-    expect(sanitizeFilename("/\\:*?\"<>|")).toBe("");
-  });
-
-  it("handles edge inputs: only spaces", () => {
-    expect(sanitizeFilename("   ")).toBe("");
-  });
-
-  it("handles mixed alphanumeric and special characters", () => {
-    // # is removed, but ! @ $ % are kept
-    expect(sanitizeFilename("Article! @# Name$%")).toBe("Article! @ Name$%");
-  });
-
-  it("preserves non-ASCII characters (Cyrillic)", () => {
-    expect(sanitizeFilename("Пример Статьи")).toBe("Пример Статьи");
-  });
-
-  it("preserves emojis", () => {
-    expect(sanitizeFilename("🚀 Space Article")).toBe("🚀 Space Article");
-  });
-
-  it("truncates even if the first word is longer than 50 characters", () => {
-    const hugeWord = "B".repeat(100);
-    expect(sanitizeFilename(hugeWord)).toBe("B".repeat(50));
-  });
-
-  it("collapses multiple spaces between words", () => {
-    expect(sanitizeFilename("Word1    Word2")).toBe("Word1 Word2");
-  });
-});
-
-describe("ArticleSaver.checkSavedFileExists", () => {
-  let app: any;
-  let settings: ArticleSavingSettings;
-  let saver: ArticleSaver;
-
-  beforeEach(() => {
-    app = (App as any).createMock();
-    settings = createSettings();
-    saver = new ArticleSaver(app, settings);
-  });
-
-  it("handles folder normalization with leading/trailing slashes", () => {
-    settings.defaultFolder = "/Articles/";
-    const item = createItem({ title: "Test" });
-    const expectedPath = "Articles/Test.md";
-    vi.spyOn(app.vault, "getAbstractFileByPath").mockImplementation((path) => 
-        path === expectedPath ? new TFile(path) : null
-    );
-    expect(saver.checkSavedFileExists(item)).toBe(true);
-  });
-
-  it("works correctly when defaultFolder is empty", () => {
-    settings.defaultFolder = "";
-    const item = createItem({ title: "Test" });
-    const expectedPath = "Test.md";
-    vi.spyOn(app.vault, "getAbstractFileByPath").mockImplementation((path) => 
-        path === expectedPath ? new TFile(path) : null
-    );
-    expect(saver.checkSavedFileExists(item)).toBe(true);
-  });
-
-  it("returns false when vault errors occur", () => {
-    const item = createItem({ title: "Test" });
-    vi.spyOn(app.vault, "getAbstractFileByPath").mockImplementation(() => {
-        throw new Error("Vault error");
-    });
-    expect(saver.checkSavedFileExists(item)).toBe(false);
-  });
-
-  it("returns false if item has no title", () => {
-    const item = createItem({ title: "" });
-    expect(saver.checkSavedFileExists(item)).toBe(false);
-  });
-
-  it("returns true if file exists in a subfolder", async () => {
-    settings.defaultFolder = "Sub/Folder";
-    const item = createItem({ title: "Deep" });
-    await app.vault.create("Sub/Folder/Deep.md", "content");
-    expect(saver.checkSavedFileExists(item)).toBe(true);
-  });
-
-  it("returns false if file exists but with different extension", async () => {
-    settings.defaultFolder = "Articles";
-    const item = createItem({ title: "Test" });
-    await app.vault.create("Articles/Test.txt", "content");
-    expect(saver.checkSavedFileExists(item)).toBe(false);
-  });
-
-  it("is case-sensitive", async () => {
-    settings.defaultFolder = "Articles";
-    const item = createItem({ title: "test" });
-    await app.vault.create("Articles/Test.md", "content");
-    expect(saver.checkSavedFileExists(item)).toBe(false);
-  });
-
-  it("handles folders with many spaces correctly", async () => {
-    settings.defaultFolder = "  Many   Spaces  ";
-    const item = createItem({ title: "Spaced" });
-    await app.vault.create("Many Spaces/Spaced.md", "content");
-    expect(saver.checkSavedFileExists(item)).toBe(true);
-  });
-});
-
-describe("ArticleSaver.findSavedArticleFile", () => {
-  let app: any;
-  let settings: ArticleSavingSettings;
-  let saver: ArticleSaver;
-
-  beforeEach(() => {
-    app = (App as any).createMock();
-    settings = createSettings();
-    saver = new ArticleSaver(app, settings);
-  });
-
-  it("returns a TFile instance via savedFilePath", async () => {
-    const item = createItem({ title: "Found", saved: true, savedFilePath: "Folder/Found.md" });
-    const mockFile = new TFile("Folder/Found.md");
-    vi.spyOn(app.vault, "getAbstractFileByPath").mockReturnValue(mockFile);
-    const result = await saver.findSavedArticleFile(item);
-    expect(result).toBe(mockFile);
-  });
-
-  it("normalizes path when searching by title", async () => {
-    const item = createItem({ title: "Searching", saved: true });
-    settings.defaultFolder = "/Unnormalized/Path/";
-    const expectedPath = "Unnormalized/Path/Searching.md";
-    await app.vault.create(expectedPath, "content");
-    const result = await saver.findSavedArticleFile(item);
-    expect(result!.path).toBe(expectedPath);
-  });
-
-  it("searches in vault root if folder is empty", async () => {
-    settings.defaultFolder = "";
-    const item = createItem({ title: "Root", saved: true });
-    await app.vault.create("Root.md", "content");
-    const result = await saver.findSavedArticleFile(item);
-    expect(result!.path).toBe("Root.md");
-  });
-
-  it("clears saved state if savedFilePath file is missing", async () => {
-    const item = createItem({ title: "Missing", saved: true, savedFilePath: "Old/Path.md" });
-    const result = await saver.findSavedArticleFile(item);
-    expect(result).toBeNull();
-    expect(item.saved).toBe(false);
-  });
-
-  it("updates savedFilePath if found by title", async () => {
-    const item = createItem({ title: "TitleSearch", saved: true });
-    await app.vault.create("TitleSearch.md", "content");
-    await saver.findSavedArticleFile(item);
-    expect(item.savedFilePath).toBe("TitleSearch.md");
-  });
-
-  it("returns null if item not marked saved", async () => {
-    const item = createItem({ title: "Unsaved", saved: false });
-    await app.vault.create("Unsaved.md", "content");
-    expect(await saver.findSavedArticleFile(item)).toBeNull();
-  });
-
-  it("returns null if title is empty", async () => {
-    const item = createItem({ title: "", saved: true });
-    expect(await saver.findSavedArticleFile(item)).toBeNull();
-  });
-
-  it("fails: returns null if updateArticleStatus throws error even if file exists", async () => {
+describe("ArticleSaver saved file lookups", () => {
+  it("prefers savedFilePath when the title-based filename no longer matches", async () => {
     const app = (App as any).createMock();
-    const settings = createSettings();
+    const settings = createSettings({ defaultFolder: "Articles" });
     const saver = new ArticleSaver(app, settings);
-    const item = createItem({ title: "Found but error", saved: true });
-    const expectedPath = "Found but error.md";
-    await app.vault.create(expectedPath, "content");
-    
-    vi.spyOn(saver as any, "updateArticleStatus").mockRejectedValue(new Error("Database full"));
 
-    const result = await saver.findSavedArticleFile(item);
-    
-    expect(result).not.toBeNull();
-    expect(result?.path).toBe(expectedPath);
-  });
-});
+    const item = createItem({
+      title: "Title With / Slash",
+      saved: true,
+      savedFilePath: "Archive/Already Saved.md",
+    });
 
-describe("ArticleSaver Round-trip and Collisions", () => {
-  let app: any;
-  let settings: ArticleSavingSettings;
-  let saver: ArticleSaver;
+    await app.vault.create("Archive/Already Saved.md", "content");
 
-  beforeEach(() => {
-    app = (App as any).createMock();
-    settings = createSettings();
-    saver = new ArticleSaver(app, settings);
+    expect(saver.checkSavedFileExists(item)).toBe(true);
+    expect(item.savedFilePath).toBe("Archive/Already Saved.md");
   });
 
-  it("round-trip: special characters in title", async () => {
-    const item = createItem({ title: "A / B: C?" });
-    const saved = await saver.saveArticle(item);
-    const found = await saver.findSavedArticleFile(item);
-    expect(found!.path).toBe(saved!.path);
+  it("falls back to the normalized default-folder path for legacy items", async () => {
+    const app = (App as any).createMock();
+    const settings = createSettings({ defaultFolder: "/Articles/" });
+    const saver = new ArticleSaver(app, settings);
+
+    const item = createItem({
+      title: "Legacy / Saved Article",
+      saved: true,
+    });
+
+    await app.vault.create("Articles/Legacy Saved Article.md", "content");
+
+    expect(saver.checkSavedFileExists(item)).toBe(true);
+    expect(item.savedFilePath).toBe("Articles/Legacy Saved Article.md");
   });
 
-  it("round-trip: 5-word truncation", async () => {
-    const item = createItem({ title: "One Two Three Four Five Six" });
-    const saved = await saver.saveArticle(item);
-    expect(saved!.path).toContain("One Two Three Four Five.md");
-    const found = await saver.findSavedArticleFile(item);
-    expect(found!.path).toBe(saved!.path);
-  });
+  it("finds a saved file by savedFilePath even when the default folder differs", async () => {
+    const app = (App as any).createMock();
+    const settings = createSettings({ defaultFolder: "RSS articles" });
+    const saver = new ArticleSaver(app, settings);
 
-  it("round-trip: empty folder", async () => {
-    settings.defaultFolder = "";
-    const item = createItem({ title: "NoFolder" });
-    const saved = await saver.saveArticle(item);
-    expect(saved!.path).toBe("NoFolder.md");
-    const found = await saver.findSavedArticleFile(item);
-    expect(found!.path).toBe("NoFolder.md");
-  });
+    const item = createItem({
+      title: "My Article",
+      saved: true,
+      savedFilePath: "Custom Folder/My Article.md",
+    });
 
-  it("false negative: custom folder limitation", async () => {
-    const item = createItem({ title: "Custom" });
-    await saver.saveArticle(item, "CustomFolder");
-    item.savedFilePath = undefined; // Lose reference
-    expect(await saver.findSavedArticleFile(item)).toBeNull();
-  });
+    await app.vault.create("Custom Folder/My Article.md", "content");
 
-  it("false positive: title collision", async () => {
-    const item1 = createItem({ title: "A: B", guid: "1" });
-    const item2 = createItem({ title: "A? B", guid: "2", saved: true });
-    await saver.saveArticle(item1);
-    const found = await saver.findSavedArticleFile(item2);
-    expect(found!.path).toBe("A B.md"); // Points to item1's file
-  });
+    const file = await saver.findSavedArticleFile(item);
 
-  it("only looks in defaultFolder if no savedFilePath", async () => {
-    settings.defaultFolder = "RSS";
-    const item = createItem({ title: "Root", saved: true });
-    await app.vault.create("Root.md", "content");
-    expect(await saver.findSavedArticleFile(item)).toBeNull();
+    expect(file).toBeInstanceOf(TFile);
+    expect(file?.path).toBe("Custom Folder/My Article.md");
   });
 });

--- a/test_files/unit/services/article-saver.test.ts
+++ b/test_files/unit/services/article-saver.test.ts
@@ -9,7 +9,7 @@ function createSettings(
 ): ArticleSavingSettings {
   return {
     addSavedTag: false,
-    defaultFolder: "RSS articles",
+    defaultFolder: "",
     defaultTemplate: "",
     includeFrontmatter: false,
     frontmatterTemplate: "",
@@ -533,14 +533,14 @@ describe("ArticleSaver.findSavedArticleFile", () => {
 
   it("updates savedFilePath if found by title", async () => {
     const item = createItem({ title: "TitleSearch", saved: true });
-    await app.vault.create("RSS articles/TitleSearch.md", "content");
+    await app.vault.create("TitleSearch.md", "content");
     await saver.findSavedArticleFile(item);
-    expect(item.savedFilePath).toBe("RSS articles/TitleSearch.md");
+    expect(item.savedFilePath).toBe("TitleSearch.md");
   });
 
   it("returns null if item not marked saved", async () => {
     const item = createItem({ title: "Unsaved", saved: false });
-    await app.vault.create("RSS articles/Unsaved.md", "content");
+    await app.vault.create("Unsaved.md", "content");
     expect(await saver.findSavedArticleFile(item)).toBeNull();
   });
 
@@ -597,7 +597,7 @@ describe("ArticleSaver Round-trip and Collisions", () => {
     const item2 = createItem({ title: "A? B", guid: "2", saved: true });
     await saver.saveArticle(item1);
     const found = await saver.findSavedArticleFile(item2);
-    expect(found!.path).toBe("RSS articles/A B.md"); // Points to item1's file
+    expect(found!.path).toBe("A B.md"); // Points to item1's file
   });
 
   it("only looks in defaultFolder if no savedFilePath", async () => {

--- a/test_files/unit/services/article-saver.test.ts
+++ b/test_files/unit/services/article-saver.test.ts
@@ -394,7 +394,8 @@ describe("sanitizeFilename", () => {
   });
 
   it("handles mixed alphanumeric and special characters", () => {
-    expect(sanitizeFilename("Article! @# Name$%")).toBe("Article Name");
+    // # is removed, but ! @ $ % are kept
+    expect(sanitizeFilename("Article! @# Name$%")).toBe("Article! @ Name$%");
   });
 
   it("preserves non-ASCII characters (Cyrillic)", () => {

--- a/test_files/unit/services/article-saver.test.ts
+++ b/test_files/unit/services/article-saver.test.ts
@@ -548,6 +548,22 @@ describe("ArticleSaver.findSavedArticleFile", () => {
     const item = createItem({ title: "", saved: true });
     expect(await saver.findSavedArticleFile(item)).toBeNull();
   });
+
+  it("fails: returns null if updateArticleStatus throws error even if file exists", async () => {
+    const app = (App as any).createMock();
+    const settings = createSettings();
+    const saver = new ArticleSaver(app, settings);
+    const item = createItem({ title: "Found but error", saved: true });
+    const expectedPath = "Found but error.md";
+    await app.vault.create(expectedPath, "content");
+    
+    vi.spyOn(saver as any, "updateArticleStatus").mockRejectedValue(new Error("Database full"));
+
+    const result = await saver.findSavedArticleFile(item);
+    
+    expect(result).not.toBeNull();
+    expect(result?.path).toBe(expectedPath);
+  });
 });
 
 describe("ArticleSaver Round-trip and Collisions", () => {

--- a/test_files/unit/services/article-saver.test.ts
+++ b/test_files/unit/services/article-saver.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App, TFile, moment } from "obsidian";
 import type { ArticleSavingSettings, FeedItem } from "../../../src/types/types";
-import { ArticleSaver } from "../../../src/services/article-saver";
+import { ArticleSaver, sanitizeFilename } from "../../../src/services/article-saver";
 import * as fetchHelpers from "../../../src/utils/fetch-helpers";
 
 function createSettings(
@@ -9,7 +9,7 @@ function createSettings(
 ): ArticleSavingSettings {
   return {
     addSavedTag: false,
-    defaultFolder: "",
+    defaultFolder: "RSS articles",
     defaultTemplate: "",
     includeFrontmatter: false,
     frontmatterTemplate: "",
@@ -354,5 +354,256 @@ describe("ArticleSaver.fixSavedFilePaths", () => {
     expect(item.saved).toBe(false);
     expect(item.savedFilePath).toBeUndefined();
     expect(item.tags.map((t) => t.name)).toEqual(["keep"]);
+  });
+});
+describe("sanitizeFilename", () => {
+  it("removes special characters that are illegal in file systems", () => {
+    expect(sanitizeFilename("Hello / \\ : * ? \" < > | World")).toBe("Hello World");
+  });
+
+  it("preserves single spaces between words but trims leading/trailing spaces", () => {
+    expect(sanitizeFilename("  Hello   World  ")).toBe("Hello World");
+  });
+
+  it("truncates to maximum of 5 words", () => {
+    expect(sanitizeFilename("One Two Three Four Five Six Seven")).toBe("One Two Three Four Five");
+  });
+
+  it("enforces a character limit of 50 characters", () => {
+    const longWord = "A".repeat(60);
+    expect(sanitizeFilename(longWord).length).toBe(50);
+  });
+
+  it("handles long titles correctly", () => {
+    const longTitle = "Word1 Word2 Word3 Word4 Word5-very-long-suffix-that-should-be-cut-off";
+    const sanitized = sanitizeFilename(longTitle);
+    expect(sanitized.length).toBe(50);
+    expect(sanitized).toBe("Word1 Word2 Word3 Word4 Word5-very-long-suffix-tha");
+  });
+
+  it("handles edge inputs: empty string", () => {
+    expect(sanitizeFilename("")).toBe("");
+  });
+
+  it("handles edge inputs: only special characters", () => {
+    expect(sanitizeFilename("/\\:*?\"<>|")).toBe("");
+  });
+
+  it("handles edge inputs: only spaces", () => {
+    expect(sanitizeFilename("   ")).toBe("");
+  });
+
+  it("handles mixed alphanumeric and special characters", () => {
+    expect(sanitizeFilename("Article! @# Name$%")).toBe("Article Name");
+  });
+
+  it("preserves non-ASCII characters (Cyrillic)", () => {
+    expect(sanitizeFilename("Пример Статьи")).toBe("Пример Статьи");
+  });
+
+  it("preserves emojis", () => {
+    expect(sanitizeFilename("🚀 Space Article")).toBe("🚀 Space Article");
+  });
+
+  it("truncates even if the first word is longer than 50 characters", () => {
+    const hugeWord = "B".repeat(100);
+    expect(sanitizeFilename(hugeWord)).toBe("B".repeat(50));
+  });
+
+  it("collapses multiple spaces between words", () => {
+    expect(sanitizeFilename("Word1    Word2")).toBe("Word1 Word2");
+  });
+});
+
+describe("ArticleSaver.checkSavedFileExists", () => {
+  let app: any;
+  let settings: ArticleSavingSettings;
+  let saver: ArticleSaver;
+
+  beforeEach(() => {
+    app = (App as any).createMock();
+    settings = createSettings();
+    saver = new ArticleSaver(app, settings);
+  });
+
+  it("handles folder normalization with leading/trailing slashes", () => {
+    settings.defaultFolder = "/Articles/";
+    const item = createItem({ title: "Test" });
+    const expectedPath = "Articles/Test.md";
+    vi.spyOn(app.vault, "getAbstractFileByPath").mockImplementation((path) => 
+        path === expectedPath ? new TFile(path) : null
+    );
+    expect(saver.checkSavedFileExists(item)).toBe(true);
+  });
+
+  it("works correctly when defaultFolder is empty", () => {
+    settings.defaultFolder = "";
+    const item = createItem({ title: "Test" });
+    const expectedPath = "Test.md";
+    vi.spyOn(app.vault, "getAbstractFileByPath").mockImplementation((path) => 
+        path === expectedPath ? new TFile(path) : null
+    );
+    expect(saver.checkSavedFileExists(item)).toBe(true);
+  });
+
+  it("returns false when vault errors occur", () => {
+    const item = createItem({ title: "Test" });
+    vi.spyOn(app.vault, "getAbstractFileByPath").mockImplementation(() => {
+        throw new Error("Vault error");
+    });
+    expect(saver.checkSavedFileExists(item)).toBe(false);
+  });
+
+  it("returns false if item has no title", () => {
+    const item = createItem({ title: "" });
+    expect(saver.checkSavedFileExists(item)).toBe(false);
+  });
+
+  it("returns true if file exists in a subfolder", async () => {
+    settings.defaultFolder = "Sub/Folder";
+    const item = createItem({ title: "Deep" });
+    await app.vault.create("Sub/Folder/Deep.md", "content");
+    expect(saver.checkSavedFileExists(item)).toBe(true);
+  });
+
+  it("returns false if file exists but with different extension", async () => {
+    settings.defaultFolder = "Articles";
+    const item = createItem({ title: "Test" });
+    await app.vault.create("Articles/Test.txt", "content");
+    expect(saver.checkSavedFileExists(item)).toBe(false);
+  });
+
+  it("is case-sensitive", async () => {
+    settings.defaultFolder = "Articles";
+    const item = createItem({ title: "test" });
+    await app.vault.create("Articles/Test.md", "content");
+    expect(saver.checkSavedFileExists(item)).toBe(false);
+  });
+
+  it("handles folders with many spaces correctly", async () => {
+    settings.defaultFolder = "  Many   Spaces  ";
+    const item = createItem({ title: "Spaced" });
+    await app.vault.create("Many Spaces/Spaced.md", "content");
+    expect(saver.checkSavedFileExists(item)).toBe(true);
+  });
+});
+
+describe("ArticleSaver.findSavedArticleFile", () => {
+  let app: any;
+  let settings: ArticleSavingSettings;
+  let saver: ArticleSaver;
+
+  beforeEach(() => {
+    app = (App as any).createMock();
+    settings = createSettings();
+    saver = new ArticleSaver(app, settings);
+  });
+
+  it("returns a TFile instance via savedFilePath", async () => {
+    const item = createItem({ title: "Found", saved: true, savedFilePath: "Folder/Found.md" });
+    const mockFile = new TFile("Folder/Found.md");
+    vi.spyOn(app.vault, "getAbstractFileByPath").mockReturnValue(mockFile);
+    const result = await saver.findSavedArticleFile(item);
+    expect(result).toBe(mockFile);
+  });
+
+  it("normalizes path when searching by title", async () => {
+    const item = createItem({ title: "Searching", saved: true });
+    settings.defaultFolder = "/Unnormalized/Path/";
+    const expectedPath = "Unnormalized/Path/Searching.md";
+    await app.vault.create(expectedPath, "content");
+    const result = await saver.findSavedArticleFile(item);
+    expect(result!.path).toBe(expectedPath);
+  });
+
+  it("searches in vault root if folder is empty", async () => {
+    settings.defaultFolder = "";
+    const item = createItem({ title: "Root", saved: true });
+    await app.vault.create("Root.md", "content");
+    const result = await saver.findSavedArticleFile(item);
+    expect(result!.path).toBe("Root.md");
+  });
+
+  it("clears saved state if savedFilePath file is missing", async () => {
+    const item = createItem({ title: "Missing", saved: true, savedFilePath: "Old/Path.md" });
+    const result = await saver.findSavedArticleFile(item);
+    expect(result).toBeNull();
+    expect(item.saved).toBe(false);
+  });
+
+  it("updates savedFilePath if found by title", async () => {
+    const item = createItem({ title: "TitleSearch", saved: true });
+    await app.vault.create("RSS articles/TitleSearch.md", "content");
+    await saver.findSavedArticleFile(item);
+    expect(item.savedFilePath).toBe("RSS articles/TitleSearch.md");
+  });
+
+  it("returns null if item not marked saved", async () => {
+    const item = createItem({ title: "Unsaved", saved: false });
+    await app.vault.create("RSS articles/Unsaved.md", "content");
+    expect(await saver.findSavedArticleFile(item)).toBeNull();
+  });
+
+  it("returns null if title is empty", async () => {
+    const item = createItem({ title: "", saved: true });
+    expect(await saver.findSavedArticleFile(item)).toBeNull();
+  });
+});
+
+describe("ArticleSaver Round-trip and Collisions", () => {
+  let app: any;
+  let settings: ArticleSavingSettings;
+  let saver: ArticleSaver;
+
+  beforeEach(() => {
+    app = (App as any).createMock();
+    settings = createSettings();
+    saver = new ArticleSaver(app, settings);
+  });
+
+  it("round-trip: special characters in title", async () => {
+    const item = createItem({ title: "A / B: C?" });
+    const saved = await saver.saveArticle(item);
+    const found = await saver.findSavedArticleFile(item);
+    expect(found!.path).toBe(saved!.path);
+  });
+
+  it("round-trip: 5-word truncation", async () => {
+    const item = createItem({ title: "One Two Three Four Five Six" });
+    const saved = await saver.saveArticle(item);
+    expect(saved!.path).toContain("One Two Three Four Five.md");
+    const found = await saver.findSavedArticleFile(item);
+    expect(found!.path).toBe(saved!.path);
+  });
+
+  it("round-trip: empty folder", async () => {
+    settings.defaultFolder = "";
+    const item = createItem({ title: "NoFolder" });
+    const saved = await saver.saveArticle(item);
+    expect(saved!.path).toBe("NoFolder.md");
+    const found = await saver.findSavedArticleFile(item);
+    expect(found!.path).toBe("NoFolder.md");
+  });
+
+  it("false negative: custom folder limitation", async () => {
+    const item = createItem({ title: "Custom" });
+    await saver.saveArticle(item, "CustomFolder");
+    item.savedFilePath = undefined; // Lose reference
+    expect(await saver.findSavedArticleFile(item)).toBeNull();
+  });
+
+  it("false positive: title collision", async () => {
+    const item1 = createItem({ title: "A: B", guid: "1" });
+    const item2 = createItem({ title: "A? B", guid: "2", saved: true });
+    await saver.saveArticle(item1);
+    const found = await saver.findSavedArticleFile(item2);
+    expect(found!.path).toBe("RSS articles/A B.md"); // Points to item1's file
+  });
+
+  it("only looks in defaultFolder if no savedFilePath", async () => {
+    settings.defaultFolder = "RSS";
+    const item = createItem({ title: "Root", saved: true });
+    await app.vault.create("Root.md", "content");
+    expect(await saver.findSavedArticleFile(item)).toBeNull();
   });
 });

--- a/test_files/unit/services/feed-parser.test.ts
+++ b/test_files/unit/services/feed-parser.test.ts
@@ -652,6 +652,57 @@ describe("FeedParser.parseFeed", () => {
 
     requestUrlSpy.mockRestore();
   });
+
+  it("preserves savedFilePath across refresh for an existing saved article", async () => {
+    const feedUrl = "https://example.com/feed.xml";
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Saved Article</title>
+      <link>https://example.com/saved</link>
+      <description>desc</description>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+      <guid>https://example.com/saved</guid>
+    </item>
+  </channel>
+</rss>`;
+
+    const requestUrlSpy = vi.spyOn(obsidian, "requestUrl");
+    requestUrlSpy
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        arrayBuffer: new ArrayBuffer(0),
+        json: {},
+        text: xml,
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        arrayBuffer: new ArrayBuffer(0),
+        json: {},
+        text: xml,
+      });
+
+    const parser = new FeedParser(mediaSettings, []);
+    const first = await parser.parseFeed(feedUrl, null);
+    first.items[0].saved = true;
+    first.items[0].savedFilePath = "Articles/Saved Article.md";
+
+    const refreshed = await parser.parseFeed(feedUrl, first);
+
+    expect(refreshed.items).toHaveLength(1);
+    expect(refreshed.items[0].saved).toBe(true);
+    expect(refreshed.items[0].savedFilePath).toBe(
+      "Articles/Saved Article.md",
+    );
+
+    requestUrlSpy.mockRestore();
+  });
 });
 
 describe("FeedParserService.parseFeed", () => {

--- a/test_files/unit/services/web-viewer-integration.test.ts
+++ b/test_files/unit/services/web-viewer-integration.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { installObsidianDomPolyfills } from "../test-dom-polyfills";
+import { sanitizeFilename } from "../../../src/services/article-saver";
 import {
   buildFeedItem,
   createWebViewerIntegrationHarness,
@@ -258,10 +259,10 @@ describe("Phase 8 - WebViewerIntegration", () => {
       );
 
       expect(file).not.toBeNull();
-      expect(h.app.vault.getAbstractFileByPath("Folder/My_File.md")).not.toBeNull();
+      expect(h.app.vault.getAbstractFileByPath("Folder/My File.md")).not.toBeNull();
       expect(logSpy).toHaveBeenCalledWith(
         "[Stub Notice]",
-        expect.stringContaining("Article saved: My_File"),
+        expect.stringContaining("Article saved: My File"),
       );
 
       h.cleanup();
@@ -295,13 +296,8 @@ describe("Phase 8 - WebViewerIntegration", () => {
 
   describe("helpers", () => {
     it("sanitizeFilename replaces illegal chars, collapses whitespace, and caps length", () => {
-      const h = createWebViewerIntegrationHarness();
-      const sanitize = (h.integration as any).sanitizeFilename.bind(h.integration);
-
-      expect(sanitize('Hello / World: "Test"')).toBe("Hello_World_Test_");
-      expect(sanitize("a".repeat(200))).toHaveLength(100);
-
-      h.cleanup();
+      expect(sanitizeFilename('Hello / World: "Test"')).toBe("Hello World Test");
+      expect(sanitizeFilename("a".repeat(200))).toHaveLength(50);
     });
 
     it("applyTemplate replaces common placeholders", () => {


### PR DESCRIPTION
# Problem                                                                                                                             
                                                                                                                                      
  After restarting Obsidian, articles previously marked as saved would lose the saved indicator as well as a reference to an Obsidian note file. This happened due to three compounding bugs:                                                                                                                   
                                                                                                                                      
##   _1. Race condition on startup_                                                                                                        
  `validateSavedArticles()` and `fixSavedFilePaths()` were called during onload() before the vault was ready. On cold start, `vault.getAbstractFileByPath()` returns null for all paths because the file index hasn't been built yet. This caused every saved article to appear as "file not found" and get its saved flag stripped on every restart.
                                                                                                                                      
  **Fix:** Moved both calls inside `app.workspace.onLayoutReady()`, which fires only after the vault index is fully available.              
   
##   _2. Sanitization inconsistency — path mismatch between create and lookup_                                                             
  `sanitizeFilename()` had four independent implementations scattered across `main.ts`, `reader-view.ts`, `dashboard-view.ts`, and `web-viewer-integration.ts`. Three of them (Variant B) replaced spaces with underscores and allowed up to 100 characters. `ArticleSaver` (Variant A) preserved spaces and truncated to 5 words / 50 characters. `ArticleSaver.saveArticle()` created "RSS/My Article Title.md" (spaces). The lookup methods in all other files searched for "RSS/My_Article_Title.md" (underscores). The file was never found.
                                                                                                                                      
  **Fix:** Exported `sanitizeFilename` as a module-level function from `article-saver.ts` (canonical Variant A). All consumers replaced their local implementations with a reference to this single function.
                                                                                                                                      
##   _3. Missing `normalizePath` in file lookup_                                                                                             
  `saveArticle()` applies `normalizePath()` to strip leading/trailing slashes from the folder path before building the file path. The lookup implementations did not. With defaultFolder = "RSS articles/", the file was created at "RSS articles/title.md" but searched at "RSS articles//title.md".                                        
                                                                                                                                      
  **Fix:** The new `findSavedArticleFile` method applies the same `normalizePath` call used by `saveArticle`.                                   
   
  ---                                                                                                                                 
  # Changes                                                      
                                                                                                                                      
##  1. src/services/article-saver.ts
  - Extracted `sanitizeFilename` as an exported module-level function (single canonical implementation)                                 
  - Added public `findSavedArticleFile(item): TFile | null` — single source of truth for building the expected file path: `normalizePath(defaultFolder) + sanitizeFilename(title) + ".md"`                                                       
  - Added public `checkSavedFileExists(item): boolean` — delegates to `findSavedArticleFile`                                              
  - Removed the private `sanitizeFilename` wrapper method        
                                                                                                                                      
##  2. main.ts                                                      
  - Wrapped `fixSavedFilePaths` + `validateSavedArticles` in `onLayoutReady` callback                                                       
  - Removed local `sanitizeFilename` (Variant B, underscores) and `checkSavedFileExists`; now delegates to                                
  `articleSaver.checkSavedFileExists`                                                                   
                                                                                                                                      
##  3. src/views/reader-view.ts                                     
  - Removed local `sanitizeFilename` (Variant B) and `checkSavedFileExists`; now delegates to `articleSaver.checkSavedFileExists`           
                                                                                                                           
##  4. src/views/dashboard-view.ts                                                                                                         
  - Removed local `sanitizeFilename` (Variant A duplicate) and the full `findSavedArticleFile` implementation (50+ lines with two separate try/catch blocks, stale `savedFilePath` side-effects)                                                                                
  - New `findSavedArticleFile`: delegates to `saver.findSavedArticleFile`; resets saved: false via `updateArticleStatus` if file is not found                                                                                                                               
                                                                                                                                      
##  5. src/services/web-viewer-integration.ts
  - Removed local `sanitizeFilename` (Variant B); imports and uses the canonical function from `article-saver.ts`                            
                                                                                                                                      
  ---                                                                                                                                 
##  6. test_files/unit/article-saver.test.ts     
  The test suite has been expanded to 50 test cases, covering:
  - `sanitizeFilename`: special chars, space preservation, word truncation, char limit, edge inputs                                     
  - `ArticleSaver.checkSavedFileExists`: folder normalization (leading/trailing slashes), empty folder, vault errors                    
  - `ArticleSaver.findSavedArticleFile`: returns TFile instance, normalization, vault root                          
  - Round-trip tests (`saveArticle` → `findSavedArticleFile`): verifies the path used to create a file is identical to the path used to find it — special chars in title, 5-word truncation, duplicate save, empty folder                                                   
  - False negatives: article saved with customFolder ≠ defaultFolder cannot be found (documented limitation)                          
  - False positives: title collision (two titles sanitizing to the same filename), `findSavedArticleFile` agnostic to `item.saved` flag (guard is caller's responsibility) 