### PR TITLE
feat: add retry failed feeds action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- Fixed the All feeds refresh-details popup showing alongside Obsidian's delayed native tooltip. [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168)
 - Fixed refresh-detail tooltip and ghost-popup regressions, and prevented global-refresh vault saves from reloading empty article shards. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
 - Fixed per-feed auto-refresh intervals so Use global, Off, and custom schedules control runtime refresh timing. Failed attempts now wait their configured interval without changing the last successful update time. [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166)
 - Fixed low-resolution fallback hero images being stretched across the Reader by preserving their intrinsic width, centering them, and only scaling them down when needed to fit the available space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Added Shift+click and an All feeds context-menu action to retry failed, non-excluded feeds without advancing the global refresh timestamp. [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168)
 - Added static refresh-status timestamps and accessible refresh details for all feeds, folders, and feeds. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
 - New installations now default global feed auto-refresh to Off.
 - Added automatic and per-feed Windows-1251 decoding for RSS/Atom feeds, including preview and refresh support. New dropdown available in the add/edit feed window > Feed options > Feed Encoding [GH Issue #155](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/155)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -12,6 +12,7 @@ records the complete 2026-08-16 documentation classification.
 | [Documentation archive cleanup](plans/unreleased/169-documentation-archive-cleanup.md) | 2026-08-16 | [GH Issue #169](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/169) | `314ae6f`      |
 | [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) | `5592c39`      |
 | [Refresh status and progress indicators](plans/unreleased/167-refresh-status-indicators.md) | 2026-08-16 | [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167) | `6f767c7`      |
+| [Retry failed feeds](plans/unreleased/168-retry-failed-feeds.md) | 2026-08-17 | [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168) | pending commit |
 | [WordPress LaTeX image rendering](plans/unreleased/wordpress-latex-image-rendering.md) | 2026-08-08 | Unknown                                                                             | `9ce3582`      |
 
 ## Versioned plans

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -12,7 +12,7 @@ records the complete 2026-08-16 documentation classification.
 | [Documentation archive cleanup](plans/unreleased/169-documentation-archive-cleanup.md) | 2026-08-16 | [GH Issue #169](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/169) | `314ae6f`      |
 | [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) | `5592c39`      |
 | [Refresh status and progress indicators](plans/unreleased/167-refresh-status-indicators.md) | 2026-08-16 | [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167) | `6f767c7`      |
-| [Retry failed feeds](plans/unreleased/168-retry-failed-feeds.md) | 2026-08-17 | [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168) | pending commit |
+| [Retry failed feeds](plans/unreleased/168-retry-failed-feeds.md) | 2026-08-17 | [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168) | `9a4968d`      |
 | [WordPress LaTeX image rendering](plans/unreleased/wordpress-latex-image-rendering.md) | 2026-08-08 | Unknown                                                                             | `9ce3582`      |
 
 ## Versioned plans

--- a/docs/archive/document-inventory.md
+++ b/docs/archive/document-inventory.md
@@ -24,7 +24,7 @@ This is the durable audit record for [GH Issue #169](https://github.com/amatya-a
 
 - `docs/archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md` — implemented, awaiting release.
 - `docs/archive/plans/unreleased/167-refresh-status-indicators.md` — implemented, awaiting release.
-- `docs/plans/168-retry-failed-feeds.md` — blocked by issues #166 and #167.
+- `docs/archive/plans/unreleased/168-retry-failed-feeds.md` — implemented, awaiting release.
 - `docs/plans/cover-image-fallback-og-fetch.md` — proposed future work.
 - `docs/plans/deprecate-feed-manager-modal.md` — proposed 3.0 work.
 - `docs/plans/draft-20260816-development-branch-realignment.md` — draft work.

--- a/docs/archive/plans/unreleased/167-refresh-status-indicators.md
+++ b/docs/archive/plans/unreleased/167-refresh-status-indicators.md
@@ -15,7 +15,7 @@ implementation: "6f767c7"
   aggregation, desktop/mobile/popout UI, and accessibility are affected.
 - **Prerequisite:** [Per-feed auto-refresh scheduling fix](166-per-feed-auto-refresh-scheduling.md)
   must be implemented, validated, committed, and archived first.
-- **Next stage:** [Retry failed feeds with Shift+click](../../../plans/168-retry-failed-feeds.md).
+- **Next stage:** [Retry failed feeds with Shift+click](168-retry-failed-feeds.md).
 
 Do not implement this plan against the current global-only scheduler. Begin only
 after the prerequisite's per-feed completion field and orchestration contract

--- a/docs/archive/plans/unreleased/168-retry-failed-feeds.md
+++ b/docs/archive/plans/unreleased/168-retry-failed-feeds.md
@@ -3,7 +3,7 @@ status: implemented
 completed: 2026-08-17
 released_in: unreleased
 issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168
-implementation: ""
+implementation: "9a4968d"
 ---
 
 # Retry Failed Feeds with Shift+Click

--- a/docs/archive/plans/unreleased/168-retry-failed-feeds.md
+++ b/docs/archive/plans/unreleased/168-retry-failed-feeds.md
@@ -1,15 +1,8 @@
 ---
-status: blocked
-owner: unassigned
-created: 2026-08-16
+status: implemented
+completed: 2026-08-17
+released_in: unreleased
 issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168
-milestone: vNext
-workstream: feed-refresh
-sequence: 3
-depends_on:
-  - https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166
-  - https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167
-release_requirement: stretch
 implementation: ""
 ---
 
@@ -17,10 +10,10 @@ implementation: ""
 
 ## Status and scope
 
-- **Status:** Blocked; not implemented.
+- **Status:** Implemented and validated on `feat/168-retry-failed-feeds`.
 - **Classification:** User-visible feature.
 - **Risk:** Medium. The change spans sidebar input and refresh orchestration, but it does not require a new setting, dependency, or persistence schema.
-- **Prerequisites:** [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md) and [Refresh status and progress indicators](../archive/plans/unreleased/167-refresh-status-indicators.md) must each be implemented, validated, committed, and archived first.
+- **Prerequisites:** [Per-feed auto-refresh scheduling fix](../166-per-feed-auto-refresh-scheduling.md) and [Refresh status and progress indicators](../167-refresh-status-indicators.md) were implemented, validated, committed, and archived first.
 - **Sequence:** This is stage 3. Do not implement it in the same change or commit as either prerequisite.
 
 ## Problem

--- a/docs/plans/release-vnext-roadmap.md
+++ b/docs/plans/release-vnext-roadmap.md
@@ -117,7 +117,7 @@ Then implement the refresh work in three separately validated changes:
 
 1. [Per-feed auto-refresh scheduling fix](../archive/plans/unreleased/166-per-feed-auto-refresh-scheduling.md)
 2. [Refresh status and progress indicators](../archive/plans/unreleased/167-refresh-status-indicators.md)
-3. [Retry failed feeds with Shift+click](168-retry-failed-feeds.md)
+3. [Retry failed feeds with Shift+click](../archive/plans/unreleased/168-retry-failed-feeds.md)
 
 Each stage must be implemented, validated, committed, and have its plan moved
 according to the repository plan lifecycle before implementation starts on the

--- a/main.ts
+++ b/main.ts
@@ -1189,7 +1189,9 @@ export default class RssDashboardPlugin extends Plugin {
 
   async refreshFeeds(
     selectedFeeds?: Feed[],
-    intent: "global" | "targeted" | "due" = selectedFeeds ? "targeted" : "global",
+    intent: "global" | "targeted" | "due" | "failed" = selectedFeeds
+      ? "targeted"
+      : "global",
   ) {
     try {
       const candidateFeeds = selectedFeeds || this.settings.feeds;
@@ -1234,7 +1236,7 @@ export default class RssDashboardPlugin extends Plugin {
       await this.refreshFeedBatch(
         feedsToRefresh,
         feedNoticeText,
-        intent === "global",
+        intent,
       );
     } catch (error) {
       console.error(`[RSS dashboard] Error refreshing feeds:`, error);
@@ -1242,6 +1244,19 @@ export default class RssDashboardPlugin extends Plugin {
         `Error refreshing  ${error instanceof Error ? error.message : "Unknown error"}`,
       );
     }
+  }
+
+  async refreshFailedFeeds(): Promise<void> {
+    const failedFeeds = this.settings.feeds.filter(
+      (feed) => Boolean(feed.lastFetchError) && !this.isFeedExcludedFromRefresh(feed),
+    );
+
+    if (failedFeeds.length === 0) {
+      new Notice("No failed feeds to retry.");
+      return;
+    }
+
+    await this.refreshFeeds(failedFeeds, "failed");
   }
 
   /**
@@ -2717,7 +2732,7 @@ export default class RssDashboardPlugin extends Plugin {
   private async refreshFeedBatch(
     feedsToRefresh: Feed[],
     feedNoticeText: string,
-    isExplicitGlobalRefresh: boolean,
+    intent: "global" | "targeted" | "due" | "failed",
   ): Promise<void> {
     if (this.isMultiFeedRefreshRunning) {
       new Notice("A multi-feed refresh is already in progress.");
@@ -2808,7 +2823,7 @@ export default class RssDashboardPlugin extends Plugin {
       await Promise.all(backgroundPromises);
 
       await this.validateSavedArticles();
-      if (isExplicitGlobalRefresh) {
+      if (intent === "global") {
         this.settings.lastGlobalRefreshCompletedAt = Date.now();
       }
       await this.saveSettings();
@@ -2820,7 +2835,10 @@ export default class RssDashboardPlugin extends Plugin {
         view.refresh();
       }
 
-      const failureSuffix = this.buildRefreshFailureSummary(refreshSummary);
+      const failureSuffix = this.buildRefreshFailureSummary(
+        refreshSummary,
+        intent === "global",
+      );
       new Notice(`Feeds refreshed: ${feedNoticeText}${failureSuffix}`);
     } finally {
       this.activeRefreshState.clear();
@@ -2829,10 +2847,10 @@ export default class RssDashboardPlugin extends Plugin {
     }
   }
 
-  private buildRefreshFailureSummary(summary: {
-    failed: number;
-    timedOut: number;
-  }): string {
+  private buildRefreshFailureSummary(
+    summary: { failed: number; timedOut: number },
+    includeRetryHint: boolean,
+  ): string {
     const parts: string[] = [];
     if (summary.timedOut > 0) {
       parts.push(`${summary.timedOut} timed out`);
@@ -2845,7 +2863,10 @@ export default class RssDashboardPlugin extends Plugin {
       return "";
     }
 
-    return ` (${parts.join(", ")})`;
+    const suffix = ` (${parts.join(", ")})`;
+    return includeRetryHint
+      ? `${suffix} Shift+click Refresh all feeds to retry failed feeds.`
+      : suffix;
   }
 
   private async processRefreshBatchFeed(

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -1019,8 +1019,6 @@ export class Sidebar {
         "rss-dashboard-all-feeds-icon" + (isRefreshActive ? " refreshing" : ""),
       attr: {
         "aria-labelledby": refreshLabelId,
-        "aria-label": "Refresh all feeds. Shift+click to retry failed feeds.",
-        title: "Refresh all feeds. Shift+click to retry failed feeds.",
       },
     });
     setIcon(feedIcon, "refresh-cw");

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -999,7 +999,6 @@ export class Sidebar {
       cls: "rss-dashboard-all-feeds-button" + (isAllActive ? " active" : ""),
     });
     allFeedsButton.setAttr("tabindex", "-1");
-    this.attachRefreshDetails(allFeedsButton, this.settings.feeds, "all");
     this.registerSidebarRow({ type: "all-feeds" }, allFeedsButton);
     const isRefreshActive =
       this.plugin.isMultiFeedRefreshActive ||
@@ -1021,6 +1020,7 @@ export class Sidebar {
         "aria-labelledby": refreshLabelId,
       },
     });
+    this.attachRefreshDetails(feedIcon, this.settings.feeds, "all");
     setIcon(feedIcon, "refresh-cw");
     feedIcon.addEventListener("click", (e) => {
       e.stopPropagation();

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -96,6 +96,7 @@ export interface SidebarCallbacks {
   onDeleteFeed: (feed: Feed) => void;
   onDeleteFolder: (folder: string) => void;
   onRefreshFeeds: () => Promise<void> | void;
+  onRetryFailedFeeds?: () => Promise<void> | void;
   onUpdateFeed: (feed: Feed) => Promise<void>;
   onImportOpml: () => void;
   onExportOpml: () => void;
@@ -1010,7 +1011,7 @@ export class Sidebar {
       .slice(2)}`;
     allFeedsButton.createSpan({
       cls: "rss-dashboard-refresh-details-sr-only",
-      text: "Refresh all feeds",
+      text: "Refresh all feeds. Shift+click to retry failed feeds.",
       attr: { id: refreshLabelId },
     });
     const feedIcon = allFeedsButton.createDiv({
@@ -1018,13 +1019,15 @@ export class Sidebar {
         "rss-dashboard-all-feeds-icon" + (isRefreshActive ? " refreshing" : ""),
       attr: {
         "aria-labelledby": refreshLabelId,
+        "aria-label": "Refresh all feeds. Shift+click to retry failed feeds.",
+        title: "Refresh all feeds. Shift+click to retry failed feeds.",
       },
     });
     setIcon(feedIcon, "refresh-cw");
     feedIcon.addEventListener("click", (e) => {
       e.stopPropagation();
       if (this.plugin.isMultiFeedRefreshActive) return;
-      void this.handleRefresh();
+      void this.handleRefresh(e);
     });
 
     // Label with count
@@ -1091,6 +1094,15 @@ export class Sidebar {
         .setIcon("refresh-cw")
         .onClick(() => {
           void this.callbacks.onRefreshFeeds();
+        });
+    });
+    menu.addItem((item: MenuItem) => {
+      item
+        .setTitle("Retry failed feeds")
+        .setIcon("refresh-cw")
+        .onClick(() => {
+          if (this.plugin.isMultiFeedRefreshActive) return;
+          void this.callbacks.onRetryFailedFeeds?.();
         });
     });
 
@@ -4092,9 +4104,13 @@ export class Sidebar {
     this.render();
   }
 
-  private async handleRefresh(): Promise<void> {
+  private async handleRefresh(event?: MouseEvent): Promise<void> {
     if (this.plugin.isMultiFeedRefreshActive) return;
     this.plugin.cancelPendingStartupRefresh();
+    if (event?.shiftKey) {
+      await this.plugin.refreshFailedFeeds();
+      return;
+    }
     await this.plugin.refreshFeeds();
   }
 

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -448,6 +448,23 @@ export class Sidebar {
     );
   }
 
+  private attachRefreshActionDetails(row: HTMLElement): void {
+    const actionText =
+      "Refresh all feeds. Shift+click to retry failed feeds.";
+    this.refreshStatusDetailCleanups.push(
+      attachRefreshStatusDetails({
+        row,
+        description: () => actionText,
+        render: (popup) => {
+          popup.createDiv({
+            cls: "rss-dashboard-refresh-details-line",
+            text: actionText,
+          });
+        },
+      }),
+    );
+  }
+
   private showRefreshDetails(
     anchor: HTMLElement,
     feeds: Feed[],
@@ -999,6 +1016,7 @@ export class Sidebar {
       cls: "rss-dashboard-all-feeds-button" + (isAllActive ? " active" : ""),
     });
     allFeedsButton.setAttr("tabindex", "-1");
+    this.attachRefreshActionDetails(allFeedsButton);
     this.registerSidebarRow({ type: "all-feeds" }, allFeedsButton);
     const isRefreshActive =
       this.plugin.isMultiFeedRefreshActive ||
@@ -1020,7 +1038,6 @@ export class Sidebar {
         "aria-labelledby": refreshLabelId,
       },
     });
-    this.attachRefreshDetails(feedIcon, this.settings.feeds, "all");
     setIcon(feedIcon, "refresh-cw");
     feedIcon.addEventListener("click", (e) => {
       e.stopPropagation();

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -806,6 +806,7 @@ export class RssDashboardView extends ItemView {
           onDeleteFeed: this.handleDeleteFeed.bind(this),
           onDeleteFolder: this.handleDeleteFolder.bind(this),
           onRefreshFeeds: this.handleRefreshFeeds.bind(this),
+          onRetryFailedFeeds: this.handleRetryFailedFeeds.bind(this),
           onUpdateFeed: this.handleUpdateFeed.bind(this),
           onImportOpml: this.handleImportOpml.bind(this),
           onExportOpml: this.handleExportOpml.bind(this),
@@ -2496,6 +2497,11 @@ export class RssDashboardView extends ItemView {
       this.plugin.cancelPendingStartupRefresh();
       await this.plugin.refreshFeeds();
     }
+  }
+
+  private async handleRetryFailedFeeds(): Promise<void> {
+    this.plugin.cancelPendingStartupRefresh();
+    await this.plugin.refreshFailedFeeds();
   }
 
   private handleImportOpml(): void {

--- a/test_files/stubs/obsidian.ts
+++ b/test_files/stubs/obsidian.ts
@@ -765,10 +765,19 @@ export class ItemView extends Component {
 }
 
 export class Menu {
+  static lastItems: MenuItem[] = [];
+
+  constructor() {
+    Menu.lastItems = [];
+  }
+
   addSeparator(): this {
     return this;
   }
-  addItem(_cb: (item: MenuItem) => void): this {
+  addItem(cb: (item: MenuItem) => void): this {
+    const item = new MenuItem();
+    cb(item);
+    Menu.lastItems.push(item);
     return this;
   }
   showAtPosition(): void {}
@@ -776,14 +785,23 @@ export class Menu {
 }
 
 export class MenuItem {
-  setTitle(): this {
+  title = "";
+  callback: ((evt: MouseEvent) => unknown) | undefined;
+
+  setTitle(title: string): this {
+    this.title = title;
     return this;
   }
   setIcon(): this {
     return this;
   }
-  onClick(_cb: (evt: any) => any): this {
+  onClick(cb: (evt: MouseEvent) => unknown): this {
+    this.callback = cb;
     return this;
+  }
+
+  trigger(): unknown {
+    return this.callback?.(new MouseEvent("click"));
   }
 }
 

--- a/test_files/unit/components/sidebar-core.test.ts
+++ b/test_files/unit/components/sidebar-core.test.ts
@@ -463,10 +463,10 @@ describe("Sidebar Core", () => {
       const icon = container.querySelector(
         ".rss-dashboard-all-feeds-icon",
       ) as HTMLElement;
-      expect(icon.getAttribute("title")).toBe(
-        "Refresh all feeds. Shift+click to retry failed feeds.",
-      );
-      expect(icon.getAttribute("aria-label")).toBe(
+      expect(icon.hasAttribute("title")).toBe(false);
+      expect(icon.hasAttribute("aria-label")).toBe(false);
+      const labelId = icon.getAttribute("aria-labelledby") ?? "";
+      expect(container.querySelector(`#${labelId}`)?.textContent).toBe(
         "Refresh all feeds. Shift+click to retry failed feeds.",
       );
 

--- a/test_files/unit/components/sidebar-core.test.ts
+++ b/test_files/unit/components/sidebar-core.test.ts
@@ -36,6 +36,10 @@ interface TestPlugin extends Partial<RssDashboardPlugin> {
   saveSettings: Mock<() => Promise<void>>;
   activeRefreshState?: Map<string, FeedRefreshState>;
   backgroundImportQueue?: FeedMetadata[];
+  refreshFeeds: Mock<() => Promise<void>>;
+  refreshFailedFeeds: Mock<() => Promise<void>>;
+  cancelPendingStartupRefresh: Mock<() => void>;
+  isMultiFeedRefreshActive?: boolean;
 }
 
 /** Typed interface for Sidebar private member access */
@@ -121,7 +125,11 @@ describe("Sidebar Core", () => {
     plugin = {
       settings,
       saveSettings: vi.fn().mockResolvedValue(undefined),
+      refreshFeeds: vi.fn().mockResolvedValue(undefined),
+      refreshFailedFeeds: vi.fn().mockResolvedValue(undefined),
+      cancelPendingStartupRefresh: vi.fn(),
     };
+    callbacks.onRetryFailedFeeds = plugin.refreshFailedFeeds;
   });
 
   it("should initialize with correct properties", () => {
@@ -432,6 +440,69 @@ describe("Sidebar Core", () => {
         queuedEl?.querySelector(".rss-dashboard-feed-processing-indicator")
           ?.textContent,
       ).toContain("⏳");
+    });
+
+    it("uses plain click for global refresh and Shift+click for failed-feed retry", () => {
+      settings.feeds = [
+        createFeed({ lastFetchError: "network down" }),
+        createFeed({
+          title: "Feed B",
+          url: "https://example.com/b.xml",
+        }),
+      ];
+      const sidebar = new Sidebar(
+        app,
+        container,
+        plugin as unknown as RssDashboardPlugin,
+        settings,
+        options,
+        callbacks,
+      );
+
+      sidebar.render();
+      const icon = container.querySelector(
+        ".rss-dashboard-all-feeds-icon",
+      ) as HTMLElement;
+      expect(icon.getAttribute("title")).toBe(
+        "Refresh all feeds. Shift+click to retry failed feeds.",
+      );
+      expect(icon.getAttribute("aria-label")).toBe(
+        "Refresh all feeds. Shift+click to retry failed feeds.",
+      );
+
+      icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      icon.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, shiftKey: true }),
+      );
+
+      expect(plugin.refreshFeeds).toHaveBeenCalledTimes(1);
+      expect(plugin.refreshFailedFeeds).toHaveBeenCalledTimes(1);
+    });
+
+    it("exposes failed-feed retry from the all-feeds context menu", () => {
+      const sidebar = new Sidebar(
+        app,
+        container,
+        plugin as unknown as RssDashboardPlugin,
+        settings,
+        options,
+        callbacks,
+      );
+      sidebar.render();
+
+      const allFeedsButton = container.querySelector(
+        ".rss-dashboard-all-feeds-button",
+      ) as HTMLElement;
+      allFeedsButton.dispatchEvent(
+        new MouseEvent("contextmenu", { bubbles: true }),
+      );
+
+      const retryItem = ObsidianStubs.Menu.lastItems.find(
+        (item) => item.title === "Retry failed feeds",
+      );
+      expect(retryItem).toBeDefined();
+      retryItem?.trigger();
+      expect(plugin.refreshFailedFeeds).toHaveBeenCalledTimes(1);
     });
 
     it("prefers import processing visuals over refresh visuals when both exist", () => {

--- a/test_files/unit/components/sidebar-rendering.test.ts
+++ b/test_files/unit/components/sidebar-rendering.test.ts
@@ -157,6 +157,29 @@ describe("Sidebar Rendering", () => {
     );
   });
 
+  it("keeps the custom refresh-details popup on hover", async () => {
+    vi.useFakeTimers();
+    document.body.appendChild(container);
+    const sidebar = new Sidebar(
+      app as unknown as import("obsidian").App,
+      container,
+      plugin as unknown as RssDashboardPlugin,
+      settings,
+      options,
+      callbacks,
+    );
+    sidebar.render();
+
+    const refreshIcon = container.querySelector<HTMLElement>(
+      ".rss-dashboard-all-feeds-icon",
+    );
+    expect(refreshIcon).not.toBeNull();
+    refreshIcon?.dispatchEvent(new MouseEvent("mouseenter"));
+    await vi.advanceTimersByTimeAsync(350);
+
+    expect(document.body.querySelector(".rss-dashboard-refresh-details")).not.toBeNull();
+  });
+
   it("should show unread badge for All Feeds if at least one unread item exists", () => {
     const sidebar = new Sidebar(
       app as unknown as import("obsidian").App,

--- a/test_files/unit/components/sidebar-rendering.test.ts
+++ b/test_files/unit/components/sidebar-rendering.test.ts
@@ -135,7 +135,7 @@ describe("Sidebar Rendering", () => {
     expect(allFeedsBtn?.textContent).toContain("All Feeds");
   });
 
-  it("keeps the refresh icon accessible without a competing native tooltip", () => {
+  it("communicates both refresh actions through accessible text and the tooltip", () => {
     const sidebar = new Sidebar(
       app as unknown as import("obsidian").App,
       container,
@@ -149,11 +149,15 @@ describe("Sidebar Rendering", () => {
     const refreshIcon = container.querySelector<HTMLElement>(
       ".rss-dashboard-all-feeds-icon",
     );
-    expect(refreshIcon?.hasAttribute("aria-label")).toBe(false);
-    expect(refreshIcon?.hasAttribute("title")).toBe(false);
+    expect(refreshIcon?.getAttribute("aria-label")).toBe(
+      "Refresh all feeds. Shift+click to retry failed feeds.",
+    );
+    expect(refreshIcon?.getAttribute("title")).toBe(
+      "Refresh all feeds. Shift+click to retry failed feeds.",
+    );
     const labelId = refreshIcon?.getAttribute("aria-labelledby") ?? "";
     expect(document.getElementById(labelId)?.textContent).toBe(
-      "Refresh all feeds",
+      "Refresh all feeds. Shift+click to retry failed feeds.",
     );
   });
 

--- a/test_files/unit/components/sidebar-rendering.test.ts
+++ b/test_files/unit/components/sidebar-rendering.test.ts
@@ -170,14 +170,16 @@ describe("Sidebar Rendering", () => {
     );
     sidebar.render();
 
-    const refreshIcon = container.querySelector<HTMLElement>(
-      ".rss-dashboard-all-feeds-icon",
+    const allFeedsButton = container.querySelector<HTMLElement>(
+      ".rss-dashboard-all-feeds-button",
     );
-    expect(refreshIcon).not.toBeNull();
-    refreshIcon?.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(allFeedsButton).not.toBeNull();
+    allFeedsButton?.dispatchEvent(new MouseEvent("mouseenter"));
     await vi.advanceTimersByTimeAsync(350);
 
-    expect(document.body.querySelector(".rss-dashboard-refresh-details")).not.toBeNull();
+    expect(
+      document.body.querySelector(".rss-dashboard-refresh-details")?.textContent,
+    ).toBe("Refresh all feeds. Shift+click to retry failed feeds.");
   });
 
   it("should show unread badge for All Feeds if at least one unread item exists", () => {

--- a/test_files/unit/components/sidebar-rendering.test.ts
+++ b/test_files/unit/components/sidebar-rendering.test.ts
@@ -135,7 +135,7 @@ describe("Sidebar Rendering", () => {
     expect(allFeedsBtn?.textContent).toContain("All Feeds");
   });
 
-  it("communicates both refresh actions through accessible text and the tooltip", () => {
+  it("communicates both refresh actions without a competing native tooltip", () => {
     const sidebar = new Sidebar(
       app as unknown as import("obsidian").App,
       container,
@@ -149,12 +149,8 @@ describe("Sidebar Rendering", () => {
     const refreshIcon = container.querySelector<HTMLElement>(
       ".rss-dashboard-all-feeds-icon",
     );
-    expect(refreshIcon?.getAttribute("aria-label")).toBe(
-      "Refresh all feeds. Shift+click to retry failed feeds.",
-    );
-    expect(refreshIcon?.getAttribute("title")).toBe(
-      "Refresh all feeds. Shift+click to retry failed feeds.",
-    );
+    expect(refreshIcon?.hasAttribute("aria-label")).toBe(false);
+    expect(refreshIcon?.hasAttribute("title")).toBe(false);
     const labelId = refreshIcon?.getAttribute("aria-labelledby") ?? "";
     expect(document.getElementById(labelId)?.textContent).toBe(
       "Refresh all feeds. Shift+click to retry failed feeds.",

--- a/test_files/unit/main/feed-refresh-pipeline.test.ts
+++ b/test_files/unit/main/feed-refresh-pipeline.test.ts
@@ -65,6 +65,7 @@ interface TestPlugin {
   saveData: ReturnType<typeof vi.fn>;
   feedParser: TestFeedParser;
   refreshFeeds: (selectedFeeds?: Feed[]) => Promise<void>;
+  refreshFailedFeeds: () => Promise<void>;
   activeRefreshState: Map<string, unknown>;
   getActiveDashboardView: ReturnType<typeof vi.fn>;
   validateSavedArticles: ReturnType<typeof vi.fn>;
@@ -115,6 +116,79 @@ beforeEach(() => {
 });
 
 describe("refreshFeeds() pipeline behavior", () => {
+  it("retries the current failed, non-excluded feeds and includes feeds with automatic refresh off", async () => {
+    const failed = createFeed({
+      title: "Failed Feed",
+      url: "https://example.com/failed.xml",
+      lastFetchError: "network down",
+      scanInterval: 0,
+    });
+    const excluded = createFeed({
+      title: "Excluded Failed Feed",
+      url: "https://example.com/excluded.xml",
+      lastFetchError: "network down",
+      excludeFromRefresh: true,
+    });
+    const healthy = createFeed({
+      title: "Healthy Feed",
+      url: "https://example.com/healthy.xml",
+    });
+    const plugin = createPluginWithSettings([failed, excluded, healthy]);
+    const refreshSpy = vi
+      .spyOn(plugin, "refreshFeeds")
+      .mockResolvedValue(undefined);
+
+    await plugin.refreshFailedFeeds();
+
+    expect(refreshSpy).toHaveBeenCalledWith([failed], "failed");
+  });
+
+  it("shows an empty-state notice without starting a retry when no eligible failures exist", async () => {
+    const excluded = createFeed({
+      lastFetchError: "network down",
+      excludeFromRefresh: true,
+    });
+    const plugin = createPluginWithSettings([createFeed(), excluded]);
+    const refreshSpy = vi.spyOn(plugin, "refreshFeeds");
+
+    await plugin.refreshFailedFeeds();
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(plugin.feedParser.refreshFeed).not.toHaveBeenCalled();
+    expect(getNoticeMessages(consoleLogSpy)).toContain(
+      "No failed feeds to retry.",
+    );
+  });
+
+  it("keeps global completion unchanged while successful and repeated failed retries update their errors", async () => {
+    const recovered = createFeed({
+      url: "https://example.com/recovered.xml",
+      lastFetchError: "network down",
+    });
+    const stillFailing = createFeed({
+      url: "https://example.com/still-failing.xml",
+      lastFetchError: "old error",
+    });
+    const plugin = createPluginWithSettings([recovered, stillFailing]);
+    plugin.settings.lastGlobalRefreshCompletedAt = 123;
+    (plugin.feedParser.refreshFeed as unknown as {
+      mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+    }).mockImplementation(async (feed) => {
+      if (feed.url === stillFailing.url) {
+        throw new Error("new error");
+      }
+      return { ...feed, lastFetchError: undefined };
+    });
+
+    await plugin.refreshFailedFeeds();
+
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBe(123);
+    expect(plugin.settings.feeds[0].lastFetchError).toBeUndefined();
+    expect(plugin.settings.feeds[1].lastFetchError).toBe("new error");
+    expect(plugin.settings.feeds[0].lastRefreshAttemptCompletedAt).toBeDefined();
+    expect(plugin.settings.feeds[1].lastRefreshAttemptCompletedAt).toBeDefined();
+  });
+
   it("records global completion after an explicit all-feeds refresh even when one attempt fails", async () => {
     const successful = createFeed({ url: "https://example.com/one.xml" });
     const failing = createFeed({ url: "https://example.com/two.xml" });
@@ -287,6 +361,9 @@ describe("refreshFeeds() pipeline behavior", () => {
     const notices = getNoticeMessages(consoleLogSpy);
     expect(notices[0]).toBe("Refreshing 5 feeds...");
     expect(notices).toContain("Feeds refreshed: 5 feeds");
+    expect(notices.some((notice) => notice.includes("Shift+click"))).toBe(
+      false,
+    );
   });
 
   it("refreshes a single feed via the direct path and does not require an active dashboard view", async () => {
@@ -369,7 +446,9 @@ describe("refreshFeeds() pipeline behavior", () => {
 
     const notices = getNoticeMessages(consoleLogSpy);
     expect(notices[0]).toBe("Refreshing 2 feeds...");
-    expect(notices).toContain("Feeds refreshed: 2 feeds (1 timed out)");
+    expect(notices).toContain(
+      "Feeds refreshed: 2 feeds (1 timed out) Shift+click Refresh all feeds to retry failed feeds.",
+    );
   });
 
   it("swallows direct refresh errors and shows an error Notice", async () => {


### PR DESCRIPTION
  Closes #168

  ### Summary

  - Add Shift+click retry for failed, non-excluded feeds.
  - Add Retry failed feeds to the All feeds context menu.
  - Preserve the existing refresh pipeline, progress state, persistence, error handling, and per-feed timestamps.
  - Keep automatic-refresh Off feeds eligible for manual retry.
  - Avoid advancing the global refresh timestamp for failed-only retries.
  - Show the custom All feeds tooltip:
    “Refresh all feeds. Shift+click to retry failed feeds.”

  - Suppress Obsidian’s competing native tooltip.

  ### Validation

  - 190 test files passed
  - 1,659 unit tests passed
  - ESLint passed
  - Platform compatibility checks passed
  - TypeScript check passed
  - Production build passed