### PR TITLE
fix: schedule per-feed auto refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Fixed per-feed auto-refresh intervals so Use global, Off, and custom schedules control runtime refresh timing. Failed attempts now wait their configured interval without changing the last successful update time. [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166)
 - Fixed low-resolution fallback hero images being stretched across the Reader by preserving their intrinsic width, centering them, and only scaling them down when needed to fit the available space.
 - Fixed article saves failing on Windows when long titles produced filenames that exceeded safe path lengths by truncating generated filenames to 100 characters while preserving the full title in the note content. [GH Issue #157](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/157)
 - Fix: Math formulas from Math StackExchange feeds now render in Reader content and dashboard title cards through the Markdown renderer lifecycle path, with a small in-memory cache for reopen performance. Full implementation notes are archived in [math rendering investigation](docs/archive/investigations/2026/math-rendering.md). [GH Issue #162](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/162)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -10,6 +10,7 @@ records the complete 2026-08-16 documentation classification.
 | Plan                                                                                   | Completed  | Issue                                                                               | Implementation |
 | -------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------- | -------------- |
 | [Documentation archive cleanup](plans/unreleased/169-documentation-archive-cleanup.md) | 2026-08-16 | [GH Issue #169](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/169) | `314ae6f`      |
+| [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) |                |
 | [WordPress LaTeX image rendering](plans/unreleased/wordpress-latex-image-rendering.md) | 2026-08-08 | Unknown                                                                             | `9ce3582`      |
 
 ## Versioned plans

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -10,7 +10,7 @@ records the complete 2026-08-16 documentation classification.
 | Plan                                                                                   | Completed  | Issue                                                                               | Implementation |
 | -------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------- | -------------- |
 | [Documentation archive cleanup](plans/unreleased/169-documentation-archive-cleanup.md) | 2026-08-16 | [GH Issue #169](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/169) | `314ae6f`      |
-| [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) |                |
+| [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) | `5592c39`      |
 | [WordPress LaTeX image rendering](plans/unreleased/wordpress-latex-image-rendering.md) | 2026-08-08 | Unknown                                                                             | `9ce3582`      |
 
 ## Versioned plans

--- a/docs/archive/document-inventory.md
+++ b/docs/archive/document-inventory.md
@@ -22,7 +22,7 @@ This is the durable audit record for [GH Issue #169](https://github.com/amatya-a
 
 **Implementation plans — retain in `docs/plans/`:**
 
-- `docs/plans/166-per-feed-auto-refresh-scheduling.md` — accepted, blocked only by implementation work.
+- `docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md` — implemented, awaiting release.
 - `docs/plans/167-refresh-status-indicators.md` — blocked by issue #166.
 - `docs/plans/168-retry-failed-feeds.md` — blocked by issues #166 and #167.
 - `docs/plans/cover-image-fallback-og-fetch.md` — proposed future work.

--- a/docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md
+++ b/docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md
@@ -3,7 +3,7 @@ status: implemented
 completed: 2026-08-16
 released_in: unreleased
 issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166
-implementation: ""
+implementation: "5592c39"
 ---
 
 # Per-Feed Auto-Refresh Scheduling Fix

--- a/docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md
+++ b/docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md
@@ -1,13 +1,8 @@
 ---
-status: accepted
-owner: unassigned
-created: 2026-08-16
+status: implemented
+completed: 2026-08-16
+released_in: unreleased
 issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166
-milestone: vNext
-workstream: feed-refresh
-sequence: 1
-depends_on: []
-release_requirement: required
 implementation: ""
 ---
 
@@ -18,7 +13,7 @@ implementation: ""
 - **Classification:** Bug fix for an existing nonfunctional Add/Edit Feed setting.
 - **Risk:** High. Scheduling, refresh orchestration, persisted feed metadata,
   storage modes, settings lifecycle, and synchronization are affected.
-- **Required next stage:** [Refresh status and progress indicators](167-refresh-status-indicators.md).
+- **Required next stage:** [Refresh status and progress indicators](../../../plans/167-refresh-status-indicators.md).
 - **Gate:** Implement, validate, commit, and archive this plan before starting
   the indicator feature.
 
@@ -152,6 +147,34 @@ After every required check passes:
 3. Move it to `docs/archive/plans/unreleased/` and update all links and the archive catalog.
 4. Commit the complete scheduling fix as an independently reviewable change.
 5. Only then start the linked refresh-status indicator plan.
+
+## Delivered implementation
+
+- Added pure effective-interval, due-time, and due-feed helpers with Use global,
+  Off, custom, exclusion, boundary, and global-Off coverage.
+- Added a single-timeout `FeedRefreshScheduler` that starts after the configured
+  startup gate, snapshots due feeds, handles delayed wakeups, avoids active
+  multi-feed overlap, and re-arms after settings saves, reloads, refreshes, and
+  unload.
+- Added `lastRefreshAttemptCompletedAt` to feed metadata. Legacy records seed it
+  from a positive `lastUpdated`, and all storage modes preserve it through their
+  existing feed-config serialization paths.
+- Finalized every refresh attempt at success, parser-reported failure, thrown
+  error, or timeout without repurposing `lastUpdated`; URL changes reset the
+  completion and error identity.
+
+## Automated validation
+
+- Focused scheduling, migration, refresh-pipeline, modal, and lifecycle tests passed.
+- `npm run check:platform`, `npm exec -- tsc --noEmit --skipLibCheck`,
+  `npm run test:unit` (188 files, 1,645 tests), and `npm run build` passed.
+
+## Remaining manual checks
+
+- In Obsidian desktop and mobile, exercise inherited/custom/Off schedules,
+  global-Off custom scheduling, interval changes around a due boundary,
+  restart/wakeup, success/failure/timeout, manual refresh before due time,
+  add/edit/delete, URL change, bulk exclusion, and each storage mode.
 
 ## Non-goals
 

--- a/docs/development/data-flow.md
+++ b/docs/development/data-flow.md
@@ -94,7 +94,22 @@ Each refresh cycle:
 2. Parses the raw XML into structured `FeedItem` objects (title, guid, pubDate, content, media type, cover image, etc.).
 3. Passes the parsed items into the merge step.
 
-Feeds with `excludeFromRefresh: true` are skipped by bulk and auto-refresh. They can still be refreshed manually. Per-feed `scanInterval` overrides can also exclude a feed from a given bulk refresh cycle.
+Feeds with `excludeFromRefresh: true` are skipped by bulk and automatic refresh. They can still be refreshed directly from a feed view.
+
+### Automatic refresh scheduling
+
+Automatic refresh uses one rearmable timeout, not a global interval. For each
+non-excluded feed, `scanInterval: -1` turns scheduling off, a positive value
+uses that number of minutes, and `0` or an absent value inherits the global
+interval. This means a feed with a positive custom value can still refresh when
+the global interval is Off.
+
+`lastRefreshAttemptCompletedAt` is persisted per feed after every completed
+attempt, including parser-reported failure, thrown error, and timeout.
+`lastUpdated` remains the timestamp of the most recent successful parse. The
+next due time is derived in memory from the completion timestamp and effective
+interval; it is never persisted. A changed feed URL starts a new refresh
+identity and clears completion and error history.
 
 ---
 

--- a/docs/plans/167-refresh-status-indicators.md
+++ b/docs/plans/167-refresh-status-indicators.md
@@ -19,7 +19,7 @@ implementation: ""
 - **Classification:** User-visible feature.
 - **Risk:** High. Shared refresh state, persisted global metadata, scope
   aggregation, desktop/mobile/popout UI, and accessibility are affected.
-- **Prerequisite:** [Per-feed auto-refresh scheduling fix](166-per-feed-auto-refresh-scheduling.md)
+- **Prerequisite:** [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md)
   must be implemented, validated, committed, and archived first.
 - **Next stage:** [Retry failed feeds with Shift+click](168-retry-failed-feeds.md).
 

--- a/docs/plans/168-retry-failed-feeds.md
+++ b/docs/plans/168-retry-failed-feeds.md
@@ -20,7 +20,7 @@ implementation: ""
 - **Status:** Blocked; not implemented.
 - **Classification:** User-visible feature.
 - **Risk:** Medium. The change spans sidebar input and refresh orchestration, but it does not require a new setting, dependency, or persistence schema.
-- **Prerequisites:** [Per-feed auto-refresh scheduling fix](166-per-feed-auto-refresh-scheduling.md) and [Refresh status and progress indicators](167-refresh-status-indicators.md) must each be implemented, validated, committed, and archived first.
+- **Prerequisites:** [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md) and [Refresh status and progress indicators](167-refresh-status-indicators.md) must each be implemented, validated, committed, and archived first.
 - **Sequence:** This is stage 3. Do not implement it in the same change or commit as either prerequisite.
 
 ## Problem

--- a/docs/plans/release-vnext-roadmap.md
+++ b/docs/plans/release-vnext-roadmap.md
@@ -115,7 +115,7 @@ First complete the required
 [development branch realignment](draft-20260816-development-branch-realignment.md).
 Then implement the refresh work in three separately validated changes:
 
-1. [Per-feed auto-refresh scheduling fix](166-per-feed-auto-refresh-scheduling.md)
+1. [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md)
 2. [Refresh status and progress indicators](167-refresh-status-indicators.md)
 3. [Retry failed feeds with Shift+click](168-retry-failed-feeds.md)
 

--- a/main.ts
+++ b/main.ts
@@ -54,6 +54,7 @@ import {
 } from "./src/services/feed-storage-repository";
 import { ImportExportService } from "./src/services/import-export-service";
 import { BackgroundImportService } from "./src/services/background-import-service";
+import { FeedRefreshScheduler } from "./src/services/feed-refresh-scheduler";
 import {
   FEED_REQUEST_TIMEOUT_MS,
   FEED_SOFT_TIMEOUT_MS,
@@ -66,10 +67,7 @@ import { MediaService } from "./src/services/media-service";
 import { ImportOpmlModal } from "./src/modals/import-opml-modal";
 import { AddFeedModal } from "./src/modals/feed-manager/add-feed-modal";
 import { StorageMigrationModal } from "./src/modals/storage-migration-modal";
-import {
-  normalizeRefreshIntervalMinutes,
-  isValidUrl,
-} from "./src/utils/validation";
+import { isValidUrl } from "./src/utils/validation";
 import {
   dedupeAndNormalizeFeedItems,
   loadAndNormalizeSettings,
@@ -278,6 +276,7 @@ export default class RssDashboardPlugin extends Plugin {
   private vaultMetadataReloadTimer: number | null = null;
   private startupRefreshTimeoutId: number | null = null;
   private progressSaveDebounce: number | null = null;
+  private autoRefreshScheduler: FeedRefreshScheduler | null = null;
   private suppressWatcherUntil = 0;
   private static readonly FEED_REFRESH_RENDER_THROTTLE_MS = 250;
   private readonly feedStorageRepository: FeedStorageRepository;
@@ -402,16 +401,17 @@ export default class RssDashboardPlugin extends Plugin {
     }
   }
 
-  private getAutoRefreshIntervalMs(): number | null {
-    const normalizedMinutes = normalizeRefreshIntervalMinutes(
-      this.settings.refreshInterval,
-    );
-
-    if (normalizedMinutes <= 0) {
-      return null;
+  private ensureAutoRefreshScheduler(): FeedRefreshScheduler {
+    if (!this.autoRefreshScheduler) {
+      this.autoRefreshScheduler = new FeedRefreshScheduler({
+        getFeeds: () => this.settings.feeds,
+        getGlobalIntervalMinutes: () => this.settings.refreshInterval,
+        isBatchRunning: () => this.isMultiFeedRefreshRunning,
+        requestDueFeeds: async (feeds) => await this.refreshFeeds(feeds),
+      });
     }
 
-    return normalizedMinutes * 60 * 1000;
+    return this.autoRefreshScheduler;
   }
 
   private async reconcileSavedArticlesOnStartup(): Promise<void> {
@@ -609,14 +609,6 @@ export default class RssDashboardPlugin extends Plugin {
     await this.loadSettings();
     this.registerVaultMetadataChangeListeners();
 
-    const shouldRefreshOnOpen = (): boolean => {
-      const intervalMs = this.getAutoRefreshIntervalMs();
-      if (intervalMs === null) return false;
-      if (!this.settings.lastRefreshTimestamp) return true;
-      const elapsed = Date.now() - this.settings.lastRefreshTimestamp;
-      return elapsed >= intervalMs;
-    };
-
     const view = await this.getActiveDashboardView();
     if (view) {
       view.render();
@@ -625,6 +617,7 @@ export default class RssDashboardPlugin extends Plugin {
 
     try {
       this.initializeSettingsBackedServices();
+      const autoRefreshScheduler = this.ensureAutoRefreshScheduler();
 
       if (Platform.isMobile) {
         this.applyMobileOptimizations();
@@ -793,27 +786,16 @@ export default class RssDashboardPlugin extends Plugin {
         },
       });
 
-      const autoRefreshIntervalMs = this.getAutoRefreshIntervalMs();
-      if (autoRefreshIntervalMs !== null) {
-        this.registerInterval(
-          window.setInterval(() => {
-            void this.refreshFeeds();
-          }, autoRefreshIntervalMs),
-        );
-      }
-
-      if (shouldRefreshOnOpen()) {
-        const delay = Number.isFinite(this.settings.startupRefreshDelaySeconds)
-          ? this.settings.startupRefreshDelaySeconds
-          : DEFAULT_SETTINGS.startupRefreshDelaySeconds;
-        if (delay > 0) {
-          this.startupRefreshTimeoutId = window.setTimeout(() => {
-            this.startupRefreshTimeoutId = null;
-            void this.refreshFeeds();
-          }, delay * 1000);
-        } else {
-          void this.refreshFeeds();
-        }
+      const delay = Number.isFinite(this.settings.startupRefreshDelaySeconds)
+        ? this.settings.startupRefreshDelaySeconds
+        : DEFAULT_SETTINGS.startupRefreshDelaySeconds;
+      if (delay > 0) {
+        this.startupRefreshTimeoutId = window.setTimeout(() => {
+          this.startupRefreshTimeoutId = null;
+          autoRefreshScheduler.start();
+        }, delay * 1000);
+      } else {
+        autoRefreshScheduler.start();
       }
     } catch (err: unknown) {
       if (err instanceof Error) {
@@ -2093,9 +2075,15 @@ export default class RssDashboardPlugin extends Plugin {
     }
 
     const oldTitle = feed.title;
+    const oldUrl = feed.url;
     feed.title = newTitle;
     feed.url = newUrl;
     feed.folder = newFolder;
+
+    if (oldUrl !== newUrl) {
+      feed.lastRefreshAttemptCompletedAt = 0;
+      feed.lastFetchError = undefined;
+    }
 
     // Update feedTitle for all articles in this feed when the title changes
     if (oldTitle !== newTitle) {
@@ -2179,6 +2167,7 @@ export default class RssDashboardPlugin extends Plugin {
       if (shouldSave) {
         await this.saveSettings();
       }
+      this.autoRefreshScheduler?.reschedule();
     } catch (error) {
       storageError("Error loading plugin settings", error);
       new Notice(
@@ -2492,6 +2481,7 @@ export default class RssDashboardPlugin extends Plugin {
         this.getMetadataSaveCallback(),
       );
       storageLog("saveSettings completed", result);
+      this.autoRefreshScheduler?.reschedule();
     } catch (error) {
       storageError("saveSettings failed", error, {
         mode: this.settings.storageMode,
@@ -2627,16 +2617,53 @@ export default class RssDashboardPlugin extends Plugin {
     }
   }
 
+  private finalizeRefreshAttempt(
+    feed: Feed,
+    updatedFeed?: Feed,
+    error?: unknown,
+  ): void {
+    const completedAt = Date.now();
+    if (updatedFeed) {
+      this.mergeRefreshedFeed({
+        ...updatedFeed,
+        lastRefreshAttemptCompletedAt: completedAt,
+        lastFetchError: updatedFeed.lastFetchError,
+      });
+      return;
+    }
+
+    const index = this.settings.feeds.findIndex(
+      (storedFeed) => storedFeed === feed || storedFeed.url === feed.url,
+    );
+    if (index < 0) {
+      return;
+    }
+
+    this.settings.feeds[index] = {
+      ...this.settings.feeds[index],
+      lastRefreshAttemptCompletedAt: completedAt,
+      lastFetchError: error instanceof Error ? error.message : String(error),
+    };
+  }
+
   private async refreshSingleFeed(
     feed: Feed,
     feedNoticeText: string,
   ): Promise<void> {
-    const updatedFeed = await this.refreshFeedWithTimeout(feed);
-    this.mergeRefreshedFeed(updatedFeed);
+    try {
+      const updatedFeed = await this.refreshFeedWithTimeout(feed);
+      this.finalizeRefreshAttempt(feed, updatedFeed);
+    } catch (error) {
+      this.finalizeRefreshAttempt(feed, undefined, error);
+      await this.saveSettings();
+      this.autoRefreshScheduler?.reschedule();
+      throw error;
+    }
 
     await this.validateSavedArticles();
     this.settings.lastRefreshTimestamp = Date.now();
     await this.saveSettings();
+    this.autoRefreshScheduler?.reschedule();
     const view = await this.getActiveDashboardView();
     if (view) {
       view.refresh();
@@ -2736,6 +2763,7 @@ export default class RssDashboardPlugin extends Plugin {
       await this.validateSavedArticles();
       this.settings.lastRefreshTimestamp = Date.now();
       await this.saveSettings();
+      this.autoRefreshScheduler?.reschedule();
       this.activeRefreshState.clear();
       this.isMultiFeedRefreshRunning = false;
       const view = await this.getActiveDashboardView();
@@ -2782,8 +2810,9 @@ export default class RssDashboardPlugin extends Plugin {
 
     try {
       const updatedFeed = await this.refreshFeedWithTimeout(currentFeed);
-      this.mergeRefreshedFeed(updatedFeed);
+      this.finalizeRefreshAttempt(currentFeed, updatedFeed);
     } catch (error) {
+      this.finalizeRefreshAttempt(currentFeed, undefined, error);
       const isTimedOut =
         error instanceof Error && error.message === "Timed out";
       if (isTimedOut) {
@@ -2838,6 +2867,7 @@ export default class RssDashboardPlugin extends Plugin {
   }
 
   onunload() {
+    this.autoRefreshScheduler?.stop();
     if (this.progressSaveDebounce !== null) {
       window.clearTimeout(this.progressSaveDebounce);
       this.progressSaveDebounce = null;

--- a/src/modals/feed-manager/edit-feed-modal.ts
+++ b/src/modals/feed-manager/edit-feed-modal.ts
@@ -884,6 +884,7 @@ export class EditFeedModal extends Modal {
         }
 
         const oldTitle = this.feed.title;
+        const oldUrl = this.feed.url;
         const previousAutoDeleteDuration =
           typeof this.feed.autoDeleteDuration === "number"
             ? this.feed.autoDeleteDuration
@@ -891,6 +892,10 @@ export class EditFeedModal extends Modal {
         const previousFeedEncoding = this.feed.feedEncoding ?? "auto";
         this.feed.title = this.title;
         this.feed.url = this.url;
+        if (oldUrl !== this.url) {
+          this.feed.lastRefreshAttemptCompletedAt = 0;
+          this.feed.lastFetchError = undefined;
+        }
         const finalFolder = this.folderInput?.value || this.folder;
         this.feed.folder = finalFolder;
 

--- a/src/services/feed-refresh-scheduler.ts
+++ b/src/services/feed-refresh-scheduler.ts
@@ -1,0 +1,90 @@
+import type { Feed } from "../types/types";
+import { getDueFeeds, getNextRefreshDueAt } from "../utils/refresh-intervals";
+
+const MAX_TIMEOUT_MS = 2_147_483_647;
+const ACTIVE_BATCH_RECHECK_MS = 1_000;
+
+export interface FeedRefreshSchedulerOptions {
+  getFeeds: () => Feed[];
+  getGlobalIntervalMinutes: () => number;
+  isBatchRunning: () => boolean;
+  requestDueFeeds: (feeds: Feed[]) => Promise<void>;
+}
+
+/** Owns one rearmable timer for automatic, per-feed refresh scheduling. */
+export class FeedRefreshScheduler {
+  private timeoutId: number | null = null;
+  private started = false;
+
+  constructor(private readonly options: FeedRefreshSchedulerOptions) {}
+
+  public start(): void {
+    this.started = true;
+    this.reschedule();
+  }
+
+  public stop(): void {
+    this.started = false;
+    this.clearTimer();
+  }
+
+  public reschedule(): void {
+    this.clearTimer();
+    if (!this.started) {
+      return;
+    }
+
+    const now = Date.now();
+    const dueTimes = this.options
+      .getFeeds()
+      .map((feed) =>
+        getNextRefreshDueAt(feed, this.options.getGlobalIntervalMinutes()),
+      )
+      .filter((dueAt): dueAt is number => dueAt !== null);
+
+    if (dueTimes.length === 0) {
+      return;
+    }
+
+    const earliestDueAt = Math.min(...dueTimes);
+    const delay = Math.min(Math.max(0, earliestDueAt - now), MAX_TIMEOUT_MS);
+    this.timeoutId = window.setTimeout(() => {
+      this.timeoutId = null;
+      void this.handleWakeup();
+    }, delay);
+  }
+
+  private async handleWakeup(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+
+    if (this.options.isBatchRunning()) {
+      this.timeoutId = window.setTimeout(() => {
+        this.timeoutId = null;
+        void this.handleWakeup();
+      }, ACTIVE_BATCH_RECHECK_MS);
+      return;
+    }
+
+    const dueFeeds = getDueFeeds(
+      this.options.getFeeds(),
+      this.options.getGlobalIntervalMinutes(),
+      Date.now(),
+    );
+    try {
+      if (dueFeeds.length > 0) {
+        await this.options.requestDueFeeds(dueFeeds);
+      }
+    } finally {
+      this.reschedule();
+    }
+  }
+
+  private clearTimer(): void {
+    if (this.timeoutId !== null) {
+      window.clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+  }
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -95,6 +95,11 @@ export interface Feed {
   maxItemsLimit?: number;
   scanInterval?: number;
   excludeFromRefresh?: boolean;
+  /**
+   * Completion time of the most recent refresh attempt, successful or not.
+   * This is intentionally distinct from lastUpdated, which tracks successful parsing.
+   */
+  lastRefreshAttemptCompletedAt?: number;
   iconUrl?: string;
   keywordRules?: FeedKeywordRulesSettings;
   lastRefreshDiagnostics?: FeedRefreshDiagnostics;
@@ -141,6 +146,7 @@ export interface FeedMetadata {
   maxItemsLimit?: number;
   scanInterval?: number;
   excludeFromRefresh?: boolean;
+  lastRefreshAttemptCompletedAt?: number;
   importStatus?:
     | "pending"
     | "processing"

--- a/src/utils/refresh-intervals.ts
+++ b/src/utils/refresh-intervals.ts
@@ -1,4 +1,7 @@
+import type { Feed } from "../types/types";
+
 export const FEED_REFRESH_DISABLED_INTERVAL = -1;
+const MINUTE_MS = 60 * 1000;
 
 export const REFRESH_INTERVAL_PRESETS = [
   0, 5, 10, 15, 30, 60, 120, 240, 480, 720, 1440,
@@ -18,4 +21,66 @@ export function getPerFeedRefreshIntervalDropdownValue(value: number): string {
   }
 
   return "custom";
+}
+
+/** Returns the automatic refresh interval for one feed, or null when it is off. */
+export function getEffectiveRefreshIntervalMinutes(
+  feed: Pick<Feed, "scanInterval" | "excludeFromRefresh">,
+  globalIntervalMinutes: number,
+): number | null {
+  if (feed.excludeFromRefresh === true || feed.scanInterval === -1) {
+    return null;
+  }
+
+  if (
+    feed.scanInterval !== undefined &&
+    (!Number.isFinite(feed.scanInterval) || feed.scanInterval < 0)
+  ) {
+    return null;
+  }
+
+  const requestedInterval =
+    typeof feed.scanInterval === "number" && feed.scanInterval > 0
+      ? feed.scanInterval
+      : globalIntervalMinutes;
+
+  return Number.isFinite(requestedInterval) && requestedInterval > 0
+    ? requestedInterval
+    : null;
+}
+
+/** Derives a feed's next automatic refresh time without persisting it. */
+export function getNextRefreshDueAt(
+  feed: Pick<
+    Feed,
+    "scanInterval" | "excludeFromRefresh" | "lastRefreshAttemptCompletedAt"
+  >,
+  globalIntervalMinutes: number,
+): number | null {
+  const intervalMinutes = getEffectiveRefreshIntervalMinutes(
+    feed,
+    globalIntervalMinutes,
+  );
+  if (intervalMinutes === null) {
+    return null;
+  }
+
+  const completedAt = feed.lastRefreshAttemptCompletedAt;
+  if (!Number.isFinite(completedAt) || !completedAt || completedAt < 0) {
+    return 0;
+  }
+
+  return completedAt + intervalMinutes * MINUTE_MS;
+}
+
+/** Returns eligible feeds that are due at the supplied timestamp. */
+export function getDueFeeds(
+  feeds: Feed[],
+  globalIntervalMinutes: number,
+  now: number,
+): Feed[] {
+  return feeds.filter((feed) => {
+    const dueAt = getNextRefreshDueAt(feed, globalIntervalMinutes);
+    return dueAt !== null && dueAt <= now;
+  });
 }

--- a/src/utils/settings-loader.ts
+++ b/src/utils/settings-loader.ts
@@ -181,6 +181,13 @@ export function loadAndNormalizeSettings(
     if (typeof feed.maxItemsLimit !== "number") {
       feed.maxItemsLimit = settings.maxItems;
     }
+
+    if (!Number.isFinite(feed.lastRefreshAttemptCompletedAt)) {
+      feed.lastRefreshAttemptCompletedAt =
+        Number.isFinite(feed.lastUpdated) && feed.lastUpdated > 0
+          ? feed.lastUpdated
+          : 0;
+    }
   }
 
   const canonicalPageSizeRaw = settings.allArticlesPageSize;

--- a/test_files/unit/main/feed-refresh-pipeline.test.ts
+++ b/test_files/unit/main/feed-refresh-pipeline.test.ts
@@ -345,13 +345,17 @@ describe("refreshFeeds() pipeline behavior", () => {
 
   it("swallows direct refresh errors and shows an error Notice", async () => {
     const plugin = createPluginWithSettings([createFeed()]);
+    vi.spyOn(Date, "now").mockReturnValue(9_876);
 
     (plugin.feedParser.refreshFeed as unknown as { mockRejectedValue: (error: Error) => void }).mockRejectedValue(
       new Error("network down"),
     );
 
     await expect(plugin.refreshFeeds([plugin.settings.feeds[0]])).resolves.toBeUndefined();
-    expect(plugin.saveData).not.toHaveBeenCalled();
+    expect(plugin.settings.feeds[0].lastUpdated).toBe(1);
+    expect(plugin.settings.feeds[0].lastRefreshAttemptCompletedAt).toBe(9_876);
+    expect(plugin.settings.feeds[0].lastFetchError).toBe("network down");
+    expect(plugin.saveData).toHaveBeenCalledTimes(1);
 
     const notices = getNoticeMessages(consoleLogSpy);
     expect(notices[0]).toBe("Refreshing Feed A...");

--- a/test_files/unit/main/plugin-lifecycle.test.ts
+++ b/test_files/unit/main/plugin-lifecycle.test.ts
@@ -417,14 +417,14 @@ describe("onload() initialization", () => {
     ).toBeGreaterThanOrEqual(7);
   });
 
-  it("sets up refresh interval", async () => {
+  it("uses the due-aware scheduler instead of registering a global refresh interval", async () => {
     plugin.loadData = vi.fn().mockResolvedValue({ refreshInterval: 60 });
 
     // When: onload is called
     await plugin.onload();
 
-    // Then: registerInterval should be called with a setInterval result
-    expect(plugin.registerInterval).toHaveBeenCalled();
+    // Then: automatic refresh is owned by the per-feed scheduler, not Plugin.registerInterval.
+    expect(plugin.registerInterval).not.toHaveBeenCalled();
   });
 
   it("does not register auto refresh when refreshInterval is disabled", async () => {
@@ -750,7 +750,7 @@ describe("onload() initialization", () => {
     expect(plugin.settings.viewStyle).toBe("list");
   });
 
-  it("does not attempt a startup refresh before FeedParser initialization", async () => {
+  it("does not request an automatic refresh when startup finds no eligible feeds", async () => {
     plugin.loadData = vi.fn().mockResolvedValue({
       refreshInterval: 60,
       lastRefreshTimestamp: 0,
@@ -763,7 +763,7 @@ describe("onload() initialization", () => {
 
     await plugin.onload();
 
-    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).not.toHaveBeenCalled();
     expect(mockRefreshAllFeeds).not.toHaveBeenCalled();
     expect(plugin.feedParser).toBeDefined();
   });

--- a/test_files/unit/services/feed-refresh-scheduler.test.ts
+++ b/test_files/unit/services/feed-refresh-scheduler.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Feed } from "../../../src/types/types";
+import { FeedRefreshScheduler } from "../../../src/services/feed-refresh-scheduler";
+
+function createFeed(overrides: Partial<Feed> = {}): Feed {
+  return {
+    title: "Example feed",
+    url: "https://example.com/feed.xml",
+    folder: "RSS",
+    items: [],
+    lastUpdated: 0,
+    ...overrides,
+  };
+}
+
+describe("FeedRefreshScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+  });
+
+  it("arms one timer for the nearest due feed and requests a due snapshot", async () => {
+    const near = createFeed({ scanInterval: 1, lastRefreshAttemptCompletedAt: 1_000 });
+    const later = createFeed({ url: "https://example.com/later.xml", scanInterval: 5, lastRefreshAttemptCompletedAt: 1_000 });
+    const requestDueFeeds = vi.fn().mockImplementation(async () => {
+      near.lastRefreshAttemptCompletedAt = Date.now();
+    });
+    const scheduler = new FeedRefreshScheduler({
+      getFeeds: () => [near, later],
+      getGlobalIntervalMinutes: () => 30,
+      isBatchRunning: () => false,
+      requestDueFeeds,
+    });
+
+    scheduler.start();
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(requestDueFeeds).toHaveBeenCalledWith([near]);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it("schedules a custom feed when the global interval is off", async () => {
+    const custom = createFeed({ scanInterval: 2, lastRefreshAttemptCompletedAt: 0 });
+    const requestDueFeeds = vi.fn().mockImplementation(async () => {
+      custom.lastRefreshAttemptCompletedAt = Date.now();
+    });
+    const scheduler = new FeedRefreshScheduler({
+      getFeeds: () => [custom],
+      getGlobalIntervalMinutes: () => 0,
+      isBatchRunning: () => false,
+      requestDueFeeds,
+    });
+
+    scheduler.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(requestDueFeeds).toHaveBeenCalledWith([custom]);
+  });
+
+  it("does not overlap an active batch and stops cleanly", async () => {
+    const feed = createFeed({ scanInterval: 1, lastRefreshAttemptCompletedAt: 0 });
+    const requestDueFeeds = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new FeedRefreshScheduler({
+      getFeeds: () => [feed],
+      getGlobalIntervalMinutes: () => 30,
+      isBatchRunning: () => true,
+      requestDueFeeds,
+    });
+
+    scheduler.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(requestDueFeeds).not.toHaveBeenCalled();
+
+    scheduler.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/test_files/unit/utils/refresh-intervals.test.ts
+++ b/test_files/unit/utils/refresh-intervals.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { Feed } from "../../../src/types/types";
+import {
+  getDueFeeds,
+  getEffectiveRefreshIntervalMinutes,
+  getNextRefreshDueAt,
+} from "../../../src/utils/refresh-intervals";
+
+function createFeed(overrides: Partial<Feed> = {}): Feed {
+  return {
+    title: "Example feed",
+    url: "https://example.com/feed.xml",
+    folder: "RSS",
+    items: [],
+    lastUpdated: 0,
+    ...overrides,
+  };
+}
+
+describe("per-feed refresh intervals", () => {
+  it("uses a positive custom interval even when the global interval is off", () => {
+    expect(getEffectiveRefreshIntervalMinutes(createFeed({ scanInterval: 15 }), 0)).toBe(15);
+  });
+
+  it("inherits the global interval when the feed uses the global setting", () => {
+    expect(getEffectiveRefreshIntervalMinutes(createFeed({ scanInterval: 0 }), 30)).toBe(30);
+    expect(getEffectiveRefreshIntervalMinutes(createFeed(), 30)).toBe(30);
+  });
+
+  it("disables automatic refresh for an off feed, excluded feed, or invalid interval", () => {
+    expect(getEffectiveRefreshIntervalMinutes(createFeed({ scanInterval: -1 }), 30)).toBeNull();
+    expect(getEffectiveRefreshIntervalMinutes(createFeed({ excludeFromRefresh: true }), 30)).toBeNull();
+    expect(getEffectiveRefreshIntervalMinutes(createFeed({ scanInterval: Number.NaN }), 30)).toBeNull();
+  });
+
+  it("derives due time from completion without persisting it", () => {
+    const feed = createFeed({ lastRefreshAttemptCompletedAt: 1_000, scanInterval: 5 });
+    expect(getNextRefreshDueAt(feed, 30)).toBe(301_000);
+  });
+
+  it("makes a never-checked eligible feed due promptly", () => {
+    const feed = createFeed({ scanInterval: 5, lastRefreshAttemptCompletedAt: 0 });
+    expect(getNextRefreshDueAt(feed, 30)).toBe(0);
+    expect(getDueFeeds([feed], 30, 1)).toEqual([feed]);
+  });
+
+  it("recalculates the same completion anchor when an interval changes", () => {
+    const feed = createFeed({ lastRefreshAttemptCompletedAt: 1_000, scanInterval: 5 });
+    expect(getNextRefreshDueAt(feed, 30)).toBe(301_000);
+    feed.scanInterval = 10;
+    expect(getNextRefreshDueAt(feed, 30)).toBe(601_000);
+  });
+
+  it("selects only feeds due at the boundary", () => {
+    const due = createFeed({ url: "https://example.com/due.xml", lastRefreshAttemptCompletedAt: 1_000, scanInterval: 1 });
+    const later = createFeed({ url: "https://example.com/later.xml", lastRefreshAttemptCompletedAt: 1_001, scanInterval: 1 });
+    expect(getDueFeeds([due, later], 30, 61_000)).toEqual([due]);
+  });
+});

--- a/test_files/unit/utils/settings-loader.test.ts
+++ b/test_files/unit/utils/settings-loader.test.ts
@@ -124,6 +124,32 @@ describe("settings-loader", () => {
       expect(result.feeds[0].maxItemsLimit).toBe(75);
     });
 
+    it("seeds a missing refresh-attempt completion timestamp from a successful parse", async () => {
+      const { loadAndNormalizeSettings } =
+        await import("../../../src/utils/settings-loader");
+
+      const result = loadAndNormalizeSettings({
+        feeds: [createFeed({ lastUpdated: 123_456 })],
+      });
+
+      expect(result.feeds[0].lastRefreshAttemptCompletedAt).toBe(123_456);
+    });
+
+    it("keeps a valid persisted refresh-attempt completion timestamp and seeds zero otherwise", async () => {
+      const { loadAndNormalizeSettings } =
+        await import("../../../src/utils/settings-loader");
+
+      const result = loadAndNormalizeSettings({
+        feeds: [
+          createFeed({ lastUpdated: 10, lastRefreshAttemptCompletedAt: 99 }),
+          createFeed({ url: "https://example.com/new.xml", lastUpdated: 0 }),
+          createFeed({ url: "https://example.com/invalid.xml", lastRefreshAttemptCompletedAt: Number.NaN }),
+        ],
+      });
+
+      expect(result.feeds.map((feed) => feed.lastRefreshAttemptCompletedAt)).toEqual([99, 0, 0]);
+    });
+
     it("normalizes all five page-size fields to allArticlesPageSize", async () => {
       const { loadAndNormalizeSettings } =
         await import("../../../src/utils/settings-loader");


### PR DESCRIPTION
  ## Summary

  - Make Add/Edit Feed auto-refresh intervals control runtime scheduling.
  - Add a due-aware per-feed scheduler and persisted refresh-attempt completion time.
  - Preserve successful parse timestamps across failed and timed-out attempts.
  - Archive the validated implementation plan.

  ## Validation

  - `npm run test:unit`
  - `npm run check:platform`
  - `npm exec -- tsc --noEmit --skipLibCheck`
  - `npm run build`

  ## Manual follow-up

  - Verify inherited/custom/Off schedules, global-Off custom feeds, wakeup/restart,
    timeout/failure behavior, URL edits, exclusion, and each storage mode in Obsidian.

  Closes #166