### PR TITLE
feat: add refresh status indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixes
 
-- Fixed duplicate native tooltips and delayed ghost popups for sidebar refresh details. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
+- Fixed refresh-detail tooltip and ghost-popup regressions, and prevented global-refresh vault saves from reloading empty article shards. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
 - Fixed per-feed auto-refresh intervals so Use global, Off, and custom schedules control runtime refresh timing. Failed attempts now wait their configured interval without changing the last successful update time. [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166)
 - Fixed low-resolution fallback hero images being stretched across the Reader by preserving their intrinsic width, centering them, and only scaling them down when needed to fit the available space.
 - Fixed article saves failing on Windows when long titles produced filenames that exceeded safe path lengths by truncating generated filenames to 100 characters while preserving the full title in the note content. [GH Issue #157](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/157)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 
+- Fixed duplicate native tooltips when opening All feeds refresh details. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
 - Fixed per-feed auto-refresh intervals so Use global, Off, and custom schedules control runtime refresh timing. Failed attempts now wait their configured interval without changing the last successful update time. [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166)
 - Fixed low-resolution fallback hero images being stretched across the Reader by preserving their intrinsic width, centering them, and only scaling them down when needed to fit the available space.
 - Fixed article saves failing on Windows when long titles produced filenames that exceeded safe path lengths by truncating generated filenames to 100 characters while preserving the full title in the note content. [GH Issue #157](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/157)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixes
 
-- Fixed duplicate native tooltips when opening All feeds refresh details. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
+- Fixed duplicate native tooltips and delayed ghost popups for sidebar refresh details. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
 - Fixed per-feed auto-refresh intervals so Use global, Off, and custom schedules control runtime refresh timing. Failed attempts now wait their configured interval without changing the last successful update time. [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166)
 - Fixed low-resolution fallback hero images being stretched across the Reader by preserving their intrinsic width, centering them, and only scaling them down when needed to fit the available space.
 - Fixed article saves failing on Windows when long titles produced filenames that exceeded safe path lengths by truncating generated filenames to 100 characters while preserving the full title in the note content. [GH Issue #157](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/157)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Added static refresh-status timestamps and accessible refresh details for all feeds, folders, and feeds. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
 - New installations now default global feed auto-refresh to Off.
 - Added automatic and per-feed Windows-1251 decoding for RSS/Atom feeds, including preview and refresh support. New dropdown available in the add/edit feed window > Feed options > Feed Encoding [GH Issue #155](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/155)
 - Added a saved-template selector when saving articles to a custom folder, including immediate selection of newly created templates and viewable templates via Article Savings tab. [GH Issue #158](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/158)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -11,7 +11,7 @@ records the complete 2026-08-16 documentation classification.
 | -------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------- | -------------- |
 | [Documentation archive cleanup](plans/unreleased/169-documentation-archive-cleanup.md) | 2026-08-16 | [GH Issue #169](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/169) | `314ae6f`      |
 | [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) | `5592c39`      |
-| [Refresh status and progress indicators](plans/unreleased/167-refresh-status-indicators.md) | 2026-08-16 | [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167) |                |
+| [Refresh status and progress indicators](plans/unreleased/167-refresh-status-indicators.md) | 2026-08-16 | [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167) | `6f767c7`      |
 | [WordPress LaTeX image rendering](plans/unreleased/wordpress-latex-image-rendering.md) | 2026-08-08 | Unknown                                                                             | `9ce3582`      |
 
 ## Versioned plans

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -11,6 +11,7 @@ records the complete 2026-08-16 documentation classification.
 | -------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------- | -------------- |
 | [Documentation archive cleanup](plans/unreleased/169-documentation-archive-cleanup.md) | 2026-08-16 | [GH Issue #169](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/169) | `314ae6f`      |
 | [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) | `5592c39`      |
+| [Refresh status and progress indicators](plans/unreleased/167-refresh-status-indicators.md) | 2026-08-16 | [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167) |                |
 | [WordPress LaTeX image rendering](plans/unreleased/wordpress-latex-image-rendering.md) | 2026-08-08 | Unknown                                                                             | `9ce3582`      |
 
 ## Versioned plans

--- a/docs/archive/document-inventory.md
+++ b/docs/archive/document-inventory.md
@@ -23,7 +23,7 @@ This is the durable audit record for [GH Issue #169](https://github.com/amatya-a
 **Implementation plans — retain in `docs/plans/`:**
 
 - `docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md` — implemented, awaiting release.
-- `docs/plans/167-refresh-status-indicators.md` — blocked by issue #166.
+- `docs/archive/plans/unreleased/167-refresh-status-indicators.md` — implemented, awaiting release.
 - `docs/plans/168-retry-failed-feeds.md` — blocked by issues #166 and #167.
 - `docs/plans/cover-image-fallback-og-fetch.md` — proposed future work.
 - `docs/plans/deprecate-feed-manager-modal.md` — proposed 3.0 work.

--- a/docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md
+++ b/docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md
@@ -13,7 +13,7 @@ implementation: "5592c39"
 - **Classification:** Bug fix for an existing nonfunctional Add/Edit Feed setting.
 - **Risk:** High. Scheduling, refresh orchestration, persisted feed metadata,
   storage modes, settings lifecycle, and synchronization are affected.
-- **Required next stage:** [Refresh status and progress indicators](../../../plans/167-refresh-status-indicators.md).
+- **Required next stage:** [Refresh status and progress indicators](167-refresh-status-indicators.md).
 - **Gate:** Implement, validate, commit, and archive this plan before starting
   the indicator feature.
 

--- a/docs/archive/plans/unreleased/167-refresh-status-indicators.md
+++ b/docs/archive/plans/unreleased/167-refresh-status-indicators.md
@@ -1,14 +1,8 @@
 ---
-status: blocked
-owner: unassigned
-created: 2026-08-16
+status: implemented
+completed: 2026-08-16
+released_in: unreleased
 issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167
-milestone: vNext
-workstream: feed-refresh
-sequence: 2
-depends_on:
-  - https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166
-release_requirement: required
 implementation: ""
 ---
 
@@ -19,9 +13,9 @@ implementation: ""
 - **Classification:** User-visible feature.
 - **Risk:** High. Shared refresh state, persisted global metadata, scope
   aggregation, desktop/mobile/popout UI, and accessibility are affected.
-- **Prerequisite:** [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md)
+- **Prerequisite:** [Per-feed auto-refresh scheduling fix](166-per-feed-auto-refresh-scheduling.md)
   must be implemented, validated, committed, and archived first.
-- **Next stage:** [Retry failed feeds with Shift+click](168-retry-failed-feeds.md).
+- **Next stage:** [Retry failed feeds with Shift+click](../../../plans/168-retry-failed-feeds.md).
 
 Do not implement this plan against the current global-only scheduler. Begin only
 after the prerequisite's per-feed completion field and orchestration contract
@@ -182,6 +176,35 @@ After every required check passes:
 3. Move it to `docs/archive/plans/unreleased/` and update all links and the catalog.
 4. Commit the complete indicator feature independently.
 5. Only then begin the linked failed-feed retry plan.
+
+## Delivered implementation
+
+- Added persisted `lastGlobalRefreshCompletedAt`, isolated from the readable
+  legacy timestamp, and update it only after explicit all-eligible-feed refresh
+  operations settle, including individual attempt failures.
+- Added pure refresh-status aggregation and locale-aware static formatting for
+  all-feed, feed, folder, and multi-selection scopes. Article filters retain
+  their underlying refresh scope, and excluded feeds are reported separately.
+- Added dashboard status-bar completion/activity/failure text that updates
+  independently of the article list while refresh work is active.
+- Added reusable sidebar refresh details with hover/focus delay, Escape and
+  rerender cleanup, screen-reader descriptions, context-menu access, and
+  owning-document popup placement for popouts.
+- Kept retry-failed gestures and relative-time polling out of this stage.
+
+## Automated validation
+
+- Focused refresh-status, persistence, refresh-pipeline, lifecycle, sidebar,
+  and dashboard tests passed.
+- `npm run check:platform`, `npm run check:css-scope`,
+  `npm run check:important`, targeted ESLint, type-checking, the full unit suite
+  (190 files, 1,648 tests), and `npm run build` passed.
+
+## Remaining manual checks
+
+- In live Obsidian, verify desktop/mobile/popout detail placement, keyboard and
+  touch context-menu access, light/dark themes, narrow layouts, long errors,
+  and persisted completion after reload and synchronization.
 
 ## Non-goals
 

--- a/docs/archive/plans/unreleased/167-refresh-status-indicators.md
+++ b/docs/archive/plans/unreleased/167-refresh-status-indicators.md
@@ -198,7 +198,7 @@ After every required check passes:
   and dashboard tests passed.
 - `npm run check:platform`, `npm run check:css-scope`,
   `npm run check:important`, targeted ESLint, type-checking, the full unit suite
-  (190 files, 1,648 tests), and `npm run build` passed.
+  (190 files, 1,649 tests), and `npm run build` passed.
 
 ## Remaining manual checks
 

--- a/docs/archive/plans/unreleased/167-refresh-status-indicators.md
+++ b/docs/archive/plans/unreleased/167-refresh-status-indicators.md
@@ -198,7 +198,7 @@ After every required check passes:
   and dashboard tests passed.
 - `npm run check:platform`, `npm run check:css-scope`,
   `npm run check:important`, targeted ESLint, type-checking, the full unit suite
-  (190 files, 1,649 tests), and `npm run build` passed.
+  (190 files, 1,652 tests), and `npm run build` passed.
 
 ## Remaining manual checks
 

--- a/docs/archive/plans/unreleased/167-refresh-status-indicators.md
+++ b/docs/archive/plans/unreleased/167-refresh-status-indicators.md
@@ -190,6 +190,8 @@ After every required check passes:
 - Added reusable sidebar refresh details with hover/focus delay, Escape and
   rerender cleanup, screen-reader descriptions, context-menu access, and
   owning-document popup placement for popouts.
+- Suppressed plugin-originated vault metadata writes from the external-change
+  watcher so final refresh persistence cannot reload stale or empty shard state.
 - Kept retry-failed gestures and relative-time polling out of this stage.
 
 ## Automated validation
@@ -198,7 +200,7 @@ After every required check passes:
   and dashboard tests passed.
 - `npm run check:platform`, `npm run check:css-scope`,
   `npm run check:important`, targeted ESLint, type-checking, the full unit suite
-  (190 files, 1,652 tests), and `npm run build` passed.
+  (190 files, 1,653 tests), and `npm run build` passed.
 
 ## Remaining manual checks
 

--- a/docs/archive/plans/unreleased/167-refresh-status-indicators.md
+++ b/docs/archive/plans/unreleased/167-refresh-status-indicators.md
@@ -3,7 +3,7 @@ status: implemented
 completed: 2026-08-16
 released_in: unreleased
 issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167
-implementation: ""
+implementation: "6f767c7"
 ---
 
 # Refresh Status and Progress Indicators

--- a/docs/development/data-flow.md
+++ b/docs/development/data-flow.md
@@ -111,6 +111,15 @@ next due time is derived in memory from the completion timestamp and effective
 interval; it is never persisted. A changed feed URL starts a new refresh
 identity and clears completion and error history.
 
+### Global refresh completion
+
+`lastGlobalRefreshCompletedAt` is a separate persisted settings value. It
+advances only after an explicit refresh of the complete eligible feed set has
+settled, including batches with individual failures. It does not advance for
+single-feed, folder, selection, due-subset, failed-only, empty, or
+excluded-only refreshes. The legacy `lastRefreshTimestamp` remains readable for
+older data but is not used or updated by refresh behavior or status UI.
+
 ---
 
 ## 4. Merge and Carry-Forward

--- a/docs/plans/168-retry-failed-feeds.md
+++ b/docs/plans/168-retry-failed-feeds.md
@@ -20,7 +20,7 @@ implementation: ""
 - **Status:** Blocked; not implemented.
 - **Classification:** User-visible feature.
 - **Risk:** Medium. The change spans sidebar input and refresh orchestration, but it does not require a new setting, dependency, or persistence schema.
-- **Prerequisites:** [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md) and [Refresh status and progress indicators](167-refresh-status-indicators.md) must each be implemented, validated, committed, and archived first.
+- **Prerequisites:** [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md) and [Refresh status and progress indicators](../archive/plans/unreleased/167-refresh-status-indicators.md) must each be implemented, validated, committed, and archived first.
 - **Sequence:** This is stage 3. Do not implement it in the same change or commit as either prerequisite.
 
 ## Problem

--- a/docs/plans/release-vnext-roadmap.md
+++ b/docs/plans/release-vnext-roadmap.md
@@ -116,7 +116,7 @@ First complete the required
 Then implement the refresh work in three separately validated changes:
 
 1. [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md)
-2. [Refresh status and progress indicators](167-refresh-status-indicators.md)
+2. [Refresh status and progress indicators](../archive/plans/unreleased/167-refresh-status-indicators.md)
 3. [Retry failed feeds with Shift+click](168-retry-failed-feeds.md)
 
 Each stage must be implemented, validated, committed, and have its plan moved

--- a/main.ts
+++ b/main.ts
@@ -2469,7 +2469,10 @@ export default class RssDashboardPlugin extends Plugin {
           await ensureMetadataFolderExists(this.app, this.settings);
           const dataFilePath = `${metadataPath}/data.json`;
           const jsonContent = JSON.stringify(settingsData, null, 2);
-          await this.app.vault.adapter.write(dataFilePath, jsonContent);
+          await this.writeWithWatcherSuppressed(
+            async () =>
+              await this.app.vault.adapter.write(dataFilePath, jsonContent),
+          );
           storageLog("Metadata saved to vault location", {
             path: dataFilePath,
           });

--- a/main.ts
+++ b/main.ts
@@ -407,7 +407,7 @@ export default class RssDashboardPlugin extends Plugin {
         getFeeds: () => this.settings.feeds,
         getGlobalIntervalMinutes: () => this.settings.refreshInterval,
         isBatchRunning: () => this.isMultiFeedRefreshRunning,
-        requestDueFeeds: async (feeds) => await this.refreshFeeds(feeds),
+        requestDueFeeds: async (feeds) => await this.refreshFeeds(feeds, "due"),
       });
     }
 
@@ -467,6 +467,21 @@ export default class RssDashboardPlugin extends Plugin {
       const view = leaf.view;
       if (view instanceof RssDashboardView) {
         view.refresh();
+      }
+    }
+  }
+
+  /** Updates only refresh affordances so active work never resets article scroll. */
+  private async notifyRefreshStatusChanged(): Promise<void> {
+    const leaves = this.app.workspace.getLeavesOfType(RSS_DASHBOARD_VIEW_TYPE);
+    for (const leaf of leaves) {
+      if (requireApiVersion("1.7.2")) {
+        await leaf.loadIfDeferred();
+      }
+      const view = leaf.view;
+      if (view instanceof RssDashboardView) {
+        view.refreshSidebarOnly();
+        view.refreshFilterStatusBarOnly();
       }
     }
   }
@@ -1172,7 +1187,10 @@ export default class RssDashboardPlugin extends Plugin {
     }
   }
 
-  async refreshFeeds(selectedFeeds?: Feed[]) {
+  async refreshFeeds(
+    selectedFeeds?: Feed[],
+    intent: "global" | "targeted" | "due" = selectedFeeds ? "targeted" : "global",
+  ) {
     try {
       const candidateFeeds = selectedFeeds || this.settings.feeds;
       if (candidateFeeds.length === 0) {
@@ -1205,11 +1223,19 @@ export default class RssDashboardPlugin extends Plugin {
 
       new Notice(`Refreshing ${feedNoticeText}...`);
       if (feedsToRefresh.length === 1) {
-        await this.refreshSingleFeed(feedsToRefresh[0], feedNoticeText);
+        await this.refreshSingleFeed(
+          feedsToRefresh[0],
+          feedNoticeText,
+          intent === "global",
+        );
         return;
       }
 
-      await this.refreshFeedBatch(feedsToRefresh, feedNoticeText);
+      await this.refreshFeedBatch(
+        feedsToRefresh,
+        feedNoticeText,
+        intent === "global",
+      );
     } catch (error) {
       console.error(`[RSS dashboard] Error refreshing feeds:`, error);
       new Notice(
@@ -1264,7 +1290,7 @@ export default class RssDashboardPlugin extends Plugin {
       }
 
       new Notice(`Refreshing ${feed.title}...`);
-      await this.refreshSingleFeed(feed, feed.title);
+      await this.refreshSingleFeed(feed, feed.title, false);
     } catch (error) {
       console.error(`[RSS dashboard] Error refreshing feeds:`, error);
       new Notice(
@@ -2649,19 +2675,33 @@ export default class RssDashboardPlugin extends Plugin {
   private async refreshSingleFeed(
     feed: Feed,
     feedNoticeText: string,
+    isExplicitGlobalRefresh: boolean,
   ): Promise<void> {
+    this.activeRefreshState.set(feed.url, {
+      status: "processing",
+      startedAt: Date.now(),
+    });
+    await this.notifyRefreshStatusChanged();
     try {
       const updatedFeed = await this.refreshFeedWithTimeout(feed);
       this.finalizeRefreshAttempt(feed, updatedFeed);
     } catch (error) {
       this.finalizeRefreshAttempt(feed, undefined, error);
+      if (isExplicitGlobalRefresh) {
+        this.settings.lastGlobalRefreshCompletedAt = Date.now();
+      }
       await this.saveSettings();
       this.autoRefreshScheduler?.reschedule();
       throw error;
+    } finally {
+      this.activeRefreshState.delete(feed.url);
+      await this.notifyRefreshStatusChanged();
     }
 
     await this.validateSavedArticles();
-    this.settings.lastRefreshTimestamp = Date.now();
+    if (isExplicitGlobalRefresh) {
+      this.settings.lastGlobalRefreshCompletedAt = Date.now();
+    }
     await this.saveSettings();
     this.autoRefreshScheduler?.reschedule();
     const view = await this.getActiveDashboardView();
@@ -2674,6 +2714,7 @@ export default class RssDashboardPlugin extends Plugin {
   private async refreshFeedBatch(
     feedsToRefresh: Feed[],
     feedNoticeText: string,
+    isExplicitGlobalRefresh: boolean,
   ): Promise<void> {
     if (this.isMultiFeedRefreshRunning) {
       new Notice("A multi-feed refresh is already in progress.");
@@ -2710,6 +2751,9 @@ export default class RssDashboardPlugin extends Plugin {
       if (view) {
         if (typeof view.refreshSidebarOnly === "function") {
           view.refreshSidebarOnly();
+          if (typeof view.refreshFilterStatusBarOnly === "function") {
+            view.refreshFilterStatusBarOnly();
+          }
         } else {
           view.refresh();
         }
@@ -2761,7 +2805,9 @@ export default class RssDashboardPlugin extends Plugin {
       await Promise.all(backgroundPromises);
 
       await this.validateSavedArticles();
-      this.settings.lastRefreshTimestamp = Date.now();
+      if (isExplicitGlobalRefresh) {
+        this.settings.lastGlobalRefreshCompletedAt = Date.now();
+      }
       await this.saveSettings();
       this.autoRefreshScheduler?.reschedule();
       this.activeRefreshState.clear();
@@ -2776,6 +2822,7 @@ export default class RssDashboardPlugin extends Plugin {
     } finally {
       this.activeRefreshState.clear();
       this.isMultiFeedRefreshRunning = false;
+      await this.notifyRefreshStatusChanged();
     }
   }
 

--- a/src/components/refresh-status-details.ts
+++ b/src/components/refresh-status-details.ts
@@ -1,0 +1,91 @@
+/**
+ * Lightweight, owning-document detail popup for sidebar refresh status.
+ * It uses no timers other than the interaction delay and never polls time.
+ */
+export function attachRefreshStatusDetails(options: {
+  row: HTMLElement;
+  description: () => string;
+  render: (popup: HTMLElement) => void;
+}): () => void {
+  const { row } = options;
+  const ownerDocument = row.ownerDocument;
+  const ownerWindow = ownerDocument.defaultView;
+  if (!ownerWindow) return () => undefined;
+
+  let popup: HTMLElement | null = null;
+  let showTimer: number | null = null;
+  let closeTimer: number | null = null;
+  const popupId = `rss-refresh-details-${Math.random().toString(36).slice(2)}`;
+  row.setAttribute("aria-label", options.description());
+
+  const clearTimers = () => {
+    if (showTimer !== null) ownerWindow.clearTimeout(showTimer);
+    if (closeTimer !== null) ownerWindow.clearTimeout(closeTimer);
+    showTimer = null;
+    closeTimer = null;
+  };
+  const close = () => {
+    clearTimers();
+    popup?.remove();
+    popup = null;
+    row.removeAttribute("aria-describedby");
+  };
+  const show = () => {
+    if (popup || !row.isConnected) return;
+    popup = ownerDocument.body.createDiv({
+      cls: "rss-dashboard-refresh-details",
+      attr: { id: popupId, role: "status" },
+    });
+    options.render(popup);
+    const rect = row.getBoundingClientRect();
+    popup.style.setProperty("top", `${Math.max(8, rect.top)}px`);
+    popup.style.setProperty("left", `${Math.max(8, rect.right + 8)}px`);
+    row.setAttribute("aria-describedby", popupId);
+    popup.addEventListener("mouseenter", clearTimers);
+    popup.addEventListener("mouseleave", scheduleClose);
+    popup.addEventListener("focusin", clearTimers);
+    popup.addEventListener("focusout", scheduleClose);
+  };
+  const scheduleShow = () => {
+    if (popup || showTimer !== null) return;
+    if (closeTimer !== null) ownerWindow.clearTimeout(closeTimer);
+    closeTimer = null;
+    showTimer = ownerWindow.setTimeout(() => {
+      showTimer = null;
+      show();
+    }, 350);
+  };
+  const scheduleClose = () => {
+    if (!popup || closeTimer !== null) return;
+    closeTimer = ownerWindow.setTimeout(() => {
+      const activeElement = ownerDocument.activeElement;
+      if (
+        !row.matches(":hover") &&
+        !popup?.matches(":hover") &&
+        activeElement !== row &&
+        !popup?.contains(activeElement)
+      ) {
+        close();
+      }
+    }, 100);
+  };
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") close();
+  };
+
+  row.addEventListener("mouseenter", scheduleShow);
+  row.addEventListener("mouseleave", scheduleClose);
+  row.addEventListener("focusin", scheduleShow);
+  row.addEventListener("focusout", scheduleClose);
+  ownerDocument.addEventListener("keydown", onKeyDown);
+
+  return () => {
+    clearTimers();
+    close();
+    row.removeEventListener("mouseenter", scheduleShow);
+    row.removeEventListener("mouseleave", scheduleClose);
+    row.removeEventListener("focusin", scheduleShow);
+    row.removeEventListener("focusout", scheduleClose);
+    ownerDocument.removeEventListener("keydown", onKeyDown);
+  };
+}

--- a/src/components/refresh-status-details.ts
+++ b/src/components/refresh-status-details.ts
@@ -16,7 +16,17 @@ export function attachRefreshStatusDetails(options: {
   let showTimer: number | null = null;
   let closeTimer: number | null = null;
   const popupId = `rss-refresh-details-${Math.random().toString(36).slice(2)}`;
-  row.setAttribute("aria-label", options.description());
+  const descriptionId = `${popupId}-description`;
+  const previousDescriptionIds = row.getAttribute("aria-describedby");
+  const description = ownerDocument.body.createSpan({
+    cls: "rss-dashboard-refresh-details-sr-only",
+    text: options.description(),
+    attr: { id: descriptionId },
+  });
+  row.setAttribute(
+    "aria-describedby",
+    [previousDescriptionIds, descriptionId].filter(Boolean).join(" "),
+  );
 
   const clearTimers = () => {
     if (showTimer !== null) ownerWindow.clearTimeout(showTimer);
@@ -28,7 +38,6 @@ export function attachRefreshStatusDetails(options: {
     clearTimers();
     popup?.remove();
     popup = null;
-    row.removeAttribute("aria-describedby");
   };
   const show = () => {
     if (popup || !row.isConnected) return;
@@ -40,7 +49,6 @@ export function attachRefreshStatusDetails(options: {
     const rect = row.getBoundingClientRect();
     popup.style.setProperty("top", `${Math.max(8, rect.top)}px`);
     popup.style.setProperty("left", `${Math.max(8, rect.right + 8)}px`);
-    row.setAttribute("aria-describedby", popupId);
     popup.addEventListener("mouseenter", clearTimers);
     popup.addEventListener("mouseleave", scheduleClose);
     popup.addEventListener("focusin", clearTimers);
@@ -56,6 +64,10 @@ export function attachRefreshStatusDetails(options: {
     }, 350);
   };
   const scheduleClose = () => {
+    if (showTimer !== null) {
+      ownerWindow.clearTimeout(showTimer);
+      showTimer = null;
+    }
     if (!popup || closeTimer !== null) return;
     closeTimer = ownerWindow.setTimeout(() => {
       const activeElement = ownerDocument.activeElement;
@@ -87,5 +99,11 @@ export function attachRefreshStatusDetails(options: {
     row.removeEventListener("focusin", scheduleShow);
     row.removeEventListener("focusout", scheduleClose);
     ownerDocument.removeEventListener("keydown", onKeyDown);
+    description.remove();
+    if (previousDescriptionIds) {
+      row.setAttribute("aria-describedby", previousDescriptionIds);
+    } else {
+      row.removeAttribute("aria-describedby");
+    }
   };
 }

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -45,6 +45,15 @@ import {
   setFolderFeedSortCustom,
   setFolderSortCustom,
 } from "../services/sidebar-ordering-controller";
+import { attachRefreshStatusDetails } from "./refresh-status-details";
+import {
+  formatRefreshStatusTime,
+  getRefreshStatus,
+  type RefreshStatus,
+} from "../utils/refresh-status";
+import {
+  getEffectiveRefreshIntervalMinutes,
+} from "../utils/refresh-intervals";
 
 export interface SidebarOptions {
   currentFolder: string | null;
@@ -297,6 +306,7 @@ export class Sidebar {
   private sidebarRows: SidebarRowDescriptor[] = [];
   private focusedSidebarTarget: SidebarFocusTarget | null = null;
   private isSidebarKeyboardFocused = false;
+  private refreshStatusDetailCleanups: Array<() => void> = [];
 
   private renderFallbackFeedIcon(feedIcon: HTMLElement): void {
     feedIcon.empty();
@@ -347,6 +357,123 @@ export class Sidebar {
     this.cachedFolderPaths = null;
   }
 
+  private clearRefreshStatusDetails(): void {
+    for (const cleanup of this.refreshStatusDetailCleanups) cleanup();
+    this.refreshStatusDetailCleanups = [];
+  }
+
+  private getRefreshDetailLines(
+    feeds: Feed[],
+    scope: "all" | "feed" | "aggregate",
+  ): string[] {
+    const status = getRefreshStatus({
+      feeds,
+      globalIntervalMinutes: this.settings.refreshInterval,
+      globalCompletionAt: this.settings.lastGlobalRefreshCompletedAt,
+      activeFeedUrls: new Set(this.plugin.activeRefreshState?.keys() ?? []),
+      scope,
+    });
+    const lines = [
+      `${status.completionLabel}: ${formatRefreshStatusTime(status.completionAt, true)}`,
+    ];
+    if (!status.isApplicable) return lines;
+
+    if (scope === "feed") {
+      const feed = feeds[0];
+      if (!feed) return lines;
+      const interval = getEffectiveRefreshIntervalMinutes(
+        feed,
+        this.settings.refreshInterval,
+      );
+      lines.push(
+        interval === null
+          ? "Automatic refresh Off"
+          : `Effective interval: ${interval} minutes`,
+      );
+      if (status.nextDueAt !== null) {
+        lines.push(
+          `Next scheduled refresh: ${status.nextDueAt === 0 ? "Due now" : formatRefreshStatusTime(status.nextDueAt, true)}`,
+        );
+      }
+      if (feed.lastFetchError) lines.push(`Last attempt failed: ${feed.lastFetchError}`);
+      if (status.refreshingCount > 0) lines.push("In progress");
+      if (feed.excludeFromRefresh) lines.push("Excluded from global refresh");
+      return lines;
+    }
+
+    const coverage = getRefreshStatus({
+      feeds,
+      globalIntervalMinutes: this.settings.refreshInterval,
+      scope: "aggregate",
+    });
+    lines.push(`Aggregate coverage: ${formatRefreshStatusTime(coverage.completionAt, true)}`);
+    if (status.nextDueAt !== null) {
+      lines.push(
+        `Next scheduled refresh: ${status.nextDueAt === 0 ? "Due now" : formatRefreshStatusTime(status.nextDueAt, true)}`,
+      );
+    }
+    this.appendRefreshStatusCounts(lines, status);
+    return lines;
+  }
+
+  private appendRefreshStatusCounts(lines: string[], status: RefreshStatus): void {
+    if (status.failingCount > 0) lines.push(`Feeds currently failing: ${status.failingCount}`);
+    if (status.refreshingCount > 0) lines.push(`Refreshing ${status.refreshingCount} feeds...`);
+    if (status.automaticOffCount > 0) lines.push(`Automatic refresh off: ${status.automaticOffCount}`);
+    if (status.excludedCount > 0) lines.push(`Feeds excluded from global refresh: ${status.excludedCount}`);
+    if (status.neverCheckedCount > 0) lines.push(`Feeds not yet checked: ${status.neverCheckedCount}`);
+  }
+
+  private attachRefreshDetails(
+    row: HTMLElement,
+    feeds: Feed[],
+    scope: "all" | "feed" | "aggregate",
+  ): void {
+    const getLines = () => this.getRefreshDetailLines(feeds, scope);
+    this.refreshStatusDetailCleanups.push(
+      attachRefreshStatusDetails({
+        row,
+        description: () => `Refresh details. ${getLines().join(". ")}`,
+        render: (popup) => {
+          popup.createEl("strong", { text: "Refresh details" });
+          for (const line of getLines()) {
+            popup.createDiv({
+              cls: "rss-dashboard-refresh-details-line",
+              text: line,
+            });
+          }
+        },
+      }),
+    );
+  }
+
+  private showRefreshDetails(
+    anchor: HTMLElement,
+    feeds: Feed[],
+    scope: "all" | "feed" | "aggregate",
+  ): void {
+    const ownerDocument = anchor.ownerDocument;
+    const popup = ownerDocument.body.createDiv({
+      cls: "rss-dashboard-refresh-details rss-dashboard-refresh-details-manual",
+      attr: { role: "status" },
+    });
+    popup.createEl("strong", { text: "Refresh details" });
+    for (const line of this.getRefreshDetailLines(feeds, scope)) {
+      popup.createDiv({ cls: "rss-dashboard-refresh-details-line", text: line });
+    }
+    const rect = anchor.getBoundingClientRect();
+    popup.style.setProperty("top", `${Math.max(8, rect.top)}px`);
+    popup.style.setProperty("left", `${Math.max(8, rect.right + 8)}px`);
+    const ownerWindow = ownerDocument.defaultView;
+    const dismiss = (event?: KeyboardEvent) => {
+      if (event && event.key !== "Escape") return;
+      popup.remove();
+      ownerDocument.removeEventListener("keydown", dismiss);
+    };
+    ownerDocument.addEventListener("keydown", dismiss);
+    if (ownerWindow) ownerWindow.setTimeout(dismiss, 5000);
+  }
+
   constructor(
     app: App,
     container: HTMLElement,
@@ -364,6 +491,7 @@ export class Sidebar {
   }
 
   public destroy(): void {
+    this.clearRefreshStatusDetails();
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;
@@ -382,6 +510,7 @@ export class Sidebar {
       foldersScroll = oldFoldersSection.scrollTop;
     }
 
+    this.clearRefreshStatusDetails();
     this.container.empty();
     this.container.addClass("rss-dashboard-sidebar");
     this.container.tabIndex = -1;
@@ -869,6 +998,7 @@ export class Sidebar {
       cls: "rss-dashboard-all-feeds-button" + (isAllActive ? " active" : ""),
     });
     allFeedsButton.setAttr("tabindex", "-1");
+    this.attachRefreshDetails(allFeedsButton, this.settings.feeds, "all");
     this.registerSidebarRow({ type: "all-feeds" }, allFeedsButton);
     const isRefreshActive =
       this.plugin.isMultiFeedRefreshActive ||
@@ -927,6 +1057,17 @@ export class Sidebar {
 
   private showAllFeedsContextMenu(event: MouseEvent): void {
     const menu = new Menu();
+    const anchor = event.currentTarget;
+
+    menu.addItem((item: MenuItem) => {
+      item.setTitle("Refresh details").setIcon("info").onClick(() => {
+        this.showRefreshDetails(
+          anchor instanceof HTMLElement ? anchor : this.container,
+          this.settings.feeds,
+          "all",
+        );
+      });
+    });
 
     menu.addItem((item: MenuItem) => {
       item
@@ -1006,6 +1147,14 @@ export class Sidebar {
       },
     });
     folderHeader.setAttr("tabindex", "-1");
+    const folderRefreshFeeds = this.getAllDescendantFolderPaths(fullPath);
+    this.attachRefreshDetails(
+      folderHeader,
+      this.settings.feeds.filter(
+        (feed) => Boolean(feed.folder) && folderRefreshFeeds.includes(feed.folder),
+      ),
+      "aggregate",
+    );
     this.registerSidebarRow({ type: "folder", path: fullPath }, folderHeader, {
       folderPath: fullPath,
       folderName,
@@ -1400,6 +1549,7 @@ export class Sidebar {
       },
     });
     feedEl.setAttr("tabindex", "-1");
+    this.attachRefreshDetails(feedEl, [feed], "feed");
     this.registerSidebarRow({ type: "feed", url: feed.url }, feedEl, { feed });
 
     const unreadCount = feed.items.filter((item) => !item.read).length;
@@ -1791,6 +1941,20 @@ export class Sidebar {
     folderName: string,
   ): void {
     const menu = new Menu();
+    const anchor = event.currentTarget;
+
+    menu.addItem((item: MenuItem) => {
+      item.setTitle("Refresh details").setIcon("info").onClick(() => {
+        this.showRefreshDetails(
+          anchor instanceof HTMLElement ? anchor : this.container,
+          this.settings.feeds.filter((feed) => {
+            const paths = this.getAllDescendantFolderPaths(fullPath);
+            return Boolean(feed.folder) && paths.includes(feed.folder);
+          }),
+          "aggregate",
+        );
+      });
+    });
     
     if (this.isMultiSelectionTarget('folder', fullPath)) {
       this.appendSelectionContextMenu(menu);
@@ -3438,6 +3602,17 @@ export class Sidebar {
 
   private showFeedContextMenu(event: MouseEvent, feed: Feed): void {
     const menu = new Menu();
+    const anchor = event.currentTarget;
+
+    menu.addItem((item: MenuItem) => {
+      item.setTitle("Refresh details").setIcon("info").onClick(() => {
+        this.showRefreshDetails(
+          anchor instanceof HTMLElement ? anchor : this.container,
+          [feed],
+          "feed",
+        );
+      });
+    });
 
     if (this.isMultiSelectionTarget('feed', feed.url)) {
       this.appendSelectionContextMenu(menu);

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -1009,7 +1009,6 @@ export class Sidebar {
       cls:
         "rss-dashboard-all-feeds-icon" + (isRefreshActive ? " refreshing" : ""),
       attr: {
-        title: "Refresh all feeds",
         "aria-label": "Refresh all feeds",
       },
     });

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -1005,11 +1005,19 @@ export class Sidebar {
       (this.plugin.activeRefreshState?.size ?? 0) > 0;
 
     // Feed icon (refresh button) - clickable
+    const refreshLabelId = `rss-dashboard-refresh-all-feeds-${Math.random()
+      .toString(36)
+      .slice(2)}`;
+    allFeedsButton.createSpan({
+      cls: "rss-dashboard-refresh-details-sr-only",
+      text: "Refresh all feeds",
+      attr: { id: refreshLabelId },
+    });
     const feedIcon = allFeedsButton.createDiv({
       cls:
         "rss-dashboard-all-feeds-icon" + (isRefreshActive ? " refreshing" : ""),
       attr: {
-        "aria-label": "Refresh all feeds",
+        "aria-labelledby": refreshLabelId,
       },
     });
     setIcon(feedIcon, "refresh-cw");

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1495,3 +1495,30 @@ body .rss-folder-name-modal {
 .rss-dashboard-tag-checkbox {
   pointer-events: none;
 }
+
+.rss-dashboard-refresh-details {
+  position: fixed;
+  z-index: var(--layer-popover);
+  max-width: min(360px, calc(100vw - 16px));
+  padding: 10px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background-color: var(--background-primary);
+  color: var(--text-normal);
+  box-shadow: var(--shadow-s);
+  font-size: var(--font-ui-small);
+  pointer-events: auto;
+}
+
+.rss-dashboard-refresh-details-line {
+  margin-top: 4px;
+  overflow-wrap: anywhere;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .rss-dashboard-refresh-details {
+    left: 8px;
+    right: 8px;
+    max-width: none;
+  }
+}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1515,6 +1515,18 @@ body .rss-folder-name-modal {
   overflow-wrap: anywhere;
 }
 
+.rss-dashboard-refresh-details-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (hover: none) and (pointer: coarse) {
   .rss-dashboard-refresh-details {
     left: 8px;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -434,6 +434,8 @@ export interface RssDashboardSettings {
   folders: Folder[];
   refreshInterval: number;
   lastRefreshTimestamp: number;
+  /** Completion time for an explicit refresh of the complete eligible feed set. */
+  lastGlobalRefreshCompletedAt: number;
   startupRefreshDelaySeconds: number;
   maxItems: number;
   defaultAutoDeleteDuration: number;
@@ -587,6 +589,7 @@ export const DEFAULT_SETTINGS: RssDashboardSettings = {
   ],
   refreshInterval: 0,
   lastRefreshTimestamp: 0,
+  lastGlobalRefreshCompletedAt: 0,
   startupRefreshDelaySeconds: 5,
   maxItems: 50,
   defaultAutoDeleteDuration: 30,

--- a/src/utils/refresh-status.ts
+++ b/src/utils/refresh-status.ts
@@ -97,8 +97,12 @@ export function formatRefreshStatusTime(
 
   return new Intl.DateTimeFormat(undefined, detailed
     ? {
-        dateStyle: "medium",
-        timeStyle: "medium",
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
         timeZoneName: "short",
       }
     : {

--- a/src/utils/refresh-status.ts
+++ b/src/utils/refresh-status.ts
@@ -1,0 +1,127 @@
+import type { Feed } from "../types/types";
+import {
+  getEffectiveRefreshIntervalMinutes,
+  getNextRefreshDueAt,
+} from "./refresh-intervals";
+
+export type RefreshStatusScope = "all" | "feed" | "aggregate";
+
+export interface RefreshStatus {
+  scope: RefreshStatusScope;
+  isApplicable: boolean;
+  completionAt: number | null;
+  completionLabel: "Last global refresh" | "Last checked";
+  eligibleCount: number;
+  excludedCount: number;
+  failingCount: number;
+  refreshingCount: number;
+  automaticOffCount: number;
+  neverCheckedCount: number;
+  nextDueAt: number | null;
+}
+
+export interface RefreshStatusInput {
+  feeds: Feed[];
+  globalIntervalMinutes: number;
+  scope: RefreshStatusScope;
+  globalCompletionAt?: number;
+  activeFeedUrls?: ReadonlySet<string>;
+}
+
+function completionAt(feed: Feed): number {
+  const completedAt = feed.lastRefreshAttemptCompletedAt;
+  return Number.isFinite(completedAt) && completedAt && completedAt > 0
+    ? completedAt
+    : 0;
+}
+
+/** Resolves refresh coverage independently from article filters or visible items. */
+export function getRefreshStatus(input: RefreshStatusInput): RefreshStatus {
+  const excludedCount = input.feeds.filter(
+    (feed) => feed.excludeFromRefresh === true,
+  ).length;
+  const eligibleFeeds = input.feeds.filter(
+    (feed) => feed.excludeFromRefresh !== true,
+  );
+  const isFeedScope = input.scope === "feed";
+  const coverageFeeds = isFeedScope ? input.feeds : eligibleFeeds;
+  const isApplicable = isFeedScope ? input.feeds.length > 0 : eligibleFeeds.length > 0;
+  const activeFeedUrls = input.activeFeedUrls ?? new Set<string>();
+  const completionLabel = input.scope === "all" ? "Last global refresh" : "Last checked";
+
+  let resolvedCompletionAt: number | null;
+  if (!isApplicable) {
+    resolvedCompletionAt = null;
+  } else if (input.scope === "all") {
+    const globalCompletionAt = input.globalCompletionAt;
+    resolvedCompletionAt =
+      Number.isFinite(globalCompletionAt) && globalCompletionAt && globalCompletionAt > 0
+        ? globalCompletionAt
+        : 0;
+  } else if (coverageFeeds.some((feed) => completionAt(feed) === 0)) {
+    resolvedCompletionAt = 0;
+  } else {
+    resolvedCompletionAt = Math.min(...coverageFeeds.map(completionAt));
+  }
+
+  const automaticOffCount = eligibleFeeds.filter(
+    (feed) =>
+      getEffectiveRefreshIntervalMinutes(feed, input.globalIntervalMinutes) === null,
+  ).length;
+  const nextDueTimes = eligibleFeeds
+    .map((feed) => getNextRefreshDueAt(feed, input.globalIntervalMinutes))
+    .filter((dueAt): dueAt is number => dueAt !== null);
+
+  return {
+    scope: input.scope,
+    isApplicable,
+    completionAt: resolvedCompletionAt,
+    completionLabel,
+    eligibleCount: eligibleFeeds.length,
+    excludedCount,
+    failingCount: coverageFeeds.filter((feed) => Boolean(feed.lastFetchError)).length,
+    refreshingCount: coverageFeeds.filter((feed) => activeFeedUrls.has(feed.url)).length,
+    automaticOffCount,
+    neverCheckedCount: coverageFeeds.filter((feed) => completionAt(feed) === 0).length,
+    nextDueAt: nextDueTimes.length > 0 ? Math.min(...nextDueTimes) : null,
+  };
+}
+
+/** Formats a static, local timestamp. This intentionally does not schedule polling. */
+export function formatRefreshStatusTime(
+  timestamp: number | null,
+  detailed = false,
+): string {
+  if (timestamp === null) return "Not applicable";
+  if (timestamp <= 0) return "Not yet";
+
+  return new Intl.DateTimeFormat(undefined, detailed
+    ? {
+        dateStyle: "medium",
+        timeStyle: "medium",
+        timeZoneName: "short",
+      }
+    : {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(timestamp);
+}
+
+export function getRefreshStatusSegments(status: RefreshStatus): string[] {
+  const segments: string[] = [];
+  if (status.refreshingCount > 0) {
+    segments.push(
+      status.refreshingCount === 1
+        ? "In progress"
+        : `Refreshing ${status.refreshingCount} feeds...`,
+    );
+  }
+  if (status.failingCount > 0) {
+    segments.push(
+      status.scope === "feed"
+        ? "Last attempt failed"
+        : `Feeds currently failing: ${status.failingCount}`,
+    );
+  }
+  return segments;
+}

--- a/src/utils/settings-loader.ts
+++ b/src/utils/settings-loader.ts
@@ -91,6 +91,14 @@ export function loadAndNormalizeSettings(
     : DEFAULT_SETTINGS.refreshInterval;
 
   if (
+    !Number.isFinite(settings.lastGlobalRefreshCompletedAt) ||
+    settings.lastGlobalRefreshCompletedAt < 0
+  ) {
+    settings.lastGlobalRefreshCompletedAt =
+      DEFAULT_SETTINGS.lastGlobalRefreshCompletedAt;
+  }
+
+  if (
     typeof settings.startupRefreshDelaySeconds !== "number" ||
     settings.startupRefreshDelaySeconds < 0
   ) {

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -39,6 +39,12 @@ import { computePagination } from "../utils/pagination-utils";
 import { applyAutomaticArticleTags } from "../utils/tag-utils";
 import { resolveItemExternalUrl } from "../utils/item-url-utils";
 import { buildArticleEmptyStateContext } from "../utils/filter-detection";
+import {
+  formatRefreshStatusTime,
+  getRefreshStatus,
+  getRefreshStatusSegments,
+  type RefreshStatus,
+} from "../utils/refresh-status";
 import { setupDashboardHotkeys } from "../hotkeys/dashboard-hotkeys";
 import { scheduleProcessMathElements } from "../utils/math-rendering";
 import {
@@ -1098,8 +1104,8 @@ export class RssDashboardView extends ItemView {
    *     (Data written by computeDashboardMultiFilterCounts() →
    *     this.dashboardMultiFilterCounts)
    *
-   * Visibility: hidden entirely when settings.display.showFilterStatusBar is
-   * false, or when no keyword/highlight/viewing-filter stats are available.
+   * The static refresh status is always present when this existing status-bar
+   * setting is enabled. It intentionally has no relative-time polling timer.
    *
    * Collapse state persisted in this.isFilterSubheaderCollapsed across renders.
    */
@@ -1115,15 +1121,6 @@ export class RssDashboardView extends ItemView {
       this.dashboardMultiFilterCounts !== null;
     const hasHighlightStats = this.highlightMatchCounts.length > 0;
 
-    // Only render when there is at least one row worth of content.
-    if (
-      !hasKeywordStats &&
-      !hasDashboardMultiFilterStats &&
-      !hasHighlightStats
-    ) {
-      return;
-    }
-
     const subheader = container.createDiv({
       cls: "rss-dashboard-filter-subheader",
     });
@@ -1134,6 +1131,20 @@ export class RssDashboardView extends ItemView {
     if (this.keywordFilterTooltip) {
       subheaderContent.setAttribute("title", this.keywordFilterTooltip);
     }
+
+    const refreshStatus = this.getCurrentRefreshStatus();
+    const refreshStatusRow = subheaderContent.createDiv({
+      cls: "rss-dashboard-filter-stats-row rss-dashboard-refresh-status-row",
+    });
+    const refreshStatusText = [
+      `${refreshStatus.completionLabel}: ${formatRefreshStatusTime(refreshStatus.completionAt)}`,
+      ...getRefreshStatusSegments(refreshStatus),
+    ].join(" | ");
+    refreshStatusRow.createSpan({
+      cls: "rss-dashboard-filter-stats-text rss-dashboard-refresh-status-text",
+      text: refreshStatusText,
+      attr: { "aria-live": "polite" },
+    });
 
     // ── Row 1: Keyword rules stats ──────────────────────────────────────────
     if (hasKeywordStats) {
@@ -1351,6 +1362,61 @@ export class RssDashboardView extends ItemView {
   }
 
   // --- Title and article-scope helpers ---
+  private getCurrentRefreshStatus(): RefreshStatus {
+    this.syncCurrentFeedReference();
+    let scope: "all" | "feed" | "aggregate" = "all";
+    let feeds: Feed[] = this.settings.feeds;
+
+    if (this.currentFeed) {
+      scope = "feed";
+      feeds = [this.currentFeed];
+    } else if (
+      this.selectedFolders.length > 0 ||
+      this.selectedFeeds.length > 0
+    ) {
+      scope = "aggregate";
+      feeds = this.getFeedsForSelectedRefreshScope();
+    } else if (
+      this.currentFolder &&
+      !["read", "unread", "starred", "saved", "videos", "podcasts"].includes(
+        this.currentFolder,
+      )
+    ) {
+      scope = "aggregate";
+      const folderPaths = new Set([
+        this.currentFolder,
+        ...this.getAllDescendantFolders(this.currentFolder),
+      ]);
+      feeds = this.settings.feeds.filter(
+        (feed) => Boolean(feed.folder) && folderPaths.has(feed.folder),
+      );
+    }
+
+    return getRefreshStatus({
+      feeds,
+      globalIntervalMinutes: this.settings.refreshInterval,
+      globalCompletionAt: this.settings.lastGlobalRefreshCompletedAt,
+      activeFeedUrls: new Set(this.plugin.activeRefreshState?.keys() ?? []),
+      scope,
+    });
+  }
+
+  private getFeedsForSelectedRefreshScope(): Feed[] {
+    const folderPaths = new Set<string>();
+    for (const folder of this.selectedFolders) {
+      folderPaths.add(folder);
+      for (const descendant of this.getAllDescendantFolders(folder)) {
+        folderPaths.add(descendant);
+      }
+    }
+    const selectedFeeds = new Set(this.selectedFeeds);
+    return this.settings.feeds.filter(
+      (feed) =>
+        selectedFeeds.has(feed.url) ||
+        (Boolean(feed.folder) && folderPaths.has(feed.folder)),
+    );
+  }
+
   private getTotalFeedsInSelection(): number {
     const includedFeeds = new Set<string>(this.selectedFeeds || []);
     if (this.selectedFolders && this.selectedFolders.length > 0) {

--- a/test_files/unit/components/refresh-status-details.test.ts
+++ b/test_files/unit/components/refresh-status-details.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { attachRefreshStatusDetails } from "../../../src/components/refresh-status-details";
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.empty();
+});
+
+describe("refresh status details", () => {
+  it("opens after hover delay, exposes a screen-reader description, and closes with Escape", async () => {
+    vi.useFakeTimers();
+    const row = document.body.createDiv({ text: "Feed" });
+    const cleanup = attachRefreshStatusDetails({
+      row,
+      description: () => "Refresh details. Last checked: Not yet",
+      render: (popup) => popup.createDiv({ text: "Last checked: Not yet" }),
+    });
+
+    row.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(350);
+
+    const popup = document.querySelector<HTMLElement>(
+      ".rss-dashboard-refresh-details",
+    );
+    expect(popup?.textContent).toContain("Last checked: Not yet");
+    expect(row.getAttribute("aria-describedby")).toBe(popup?.id);
+    expect(row.getAttribute("aria-label")).toContain("Refresh details");
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(document.querySelector(".rss-dashboard-refresh-details")).toBeNull();
+
+    cleanup();
+  });
+});

--- a/test_files/unit/components/refresh-status-details.test.ts
+++ b/test_files/unit/components/refresh-status-details.test.ts
@@ -7,7 +7,7 @@ afterEach(() => {
 });
 
 describe("refresh status details", () => {
-  it("opens after hover delay, exposes a screen-reader description, and closes with Escape", async () => {
+  it("opens after hover delay, exposes a description without a native tooltip trigger, and closes with Escape", async () => {
     vi.useFakeTimers();
     const row = document.body.createDiv({ text: "Feed" });
     const cleanup = attachRefreshStatusDetails({
@@ -23,12 +23,52 @@ describe("refresh status details", () => {
       ".rss-dashboard-refresh-details",
     );
     expect(popup?.textContent).toContain("Last checked: Not yet");
-    expect(row.getAttribute("aria-describedby")).toBe(popup?.id);
-    expect(row.getAttribute("aria-label")).toContain("Refresh details");
+    const descriptionId = row.getAttribute("aria-describedby");
+    expect(document.getElementById(descriptionId ?? "")?.textContent).toContain(
+      "Refresh details",
+    );
+    expect(row.hasAttribute("aria-label")).toBe(false);
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(document.querySelector(".rss-dashboard-refresh-details")).toBeNull();
 
+    cleanup();
+  });
+
+  it("cancels a pending popup when the pointer leaves before the hover delay", async () => {
+    vi.useFakeTimers();
+    const row = document.body.createDiv({ text: "Feed" });
+    const cleanup = attachRefreshStatusDetails({
+      row,
+      description: () => "Refresh details. Last checked: Not yet",
+      render: (popup) => popup.createDiv({ text: "Last checked: Not yet" }),
+    });
+
+    row.dispatchEvent(new MouseEvent("mouseenter"));
+    await vi.advanceTimersByTimeAsync(100);
+    row.dispatchEvent(new MouseEvent("mouseleave"));
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(document.querySelector(".rss-dashboard-refresh-details")).toBeNull();
+    cleanup();
+  });
+
+  it("closes an opened popup after the pointer leaves the row", async () => {
+    vi.useFakeTimers();
+    const row = document.body.createDiv({ text: "Feed" });
+    const cleanup = attachRefreshStatusDetails({
+      row,
+      description: () => "Refresh details. Last checked: Not yet",
+      render: (popup) => popup.createDiv({ text: "Last checked: Not yet" }),
+    });
+
+    row.dispatchEvent(new MouseEvent("mouseenter"));
+    await vi.advanceTimersByTimeAsync(350);
+    expect(document.querySelector(".rss-dashboard-refresh-details")).not.toBeNull();
+
+    row.dispatchEvent(new MouseEvent("mouseleave"));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(document.querySelector(".rss-dashboard-refresh-details")).toBeNull();
     cleanup();
   });
 });

--- a/test_files/unit/components/sidebar-rendering.test.ts
+++ b/test_files/unit/components/sidebar-rendering.test.ts
@@ -149,8 +149,12 @@ describe("Sidebar Rendering", () => {
     const refreshIcon = container.querySelector<HTMLElement>(
       ".rss-dashboard-all-feeds-icon",
     );
-    expect(refreshIcon?.getAttribute("aria-label")).toBe("Refresh all feeds");
+    expect(refreshIcon?.hasAttribute("aria-label")).toBe(false);
     expect(refreshIcon?.hasAttribute("title")).toBe(false);
+    const labelId = refreshIcon?.getAttribute("aria-labelledby") ?? "";
+    expect(document.getElementById(labelId)?.textContent).toBe(
+      "Refresh all feeds",
+    );
   });
 
   it("should show unread badge for All Feeds if at least one unread item exists", () => {

--- a/test_files/unit/components/sidebar-rendering.test.ts
+++ b/test_files/unit/components/sidebar-rendering.test.ts
@@ -135,6 +135,24 @@ describe("Sidebar Rendering", () => {
     expect(allFeedsBtn?.textContent).toContain("All Feeds");
   });
 
+  it("keeps the refresh icon accessible without a competing native tooltip", () => {
+    const sidebar = new Sidebar(
+      app as unknown as import("obsidian").App,
+      container,
+      plugin as unknown as RssDashboardPlugin,
+      settings,
+      options,
+      callbacks,
+    );
+    sidebar.render();
+
+    const refreshIcon = container.querySelector<HTMLElement>(
+      ".rss-dashboard-all-feeds-icon",
+    );
+    expect(refreshIcon?.getAttribute("aria-label")).toBe("Refresh all feeds");
+    expect(refreshIcon?.hasAttribute("title")).toBe(false);
+  });
+
   it("should show unread badge for All Feeds if at least one unread item exists", () => {
     const sidebar = new Sidebar(
       app as unknown as import("obsidian").App,

--- a/test_files/unit/main/feed-refresh-pipeline.test.ts
+++ b/test_files/unit/main/feed-refresh-pipeline.test.ts
@@ -115,6 +115,35 @@ beforeEach(() => {
 });
 
 describe("refreshFeeds() pipeline behavior", () => {
+  it("records global completion after an explicit all-feeds refresh even when one attempt fails", async () => {
+    const successful = createFeed({ url: "https://example.com/one.xml" });
+    const failing = createFeed({ url: "https://example.com/two.xml" });
+    const plugin = createPluginWithSettings([successful, failing]);
+    vi.spyOn(Date, "now").mockReturnValue(9_876);
+    (plugin.feedParser.refreshFeed as unknown as { mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void }).mockImplementation(
+      async (feed) => {
+        if (feed.url === failing.url) throw new Error("network down");
+        return feed;
+      },
+    );
+
+    await plugin.refreshFeeds();
+
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBe(9_876);
+    expect(plugin.settings.feeds[1].lastFetchError).toBe("network down");
+  });
+
+  it("does not record global completion for a selected-feed refresh", async () => {
+    const selected = createFeed();
+    const plugin = createPluginWithSettings([selected]);
+    plugin.settings.lastGlobalRefreshCompletedAt = 123;
+    (plugin.feedParser.refreshFeed as unknown as { mockResolvedValue: (value: Feed) => void }).mockResolvedValue(selected);
+
+    await plugin.refreshFeeds([selected]);
+
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBe(123);
+  });
+
   it("refreshes multi-feed selections with bounded concurrency, incremental merges, and a final save + refresh", async () => {
     vi.useFakeTimers();
     const feedA = createFeed({

--- a/test_files/unit/main/plugin-lifecycle.test.ts
+++ b/test_files/unit/main/plugin-lifecycle.test.ts
@@ -712,6 +712,58 @@ describe("onload() initialization", () => {
     vi.useRealTimers();
   });
 
+  it("keeps refreshed articles when shard persistence writes vault metadata", async () => {
+    vi.useFakeTimers();
+    const handlers: Record<string, (...args: unknown[]) => void> = {};
+    plugin.app.vault.on = vi.fn(
+      (event: string, callback: (...args: unknown[]) => void) => {
+        handlers[event] = callback;
+        return {};
+      },
+    );
+
+    await plugin.onload();
+    plugin.settings = {
+      ...DEFAULT_SETTINGS,
+      storageMode: "vault-shards-v2",
+      storageFolder: ".rss-dashboard-data/feeds",
+      metadataStorageMode: "vault-location",
+      metadataStorageFolder: ".rss-dashboard-data",
+      feeds: [
+        {
+          ...sampleFeed,
+          feedId: "feed-1",
+          autoDeleteDuration: 30,
+          items: [
+            {
+              ...sampleFeed.items[0],
+              pubDate: "2026-08-15T00:00:00Z",
+            },
+          ],
+        },
+      ],
+    };
+
+    const loadSpy = vi.spyOn(plugin, "loadSettings").mockImplementation(() => {
+      plugin.settings.feeds[0].items = [];
+      return Promise.resolve();
+    });
+    const adapter = plugin.app.vault.adapter as unknown as {
+      write: (path: string, content: string) => Promise<void>;
+    };
+    vi.spyOn(adapter, "write").mockImplementation((path) => {
+      handlers.modify?.({ path });
+      return Promise.resolve();
+    });
+
+    await plugin.saveSettings();
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(loadSpy).not.toHaveBeenCalled();
+    expect(plugin.settings.feeds[0].items).toHaveLength(1);
+    vi.useRealTimers();
+  });
+
   it("watcher ordering: refresh after loadSettings completes", async () => {
     vi.useFakeTimers();
     const handlers: Record<string, (...args: unknown[]) => void> = {};

--- a/test_files/unit/main/plugin-lifecycle.test.ts
+++ b/test_files/unit/main/plugin-lifecycle.test.ts
@@ -1105,7 +1105,7 @@ describe("refreshFeeds()", () => {
     expect(plugin.settings).toBeDefined();
   });
 
-  it("saves lastRefreshTimestamp after successful refresh", async () => {
+  it("records explicit global completion without changing the legacy timestamp", async () => {
     // Given: Mock refreshAllFeeds returns updated feeds
     mockRefreshAllFeeds.mockResolvedValue([sampleFeed]);
     const beforeRefresh = Date.now();
@@ -1114,105 +1114,38 @@ describe("refreshFeeds()", () => {
     await plugin.refreshFeeds();
     const afterRefresh = Date.now();
 
-    // Then: lastRefreshTimestamp should be set
-    expect(plugin.settings.lastRefreshTimestamp).toBeGreaterThanOrEqual(
+    // Then: only the unambiguous global timestamp is set
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBeGreaterThanOrEqual(
       beforeRefresh,
     );
-    expect(plugin.settings.lastRefreshTimestamp).toBeLessThanOrEqual(
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBeLessThanOrEqual(
       afterRefresh,
     );
+    expect(plugin.settings.lastRefreshTimestamp).toBe(0);
   });
 
-  it("does NOT save lastRefreshTimestamp on refresh failure", async () => {
+  it("records global completion when an explicit global attempt fails", async () => {
     // Given: Mock refreshAllFeeds throws error
     mockRefreshAllFeeds.mockRejectedValue(new Error("Network error"));
-    plugin.settings.lastRefreshTimestamp = 0;
+    plugin.settings.lastGlobalRefreshCompletedAt = 0;
 
     // When: refreshFeeds is called
     await plugin.refreshFeeds();
 
-    // Then: lastRefreshTimestamp should remain 0 (not updated on failure)
-    expect(plugin.settings.lastRefreshTimestamp).toBe(0);
+    // A completed failed attempt is still a completed global check.
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBeGreaterThan(0);
   });
 });
 
 // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
-// Test Suite: lastRefreshTimestamp settings
+// Test Suite: refresh timestamp settings
 // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-describe("lastRefreshTimestamp in settings", () => {
-  it("has lastRefreshTimestamp in DEFAULT_SETTINGS with default value 0", () => {
-    // Then: DEFAULT_SETTINGS should include lastRefreshTimestamp
+describe("refresh timestamp settings", () => {
+  it("keeps the legacy timestamp readable and defaults global completion to zero", () => {
     expect(DEFAULT_SETTINGS).toHaveProperty("lastRefreshTimestamp");
     expect(DEFAULT_SETTINGS.lastRefreshTimestamp).toBe(0);
-  });
-
-  it("shouldRefreshOnOpen returns true when no timestamp exists", () => {
-    // Given: Settings with no lastRefreshTimestamp
-    const settings = { ...DEFAULT_SETTINGS, lastRefreshTimestamp: 0 };
-
-    // When: Checking if should refresh on open
-    const shouldRefresh =
-      !settings.lastRefreshTimestamp ||
-      Date.now() - settings.lastRefreshTimestamp >=
-        settings.refreshInterval * 60 * 1000;
-
-    // Then: Should return true for first-time users
-    expect(shouldRefresh).toBe(true);
-  });
-
-  it("shouldRefreshOnOpen returns false when auto refresh is disabled", () => {
-    const settings = {
-      ...DEFAULT_SETTINGS,
-      refreshInterval: 0,
-      lastRefreshTimestamp: 0,
-    };
-
-    const shouldRefresh =
-      settings.refreshInterval > 0 &&
-      (!settings.lastRefreshTimestamp ||
-        Date.now() - settings.lastRefreshTimestamp >=
-          settings.refreshInterval * 60 * 1000);
-
-    expect(shouldRefresh).toBe(false);
-  });
-
-  it("shouldRefreshOnOpen returns true when interval has elapsed", () => {
-    // Given: Settings with timestamp 90 minutes ago, interval 60 minutes
-    const ninetyMinutesAgo = Date.now() - 90 * 60 * 1000;
-    const settings = {
-      ...DEFAULT_SETTINGS,
-      lastRefreshTimestamp: ninetyMinutesAgo,
-      refreshInterval: 60,
-    };
-
-    // When: Checking if should refresh on open
-    const shouldRefresh =
-      !settings.lastRefreshTimestamp ||
-      Date.now() - settings.lastRefreshTimestamp >=
-        settings.refreshInterval * 60 * 1000;
-
-    // Then: Should return true
-    expect(shouldRefresh).toBe(true);
-  });
-
-  it("shouldRefreshOnOpen returns false when interval has not elapsed", () => {
-    // Given: Settings with timestamp 30 minutes ago, interval 60 minutes
-    const thirtyMinutesAgo = Date.now() - 30 * 60 * 1000;
-    const settings = {
-      ...DEFAULT_SETTINGS,
-      lastRefreshTimestamp: thirtyMinutesAgo,
-      refreshInterval: 60,
-    };
-
-    // When: Checking if should refresh on open
-    const shouldRefresh =
-      !settings.lastRefreshTimestamp ||
-      Date.now() - settings.lastRefreshTimestamp >=
-        settings.refreshInterval * 60 * 1000;
-
-    // Then: Should return false
-    expect(shouldRefresh).toBe(false);
+    expect(DEFAULT_SETTINGS.lastGlobalRefreshCompletedAt).toBe(0);
   });
 });
 

--- a/test_files/unit/utils/refresh-status.test.ts
+++ b/test_files/unit/utils/refresh-status.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Feed } from "../../../src/types/types";
+import { getRefreshStatus } from "../../../src/utils/refresh-status";
+
+function createFeed(overrides: Partial<Feed> = {}): Feed {
+  return {
+    title: "Feed",
+    url: "https://example.com/feed.xml",
+    folder: "News",
+    items: [],
+    lastUpdated: 0,
+    mediaType: "article",
+    ...overrides,
+  };
+}
+
+describe("getRefreshStatus", () => {
+  it("uses only the explicit global completion for all-feed scope", () => {
+    const status = getRefreshStatus({
+      feeds: [createFeed({ lastRefreshAttemptCompletedAt: 100 })],
+      globalIntervalMinutes: 30,
+      globalCompletionAt: 200,
+      scope: "all",
+    });
+
+    expect(status.completionAt).toBe(200);
+    expect(status.completionLabel).toBe("Last global refresh");
+  });
+
+  it("reports the oldest eligible completion and separate excluded members for an aggregate", () => {
+    const status = getRefreshStatus({
+      feeds: [
+        createFeed({ url: "one", lastRefreshAttemptCompletedAt: 300 }),
+        createFeed({ url: "two", lastRefreshAttemptCompletedAt: 100 }),
+        createFeed({ url: "excluded", excludeFromRefresh: true, lastRefreshAttemptCompletedAt: 20 }),
+      ],
+      globalIntervalMinutes: 30,
+      activeFeedUrls: new Set(["one", "excluded"]),
+      scope: "aggregate",
+    });
+
+    expect(status.completionAt).toBe(100);
+    expect(status.excludedCount).toBe(1);
+    expect(status.refreshingCount).toBe(1);
+  });
+
+  it("treats an eligible never-checked feed as not yet and an excluded-only scope as not applicable", () => {
+    const notYet = getRefreshStatus({
+      feeds: [createFeed({ lastRefreshAttemptCompletedAt: 0 })],
+      globalIntervalMinutes: 30,
+      scope: "aggregate",
+    });
+    const notApplicable = getRefreshStatus({
+      feeds: [createFeed({ excludeFromRefresh: true })],
+      globalIntervalMinutes: 30,
+      scope: "aggregate",
+    });
+
+    expect(notYet.completionAt).toBe(0);
+    expect(notYet.neverCheckedCount).toBe(1);
+    expect(notApplicable.isApplicable).toBe(false);
+  });
+});

--- a/test_files/unit/utils/refresh-status.test.ts
+++ b/test_files/unit/utils/refresh-status.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Feed } from "../../../src/types/types";
-import { getRefreshStatus } from "../../../src/utils/refresh-status";
+import {
+  formatRefreshStatusTime,
+  getRefreshStatus,
+} from "../../../src/utils/refresh-status";
 
 function createFeed(overrides: Partial<Feed> = {}): Feed {
   return {
@@ -59,5 +62,11 @@ describe("getRefreshStatus", () => {
     expect(notYet.completionAt).toBe(0);
     expect(notYet.neverCheckedCount).toBe(1);
     expect(notApplicable.isApplicable).toBe(false);
+  });
+});
+
+describe("formatRefreshStatusTime", () => {
+  it("formats detailed timestamps with seconds and timezone without throwing", () => {
+    expect(() => formatRefreshStatusTime(1_789_012_345_000, true)).not.toThrow();
   });
 });

--- a/test_files/unit/utils/settings-loader.test.ts
+++ b/test_files/unit/utils/settings-loader.test.ts
@@ -232,6 +232,20 @@ describe("settings-loader", () => {
       );
     });
 
+    it("preserves global refresh completion without seeding it from the legacy timestamp", async () => {
+      const { loadAndNormalizeSettings } =
+        await import("../../../src/utils/settings-loader");
+
+      const preserved = loadAndNormalizeSettings({
+        lastRefreshTimestamp: 123,
+        lastGlobalRefreshCompletedAt: 456,
+      });
+      const legacyOnly = loadAndNormalizeSettings({ lastRefreshTimestamp: 123 });
+
+      expect(preserved.lastGlobalRefreshCompletedAt).toBe(456);
+      expect(legacyOnly.lastGlobalRefreshCompletedAt).toBe(0);
+    });
+
     it("infers legacy-json for existing installations missing storageMode (has feeds)", async () => {
       const { loadAndNormalizeSettings } =
         await import("../../../src/utils/settings-loader");


### PR DESCRIPTION
## Summary
- add an explicit global-refresh completion timestamp and scope-aware refresh status
- show static dashboard status and accessible sidebar refresh details
- archive the #167 plan and add regression coverage

## Validation
- npm run test:unit
- npm run build

Closes #167