### PR TITLE
Add link target to keyword rules

### DIFF
--- a/src/components/keyword-filter-editor.ts
+++ b/src/components/keyword-filter-editor.ts
@@ -22,6 +22,7 @@ export function createDefaultKeywordFilterRule(): KeywordFilterRule {
     applyToTitle: true,
     applyToSummary: true,
     applyToContent: true,
+    applyToLink: false,
     enabled: true,
     createdAt: Date.now(),
   };
@@ -317,6 +318,17 @@ export function renderKeywordFilterEditor(
           onChange({
             ...state,
             rules: updateRule(state.rules, index, { applyToContent: checked }),
+          }),
+      );
+      renderLocationToggle(
+        locationsRow,
+        "Link",
+        !!rule.applyToLink,
+        !rule.enabled,
+        (checked) =>
+          onChange({
+            ...state,
+            rules: updateRule(state.rules, index, { applyToLink: checked }),
           }),
       );
     });

--- a/src/services/keyword-filter-service.ts
+++ b/src/services/keyword-filter-service.ts
@@ -30,7 +30,12 @@ export class KeywordFilterService {
         return false;
       }
 
-      return !!(rule.applyToTitle || rule.applyToSummary || rule.applyToContent);
+      return !!(
+        rule.applyToTitle ||
+        rule.applyToSummary ||
+        rule.applyToContent ||
+        rule.applyToLink
+      );
     });
   }
 
@@ -122,6 +127,9 @@ export class KeywordFilterService {
     }
     if (rule.applyToContent) {
       sources.push(item.content || item.description || "");
+    }
+    if (rule.applyToLink) {
+      sources.push(item.link || "");
     }
 
     const keyword = rule.keyword.trim();

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -317,6 +317,7 @@ export interface KeywordFilterRule {
   applyToTitle: boolean;
   applyToSummary: boolean;
   applyToContent: boolean;
+  applyToLink?: boolean;
   enabled: boolean;
   createdAt: number;
 }

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -1321,6 +1321,9 @@ export class RssDashboardView extends ItemView {
     if (rule.applyToContent) {
       parts.push("content");
     }
+    if (rule.applyToLink) {
+      parts.push("link");
+    }
     return parts.join(", ");
   }
 

--- a/test_files/unit/components/keyword-filter-editor.test.ts
+++ b/test_files/unit/components/keyword-filter-editor.test.ts
@@ -73,6 +73,7 @@ describe("renderKeywordFilterEditor", () => {
       applyToTitle: true,
       applyToSummary: true,
       applyToContent: true,
+      applyToLink: false,
       enabled: true,
       createdAt: 123,
     });
@@ -151,6 +152,13 @@ describe("renderKeywordFilterEditor", () => {
     expect(summaryLabel).toBeTruthy();
     summaryLabel.click();
     expect(getState().rules[0].applyToSummary).toBe(true);
+
+    const linkLabel = Array.from(
+      document.body.querySelectorAll(".rss-keyword-filter-location-toggle label"),
+    ).find((el) => el.textContent === "Link") as HTMLLabelElement;
+    expect(linkLabel).toBeTruthy();
+    linkLabel.click();
+    expect(getState().rules[0].applyToLink).toBe(true);
   });
 
   it("disables rule controls when a rule is disabled and delete removes rule", () => {

--- a/test_files/unit/services/keyword-filter-service.test.ts
+++ b/test_files/unit/services/keyword-filter-service.test.ts
@@ -206,6 +206,30 @@ describe("KeywordFilterService.evaluateRules", () => {
     expect(KeywordFilterService.evaluateRules(item, [ruleContent], "AND")).toBe(true);
     expect(KeywordFilterService.evaluateRules(item, [ruleTitle], "AND")).toBe(false);
   });
+
+  it("can match against article links for URL-based feed filtering", () => {
+    const shortItem = createItem({
+      title: "Regular-looking title",
+      link: "https://www.youtube.com/shorts/6PkQMo39mbI",
+      description: "no marker here",
+    });
+    const watchItem = createItem({
+      title: "Regular-looking title",
+      link: "https://www.youtube.com/watch?v=rVepNd1TUew",
+      description: "no marker here",
+    });
+    const rule = createRule({
+      type: "exclude",
+      keyword: "/shorts/",
+      applyToTitle: false,
+      applyToSummary: false,
+      applyToContent: false,
+      applyToLink: true,
+    });
+
+    expect(KeywordFilterService.evaluateRules(shortItem, [rule], "AND")).toBe(false);
+    expect(KeywordFilterService.evaluateRules(watchItem, [rule], "AND")).toBe(true);
+  });
 });
 
 describe("KeywordFilterService.evaluateForArticle", () => {


### PR DESCRIPTION
## Summary
- Add Link as a keyword rule target alongside title, summary, and content.
- Allow URL-based excludes such as YouTube `/shorts/` links when feeds expose them.
- Show link-targeted rules in dashboard filter tooltips.

## Tests
- `npx vitest run --config vitest.config.mjs test_files/unit/services/keyword-filter-service.test.ts test_files/unit/components/keyword-filter-editor.test.ts`
- `npx tsc -noEmit -skipLibCheck`
- Full unit suite via pre-commit: 120 files, 1020 tests passed
- Full build gate via pre-push: `npm run build`