### PR TITLE
feat: Added a Stop button on the All feeds sidebar row during global …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Added a Stop button on the All feeds sidebar row during global refreshes, allowing users to cancel an in-progress refresh, including when only one eligible feed remains. Cancelled feeds do not advance their refresh timestamps, and in-progress fetches are aborted via an AbortSignal. Failed-feed retries and folder/selected/tag/due refreshes remain non-cancellable. [GH Issue #173](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/173)
 - Added Shift+click and an All feeds context-menu action to retry failed, non-excluded feeds without advancing the global refresh timestamp. [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168)
 - Added static refresh-status timestamps and accessible refresh details for all feeds, folders, and feeds. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
 - New installations now default global feed auto-refresh to Off.
@@ -12,6 +13,7 @@
 
 ### Fixes
 
+- Fixed sidebar icon visibility settings displaying `[object DocumentFragment]` instead of each icon's name.
 - Fixed the All feeds refresh-details popup showing alongside Obsidian's delayed native tooltip. [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168)
 - Fixed refresh-detail tooltip and ghost-popup regressions, and prevented global-refresh vault saves from reloading empty article shards. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)
 - Fixed per-feed auto-refresh intervals so Use global, Off, and custom schedules control runtime refresh timing. Failed attempts now wait their configured interval without changing the last successful update time. [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -13,6 +13,7 @@ records the complete 2026-08-16 documentation classification.
 | [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) | `5592c39`      |
 | [Refresh status and progress indicators](plans/unreleased/167-refresh-status-indicators.md) | 2026-08-16 | [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167) | `6f767c7`      |
 | [Retry failed feeds](plans/unreleased/168-retry-failed-feeds.md) | 2026-08-17 | [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168) | `9a4968d`      |
+| [Cancellable global refresh](plans/unreleased/173-cancel-global-refresh.md) | 2026-08-19 | [GH Issue #173](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/173) | —              |
 | [WordPress LaTeX image rendering](plans/unreleased/wordpress-latex-image-rendering.md) | 2026-08-08 | Unknown                                                                             | `9ce3582`      |
 
 ## Versioned plans

--- a/docs/archive/plans/unreleased/173-cancel-global-refresh.md
+++ b/docs/archive/plans/unreleased/173-cancel-global-refresh.md
@@ -1,13 +1,8 @@
 ---
-status: proposed
-created: 2026-08-17
+status: implemented
+completed: 2026-08-19
+released_in: unreleased
 issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/173
-milestone: vNext
-owner: unassigned
-workstream: refresh
-sequence: null
-depends_on: []
-release_requirement: stretch
 implementation: ""
 ---
 
@@ -24,7 +19,8 @@ been fetched.
 ## Proposed behavior
 
 - A global refresh can be cancelled regardless of whether it was started
-  manually, during startup, or by the automatic global schedule.
+  manually, during startup, or by the automatic global schedule, including
+  when only one eligible feed remains after exclusions.
 - While a global refresh is active, the All feeds row remains selectable and
   its refresh area becomes a progress row showing completed versus targeted
   feeds.
@@ -36,8 +32,8 @@ been fetched.
   underlying request cannot abort immediately.
 - The interface returns to the normal All feeds state and shows a concise
   “Refresh stopped” notice.
-- Single-feed, folder, selected-feed, due-subset, and failed-only refreshes are
-  outside this control's cancellation scope.
+- Direct single-feed, folder, selected-feed, due-subset, and failed-only
+  refreshes are outside this control's cancellation scope.
 
 ## Acceptance criteria
 
@@ -57,22 +53,29 @@ been fetched.
    network failure.
 8. Existing refresh, timeout, retry-failed, status-indicator, and persistence
    behavior remains unchanged when cancellation is not requested.
+9. An abort-triggered parser rejection does not set or persist
+   `lastFetchError`; cancellation is not presented as a feed failure.
+10. A global operation is cancellable even when it targets exactly one eligible
+    feed, while a due-subset operation remains non-cancellable.
 
 ## Implementation direction
 
 - Extend the centralized refresh orchestration in `main.ts` with cancellation
-  state for the active global operation and a cancellation boundary that
-  prevents late results from being committed.
+  state for every active global operation (including the one-feed path) and a
+  cancellation boundary that prevents late results and abort errors from being
+  committed.
 - Thread a caller-owned abort signal through the multi-feed refresh path and
   feed parser fetch path, while retaining each feed's timeout handling.
 - Expose enough observable global progress/cancellation state for
-  `src/components/sidebar.ts` to render the progress row and Stop action.
+  `src/components/sidebar.ts` to render the progress row and a keyboard- and
+  touch-operable Stop button.
 - Update the owning styles in `src/styles/` with scoped progress, focus, touch,
   and destructive-state treatment; do not use `!important`.
 - Extend the existing refresh pipeline and sidebar rendering tests under
   `test_files/unit/main/` and `test_files/unit/components/` with behavior-level
-  coverage for cancellation, partial persistence, late responses, accessibility
-  state, and row selection.
+  coverage for cancellation, partial persistence, abort-error persistence, late
+  responses, keyboard accessibility, one-feed global refreshes, due-subset
+  exclusion, and row selection.
 
 ## Validation and manual checks
 
@@ -111,3 +114,13 @@ refresh-status or scheduling foundations to function.
   operations, but not due-subset or other scoped batches.
 - Stop means no post-cancellation feed mutation; already committed results are
   authoritative and are not rolled back.
+
+## Review follow-up (2026-08-19)
+
+Implementation review identified four release-blocking regressions: the Stop
+action had to be keyboard-operable; aborted requests could not persist
+`lastFetchError`; a global refresh with one eligible feed had to use the
+cancellable path; and due-subset refreshes had to remain outside the
+cancellation scope. These corrections were completed and validated under
+Beads item `obsidian-rss-dashboard-gyj`, retaining GitHub issue #173 as their
+canonical external reference.

--- a/main.ts
+++ b/main.ts
@@ -271,6 +271,10 @@ export default class RssDashboardPlugin extends Plugin {
   public activeRefreshState = new Map<string, FeedRefreshState>();
   public settingTab: RssDashboardSettingTab | null = null;
   private isMultiFeedRefreshRunning = false;
+  private isGlobalRefreshCancelled = false;
+  private globalRefreshAbortController: AbortController | null = null;
+  private globalRefreshTotal = 0;
+  private globalRefreshCompleted = 0;
   public vaultAbsolutePath = "";
   private hasCompletedStartupSavedArticleValidation = false;
   private vaultMetadataReloadTimer: number | null = null;
@@ -490,6 +494,27 @@ export default class RssDashboardPlugin extends Plugin {
     return this.isMultiFeedRefreshRunning;
   }
 
+  public get isGlobalRefreshCancellable(): boolean {
+    return (
+      this.isMultiFeedRefreshRunning &&
+      this.globalRefreshAbortController !== null
+    );
+  }
+
+  public get globalRefreshProgress(): { completed: number; total: number } {
+    return {
+      completed: this.globalRefreshCompleted,
+      total: this.globalRefreshTotal,
+    };
+  }
+
+  public cancelGlobalRefresh(): void {
+    if (!this.isGlobalRefreshCancellable) return;
+    this.isGlobalRefreshCancelled = true;
+    this.globalRefreshAbortController?.abort();
+    new Notice("Refresh stopped.");
+  }
+
   public notifyFiltersUpdated(payload: FiltersUpdatedEventPayload): void {
     this.app.workspace.trigger("rss-dashboard:filters-updated", payload);
   }
@@ -628,7 +653,6 @@ export default class RssDashboardPlugin extends Plugin {
     if (view) {
       view.render();
     }
-
 
     try {
       this.initializeSettingsBackedServices();
@@ -1224,20 +1248,16 @@ export default class RssDashboardPlugin extends Plugin {
       }
 
       new Notice(`Refreshing ${feedNoticeText}...`);
-      if (feedsToRefresh.length === 1) {
+      if (feedsToRefresh.length === 1 && intent !== "global") {
         await this.refreshSingleFeed(
           feedsToRefresh[0],
           feedNoticeText,
-          intent === "global",
+          false,
         );
         return;
       }
 
-      await this.refreshFeedBatch(
-        feedsToRefresh,
-        feedNoticeText,
-        intent,
-      );
+      await this.refreshFeedBatch(feedsToRefresh, feedNoticeText, intent);
     } catch (error) {
       console.error(`[RSS dashboard] Error refreshing feeds:`, error);
       new Notice(
@@ -1248,7 +1268,8 @@ export default class RssDashboardPlugin extends Plugin {
 
   async refreshFailedFeeds(): Promise<void> {
     const failedFeeds = this.settings.feeds.filter(
-      (feed) => Boolean(feed.lastFetchError) && !this.isFeedExcludedFromRefresh(feed),
+      (feed) =>
+        Boolean(feed.lastFetchError) && !this.isFeedExcludedFromRefresh(feed),
     );
 
     if (failedFeeds.length === 0) {
@@ -2741,6 +2762,19 @@ export default class RssDashboardPlugin extends Plugin {
 
     this.isMultiFeedRefreshRunning = true;
     this.activeRefreshState.clear();
+
+    const isCancellableIntent = intent === "global";
+    if (isCancellableIntent) {
+      this.globalRefreshAbortController = new AbortController();
+      this.isGlobalRefreshCancelled = false;
+      this.globalRefreshTotal = feedsToRefresh.length;
+      this.globalRefreshCompleted = 0;
+    } else {
+      this.globalRefreshAbortController = null;
+      this.isGlobalRefreshCancelled = false;
+    }
+    const cancelSignal = this.globalRefreshAbortController?.signal;
+
     const refreshSummary = {
       failed: 0,
       timedOut: 0,
@@ -2785,6 +2819,11 @@ export default class RssDashboardPlugin extends Plugin {
       while (true) {
         await globalFetchSemaphore.acquire();
 
+        if (this.isGlobalRefreshCancelled) {
+          globalFetchSemaphore.release();
+          return;
+        }
+
         const currentFeed = feedsToRefresh[nextFeedIndex];
         nextFeedIndex += 1;
         if (!currentFeed) {
@@ -2796,6 +2835,7 @@ export default class RssDashboardPlugin extends Plugin {
           currentFeed,
           refreshSummary,
           refreshView,
+          cancelSignal,
         ).finally(() => {
           globalFetchSemaphore.release();
         });
@@ -2811,10 +2851,7 @@ export default class RssDashboardPlugin extends Plugin {
       }
     };
 
-    const workerCount = Math.min(
-      MAX_CONCURRENT_FETCHES,
-      feedsToRefresh.length,
-    );
+    const workerCount = Math.min(MAX_CONCURRENT_FETCHES, feedsToRefresh.length);
 
     try {
       const workers = Array.from({ length: workerCount }, () => worker());
@@ -2823,7 +2860,7 @@ export default class RssDashboardPlugin extends Plugin {
       await Promise.all(backgroundPromises);
 
       await this.validateSavedArticles();
-      if (intent === "global") {
+      if (intent === "global" && !this.isGlobalRefreshCancelled) {
         this.settings.lastGlobalRefreshCompletedAt = Date.now();
       }
       await this.saveSettings();
@@ -2835,14 +2872,20 @@ export default class RssDashboardPlugin extends Plugin {
         view.refresh();
       }
 
-      const failureSuffix = this.buildRefreshFailureSummary(
-        refreshSummary,
-        intent === "global",
-      );
-      new Notice(`Feeds refreshed: ${feedNoticeText}${failureSuffix}`);
+      if (!this.isGlobalRefreshCancelled) {
+        const failureSuffix = this.buildRefreshFailureSummary(
+          refreshSummary,
+          intent === "global",
+        );
+        new Notice(`Feeds refreshed: ${feedNoticeText}${failureSuffix}`);
+      }
     } finally {
       this.activeRefreshState.clear();
       this.isMultiFeedRefreshRunning = false;
+      this.globalRefreshAbortController = null;
+      this.isGlobalRefreshCancelled = false;
+      this.globalRefreshTotal = 0;
+      this.globalRefreshCompleted = 0;
       await this.notifyRefreshStatusChanged();
     }
   }
@@ -2873,6 +2916,7 @@ export default class RssDashboardPlugin extends Plugin {
     currentFeed: Feed,
     refreshSummary: { failed: number; timedOut: number },
     refreshView: () => Promise<void>,
+    signal?: AbortSignal,
   ): Promise<void> {
     this.activeRefreshState.set(currentFeed.url, {
       status: "processing",
@@ -2880,10 +2924,18 @@ export default class RssDashboardPlugin extends Plugin {
     });
 
     try {
-      const updatedFeed = await this.refreshFeedWithTimeout(currentFeed);
-      this.finalizeRefreshAttempt(currentFeed, updatedFeed);
+      const updatedFeed = await this.refreshFeedWithTimeout(currentFeed, {
+        signal,
+      });
+      this.globalRefreshCompleted += 1;
+      if (!this.isGlobalRefreshCancelled) {
+        this.finalizeRefreshAttempt(currentFeed, updatedFeed);
+      }
     } catch (error) {
-      this.finalizeRefreshAttempt(currentFeed, undefined, error);
+      this.globalRefreshCompleted += 1;
+      if (!this.isGlobalRefreshCancelled) {
+        this.finalizeRefreshAttempt(currentFeed, undefined, error);
+      }
       const isTimedOut =
         error instanceof Error && error.message === "Timed out";
       if (isTimedOut) {
@@ -2911,9 +2963,12 @@ export default class RssDashboardPlugin extends Plugin {
     });
   }
 
-  private async refreshFeedWithTimeout(feed: Feed): Promise<Feed> {
+  private async refreshFeedWithTimeout(
+    feed: Feed,
+    options?: { signal?: AbortSignal },
+  ): Promise<Feed> {
     return await Promise.race([
-      this.refreshFeedDirect(feed),
+      this.refreshFeedDirect(feed, options),
       new Promise<Feed>((_, reject) => {
         window.setTimeout(
           () => reject(new Error("Timed out")),
@@ -2923,9 +2978,12 @@ export default class RssDashboardPlugin extends Plugin {
     ]);
   }
 
-  private async refreshFeedDirect(feed: Feed): Promise<Feed> {
+  private async refreshFeedDirect(
+    feed: Feed,
+    options?: { signal?: AbortSignal },
+  ): Promise<Feed> {
     if (typeof this.feedParser.refreshFeed === "function") {
-      return await this.feedParser.refreshFeed(feed);
+      return await this.feedParser.refreshFeed(feed, options);
     }
 
     const updatedFeeds = await this.feedParser.refreshAllFeeds([feed]);

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -51,9 +51,7 @@ import {
   getRefreshStatus,
   type RefreshStatus,
 } from "../utils/refresh-status";
-import {
-  getEffectiveRefreshIntervalMinutes,
-} from "../utils/refresh-intervals";
+import { getEffectiveRefreshIntervalMinutes } from "../utils/refresh-intervals";
 
 export interface SidebarOptions {
   currentFolder: string | null;
@@ -396,7 +394,8 @@ export class Sidebar {
           `Next scheduled refresh: ${status.nextDueAt === 0 ? "Due now" : formatRefreshStatusTime(status.nextDueAt, true)}`,
         );
       }
-      if (feed.lastFetchError) lines.push(`Last attempt failed: ${feed.lastFetchError}`);
+      if (feed.lastFetchError)
+        lines.push(`Last attempt failed: ${feed.lastFetchError}`);
       if (status.refreshingCount > 0) lines.push("In progress");
       if (feed.excludeFromRefresh) lines.push("Excluded from global refresh");
       return lines;
@@ -407,7 +406,9 @@ export class Sidebar {
       globalIntervalMinutes: this.settings.refreshInterval,
       scope: "aggregate",
     });
-    lines.push(`Aggregate coverage: ${formatRefreshStatusTime(coverage.completionAt, true)}`);
+    lines.push(
+      `Aggregate coverage: ${formatRefreshStatusTime(coverage.completionAt, true)}`,
+    );
     if (status.nextDueAt !== null) {
       lines.push(
         `Next scheduled refresh: ${status.nextDueAt === 0 ? "Due now" : formatRefreshStatusTime(status.nextDueAt, true)}`,
@@ -417,12 +418,20 @@ export class Sidebar {
     return lines;
   }
 
-  private appendRefreshStatusCounts(lines: string[], status: RefreshStatus): void {
-    if (status.failingCount > 0) lines.push(`Feeds currently failing: ${status.failingCount}`);
-    if (status.refreshingCount > 0) lines.push(`Refreshing ${status.refreshingCount} feeds...`);
-    if (status.automaticOffCount > 0) lines.push(`Automatic refresh off: ${status.automaticOffCount}`);
-    if (status.excludedCount > 0) lines.push(`Feeds excluded from global refresh: ${status.excludedCount}`);
-    if (status.neverCheckedCount > 0) lines.push(`Feeds not yet checked: ${status.neverCheckedCount}`);
+  private appendRefreshStatusCounts(
+    lines: string[],
+    status: RefreshStatus,
+  ): void {
+    if (status.failingCount > 0)
+      lines.push(`Feeds currently failing: ${status.failingCount}`);
+    if (status.refreshingCount > 0)
+      lines.push(`Refreshing ${status.refreshingCount} feeds...`);
+    if (status.automaticOffCount > 0)
+      lines.push(`Automatic refresh off: ${status.automaticOffCount}`);
+    if (status.excludedCount > 0)
+      lines.push(`Feeds excluded from global refresh: ${status.excludedCount}`);
+    if (status.neverCheckedCount > 0)
+      lines.push(`Feeds not yet checked: ${status.neverCheckedCount}`);
   }
 
   private attachRefreshDetails(
@@ -449,8 +458,7 @@ export class Sidebar {
   }
 
   private attachRefreshActionDetails(row: HTMLElement): void {
-    const actionText =
-      "Refresh all feeds. Shift+click to retry failed feeds.";
+    const actionText = "Refresh all feeds. Shift+click to retry failed feeds.";
     this.refreshStatusDetailCleanups.push(
       attachRefreshStatusDetails({
         row,
@@ -477,7 +485,10 @@ export class Sidebar {
     });
     popup.createEl("strong", { text: "Refresh details" });
     for (const line of this.getRefreshDetailLines(feeds, scope)) {
-      popup.createDiv({ cls: "rss-dashboard-refresh-details-line", text: line });
+      popup.createDiv({
+        cls: "rss-dashboard-refresh-details-line",
+        text: line,
+      });
     }
     const rect = anchor.getBoundingClientRect();
     popup.style.setProperty("top", `${Math.max(8, rect.top)}px`);
@@ -1021,6 +1032,7 @@ export class Sidebar {
     const isRefreshActive =
       this.plugin.isMultiFeedRefreshActive ||
       (this.plugin.activeRefreshState?.size ?? 0) > 0;
+    const isCancellable = this.plugin.isGlobalRefreshCancellable ?? false;
 
     // Feed icon (refresh button) - clickable
     const refreshLabelId = `rss-dashboard-refresh-all-feeds-${Math.random()
@@ -1028,19 +1040,28 @@ export class Sidebar {
       .slice(2)}`;
     allFeedsButton.createSpan({
       cls: "rss-dashboard-refresh-details-sr-only",
-      text: "Refresh all feeds. Shift+click to retry failed feeds.",
+      text: isCancellable
+        ? "Refresh in progress. Click to stop."
+        : "Refresh all feeds. Shift+click to retry failed feeds.",
       attr: { id: refreshLabelId },
     });
-    const feedIcon = allFeedsButton.createDiv({
+    const feedIcon = allFeedsButton.createEl("button", {
       cls:
-        "rss-dashboard-all-feeds-icon" + (isRefreshActive ? " refreshing" : ""),
+        "rss-dashboard-all-feeds-icon" +
+        (isCancellable ? " stop" : isRefreshActive ? " refreshing" : ""),
       attr: {
+        type: "button",
+        title: isCancellable ? "Stop refresh" : "Refresh all feeds",
         "aria-labelledby": refreshLabelId,
       },
     });
-    setIcon(feedIcon, "refresh-cw");
+    setIcon(feedIcon, isCancellable ? "square-stop" : "refresh-cw");
     feedIcon.addEventListener("click", (e) => {
       e.stopPropagation();
+      if (isCancellable) {
+        this.plugin.cancelGlobalRefresh();
+        return;
+      }
       if (this.plugin.isMultiFeedRefreshActive) return;
       void this.handleRefresh(e);
     });
@@ -1054,6 +1075,17 @@ export class Sidebar {
       cls: "rss-dashboard-all-feeds-label",
       text: `All Feeds (${totalFeeds})`,
     });
+
+    if (isCancellable) {
+      const progress = this.plugin.globalRefreshProgress ?? {
+        completed: 0,
+        total: 0,
+      };
+      labelContainer.createSpan({
+        cls: "rss-dashboard-all-feeds-progress",
+        text: `${progress.completed}/${progress.total}`,
+      });
+    }
 
     const rightContainer = allFeedsButton.createDiv({
       cls: "rss-dashboard-all-feeds-right",
@@ -1085,13 +1117,16 @@ export class Sidebar {
     const anchor = event.currentTarget;
 
     menu.addItem((item: MenuItem) => {
-      item.setTitle("Refresh details").setIcon("info").onClick(() => {
-        this.showRefreshDetails(
-          anchor instanceof HTMLElement ? anchor : this.container,
-          this.settings.feeds,
-          "all",
-        );
-      });
+      item
+        .setTitle("Refresh details")
+        .setIcon("info")
+        .onClick(() => {
+          this.showRefreshDetails(
+            anchor instanceof HTMLElement ? anchor : this.container,
+            this.settings.feeds,
+            "all",
+          );
+        });
     });
 
     menu.addItem((item: MenuItem) => {
@@ -1185,7 +1220,8 @@ export class Sidebar {
     this.attachRefreshDetails(
       folderHeader,
       this.settings.feeds.filter(
-        (feed) => Boolean(feed.folder) && folderRefreshFeeds.includes(feed.folder),
+        (feed) =>
+          Boolean(feed.folder) && folderRefreshFeeds.includes(feed.folder),
       ),
       "aggregate",
     );
@@ -1202,10 +1238,7 @@ export class Sidebar {
       "aria-label",
       isCollapsed ? "Expand folder" : "Collapse folder",
     );
-    setIcon(
-      toggleButton,
-      isCollapsed ? "chevron-right" : "chevron-down",
-    );
+    setIcon(toggleButton, isCollapsed ? "chevron-right" : "chevron-down");
 
     if (folderObj.pinned) {
       const pinIcon = folderHeader.createDiv({
@@ -1262,7 +1295,10 @@ export class Sidebar {
 
       // Shift+click: range selection (delegate computation to caller)
       if (e.shiftKey) {
-        const clickedKey = this.getSidebarTargetKey({ type: "folder", path: fullPath });
+        const clickedKey = this.getSidebarTargetKey({
+          type: "folder",
+          path: fullPath,
+        });
         const visibleKeys = this.sidebarRows.map((r) => r.key);
         this.callbacks.onRangeSelect?.(clickedKey, visibleKeys);
         return;
@@ -1568,7 +1604,8 @@ export class Sidebar {
         }
       }
     }
-    const isSelected = (this.options.selectedFeeds || []).includes(feed.url) || isSelectedFolder;
+    const isSelected =
+      (this.options.selectedFeeds || []).includes(feed.url) || isSelectedFolder;
 
     const feedEl = container.createDiv({
       cls:
@@ -1712,7 +1749,10 @@ export class Sidebar {
       e.stopPropagation();
       // Shift+click: range selection (delegate to caller)
       if (e.shiftKey) {
-        const clickedKey = this.getSidebarTargetKey({ type: "feed", url: feed.url });
+        const clickedKey = this.getSidebarTargetKey({
+          type: "feed",
+          url: feed.url,
+        });
         const visibleKeys = this.sidebarRows.map((r) => r.key);
         this.callbacks.onRangeSelect?.(clickedKey, visibleKeys);
         return;
@@ -1850,16 +1890,19 @@ export class Sidebar {
     });
   }
 
-  private isMultiSelectionTarget(targetType: 'folder' | 'feed', targetKey: string): boolean {
+  private isMultiSelectionTarget(
+    targetType: "folder" | "feed",
+    targetKey: string,
+  ): boolean {
     const { selectedFolders, selectedFeeds } = this.options;
     const folderCount = selectedFolders?.length || 0;
     const feedCount = selectedFeeds?.length || 0;
     // Multi-selection exists if more than 1 feed is selected, or if any folder is selected.
     const hasMultiSelection = folderCount > 0 || feedCount > 1;
-                              
+
     if (!hasMultiSelection) return false;
-    
-    if (targetType === 'folder') {
+
+    if (targetType === "folder") {
       return selectedFolders?.includes(targetKey) || false;
     } else {
       return selectedFeeds?.includes(targetKey) || false;
@@ -1868,14 +1911,16 @@ export class Sidebar {
 
   private appendSelectionContextMenu(menu: Menu): void {
     menu.addItem((item: MenuItem) => {
-      item.setTitle("Mark selection as read")
+      item
+        .setTitle("Mark selection as read")
         .setIcon("check-circle")
         .onClick(() => {
           this.markSelectionReadStatus(true);
         });
     });
     menu.addItem((item: MenuItem) => {
-      item.setTitle("Mark selection as unread")
+      item
+        .setTitle("Mark selection as unread")
         .setIcon("circle")
         .onClick(() => {
           this.markSelectionReadStatus(false);
@@ -1883,7 +1928,8 @@ export class Sidebar {
     });
     menu.addSeparator();
     menu.addItem((item: MenuItem) => {
-      item.setTitle("Delete selection")
+      item
+        .setTitle("Delete selection")
         .setIcon("trash")
         .onClick(() => {
           this.deleteSelection();
@@ -1894,7 +1940,7 @@ export class Sidebar {
   private markSelectionReadStatus(read: boolean): void {
     let count = 0;
     const { selectedFolders, selectedFeeds } = this.options;
-    
+
     const feedsToUpdate = new Set<Feed>();
     for (const feed of this.settings.feeds) {
       if (selectedFeeds && selectedFeeds.includes(feed.url)) {
@@ -1914,7 +1960,7 @@ export class Sidebar {
         }
       }
     }
-    
+
     for (const feed of feedsToUpdate) {
       for (const item of feed.items) {
         if (item.read !== read) {
@@ -1923,12 +1969,12 @@ export class Sidebar {
         }
       }
     }
-    
+
     if (count > 0) {
-      new Notice(`Marked ${count} items as ${read ? 'read' : 'unread'}`);
+      new Notice(`Marked ${count} items as ${read ? "read" : "unread"}`);
       void this.plugin.saveSettings().then(() => this.render());
     } else {
-      new Notice(`No items to mark as ${read ? 'read' : 'unread'}`);
+      new Notice(`No items to mark as ${read ? "read" : "unread"}`);
     }
   }
 
@@ -1936,9 +1982,9 @@ export class Sidebar {
     const { selectedFolders, selectedFeeds } = this.options;
     const folderCount = selectedFolders?.length || 0;
     const feedCount = selectedFeeds?.length || 0;
-    
+
     if (folderCount === 0 && feedCount === 0) return;
-    
+
     let msg = `Are you sure you want to delete the selected items? This action cannot be undone.`;
     if (folderCount > 0 && feedCount === 0) {
       msg = `Are you sure you want to delete ${folderCount} selected folder(s) and all their subfolders and feeds?`;
@@ -1947,7 +1993,7 @@ export class Sidebar {
     } else {
       msg = `Are you sure you want to delete ${folderCount} folder(s) and ${feedCount} feed(s)?`;
     }
-    
+
     this.showConfirmModal(msg, () => {
       if (selectedFolders) {
         for (const folder of selectedFolders) {
@@ -1956,7 +2002,7 @@ export class Sidebar {
       }
       if (selectedFeeds) {
         for (const feedUrl of selectedFeeds) {
-          const feed = this.settings.feeds.find(f => f.url === feedUrl);
+          const feed = this.settings.feeds.find((f) => f.url === feedUrl);
           if (feed) {
             this.callbacks.onDeleteFeed(feed);
           }
@@ -1978,19 +2024,22 @@ export class Sidebar {
     const anchor = event.currentTarget;
 
     menu.addItem((item: MenuItem) => {
-      item.setTitle("Refresh details").setIcon("info").onClick(() => {
-        this.showRefreshDetails(
-          anchor instanceof HTMLElement ? anchor : this.container,
-          this.settings.feeds.filter((feed) => {
-            const paths = this.getAllDescendantFolderPaths(fullPath);
-            return Boolean(feed.folder) && paths.includes(feed.folder);
-          }),
-          "aggregate",
-        );
-      });
+      item
+        .setTitle("Refresh details")
+        .setIcon("info")
+        .onClick(() => {
+          this.showRefreshDetails(
+            anchor instanceof HTMLElement ? anchor : this.container,
+            this.settings.feeds.filter((feed) => {
+              const paths = this.getAllDescendantFolderPaths(fullPath);
+              return Boolean(feed.folder) && paths.includes(feed.folder);
+            }),
+            "aggregate",
+          );
+        });
     });
-    
-    if (this.isMultiSelectionTarget('folder', fullPath)) {
+
+    if (this.isMultiSelectionTarget("folder", fullPath)) {
       this.appendSelectionContextMenu(menu);
       menu.showAtMouseEvent(event);
       return;
@@ -3639,16 +3688,19 @@ export class Sidebar {
     const anchor = event.currentTarget;
 
     menu.addItem((item: MenuItem) => {
-      item.setTitle("Refresh details").setIcon("info").onClick(() => {
-        this.showRefreshDetails(
-          anchor instanceof HTMLElement ? anchor : this.container,
-          [feed],
-          "feed",
-        );
-      });
+      item
+        .setTitle("Refresh details")
+        .setIcon("info")
+        .onClick(() => {
+          this.showRefreshDetails(
+            anchor instanceof HTMLElement ? anchor : this.container,
+            [feed],
+            "feed",
+          );
+        });
     });
 
-    if (this.isMultiSelectionTarget('feed', feed.url)) {
+    if (this.isMultiSelectionTarget("feed", feed.url)) {
       this.appendSelectionContextMenu(menu);
       menu.showAtMouseEvent(event);
       return;

--- a/src/services/feed-parser/feed-parser-class.ts
+++ b/src/services/feed-parser/feed-parser-class.ts
@@ -17,7 +17,10 @@ import { fetchFeedXml } from "./feed-fetch.js";
 import { parseFetchErrorMessage } from "./feed-errors.js";
 import { CustomXMLParser } from "./xml-parser/custom-xml-parser.js";
 import { assertParsedFeedHasEntries } from "./parsed-feed-assert.js";
-import { FEED_REQUEST_TIMEOUT_MS, FEED_SOFT_TIMEOUT_MS } from "../feed-timeout.js";
+import {
+  FEED_REQUEST_TIMEOUT_MS,
+  FEED_SOFT_TIMEOUT_MS,
+} from "../feed-timeout.js";
 import { globalFetchSemaphore } from "./fetch-semaphore.js";
 import {
   applyFeedRetentionLimits,
@@ -365,7 +368,6 @@ export class FeedParser {
     return "";
   }
 
-
   private extractPodcastCoverImage(
     item: ParsedItem,
     feedImage: { url: string } | string | undefined,
@@ -433,11 +435,15 @@ export class FeedParser {
     }
 
     if (parsed.feedItunesImage) {
-      return optimizeImageUrl(this.convertToAbsoluteUrl(parsed.feedItunesImage, baseUrl));
+      return optimizeImageUrl(
+        this.convertToAbsoluteUrl(parsed.feedItunesImage, baseUrl),
+      );
     }
 
     if (parsed.feedImageUrl) {
-      return optimizeImageUrl(this.convertToAbsoluteUrl(parsed.feedImageUrl, baseUrl));
+      return optimizeImageUrl(
+        this.convertToAbsoluteUrl(parsed.feedImageUrl, baseUrl),
+      );
     }
 
     return "";
@@ -581,24 +587,24 @@ export class FeedParser {
             this.resolvePodcastCoverImage(item, parsed, url) ||
             existingItem.coverImage;
         } else {
-          coverImage = firstSanitizedArticleImageUrl([
-            this.extractCoverImage(
-              item.content || item.description || "",
-              url,
-            ),
-            optimizeImageUrl(
-              this.convertToAbsoluteUrl(
-                item.itunes?.image?.href || "",
+          coverImage =
+            firstSanitizedArticleImageUrl([
+              this.extractCoverImage(
+                item.content || item.description || "",
                 url,
-              )
-            ),
-            optimizeImageUrl(
-              this.convertToAbsoluteUrl(item.image?.url || "", url),
-            ),
-            (item.enclosure?.type?.startsWith("image/")
-              ? optimizeImageUrl(this.convertToAbsoluteUrl(item.enclosure.url, url))
-              : ""),
-          ]) || sanitizeArticleImageUrl(existingItem.coverImage);
+              ),
+              optimizeImageUrl(
+                this.convertToAbsoluteUrl(item.itunes?.image?.href || "", url),
+              ),
+              optimizeImageUrl(
+                this.convertToAbsoluteUrl(item.image?.url || "", url),
+              ),
+              item.enclosure?.type?.startsWith("image/")
+                ? optimizeImageUrl(
+                    this.convertToAbsoluteUrl(item.enclosure.url, url),
+                  )
+                : "",
+            ]) || sanitizeArticleImageUrl(existingItem.coverImage);
         }
         const updatedItem: FeedItem = {
           ...existingItem,
@@ -623,24 +629,24 @@ export class FeedParser {
           summary:
             this.extractSummary(item.content || item.description || "") ||
             existingItem.summary,
-          image: firstSanitizedArticleImageUrl([
-            optimizeImageUrl(
-              this.convertToAbsoluteUrl(
-                item.itunes?.image?.href || "",
+          image:
+            firstSanitizedArticleImageUrl([
+              optimizeImageUrl(
+                this.convertToAbsoluteUrl(item.itunes?.image?.href || "", url),
+              ),
+              optimizeImageUrl(
+                this.convertToAbsoluteUrl(item.image?.url || "", url),
+              ),
+              this.extractCoverImage(
+                item.content || item.description || "",
                 url,
-              )
-            ),
-            optimizeImageUrl(
-              this.convertToAbsoluteUrl(item.image?.url || "", url),
-            ),
-            this.extractCoverImage(
-              item.content || item.description || "",
-              url,
-            ),
-            (item.enclosure?.type?.startsWith("image/")
-              ? optimizeImageUrl(this.convertToAbsoluteUrl(item.enclosure.url, url))
-              : ""),
-          ]) || sanitizeArticleImageUrl(existingItem.image),
+              ),
+              item.enclosure?.type?.startsWith("image/")
+                ? optimizeImageUrl(
+                    this.convertToAbsoluteUrl(item.enclosure.url, url),
+                  )
+                : "",
+            ]) || sanitizeArticleImageUrl(existingItem.image),
           duration: item.itunes?.duration || existingItem.duration,
           explicit: item.itunes?.explicit === "yes" || existingItem.explicit,
           category: item.itunes?.category || existingItem.category,
@@ -680,22 +686,18 @@ export class FeedParser {
           coverImage = this.resolvePodcastCoverImage(item, parsed, url);
         } else {
           coverImage = firstSanitizedArticleImageUrl([
-            this.extractCoverImage(
-              item.content || item.description || "",
-              url,
-            ),
+            this.extractCoverImage(item.content || item.description || "", url),
             optimizeImageUrl(
-              this.convertToAbsoluteUrl(
-                item.itunes?.image?.href || "",
-                url,
-              )
+              this.convertToAbsoluteUrl(item.itunes?.image?.href || "", url),
             ),
             optimizeImageUrl(
               this.convertToAbsoluteUrl(item.image?.url || "", url),
             ),
-            (item.enclosure?.type?.startsWith("image/")
-              ? optimizeImageUrl(this.convertToAbsoluteUrl(item.enclosure.url, url))
-              : ""),
+            item.enclosure?.type?.startsWith("image/")
+              ? optimizeImageUrl(
+                  this.convertToAbsoluteUrl(item.enclosure.url, url),
+                )
+              : "",
           ]);
         }
         const image = firstSanitizedArticleImageUrl([
@@ -705,10 +707,7 @@ export class FeedParser {
           optimizeImageUrl(
             this.convertToAbsoluteUrl(item.image?.url || "", url),
           ),
-          this.extractCoverImage(
-            item.content || item.description || "",
-            url,
-          ),
+          this.extractCoverImage(item.content || item.description || "", url),
           item.enclosure?.type?.startsWith("image/")
             ? optimizeImageUrl(
                 this.convertToAbsoluteUrl(item.enclosure.url, url),
@@ -844,7 +843,10 @@ export class FeedParser {
     );
 
     const absoluteFeedLogoUrl = feedLogoUrl
-      ? this.convertToAbsoluteUrl(feedLogoUrl, url).replace(/\.(png|jpe?g|gif|webp|svg|ico)\/+$/i, ".$1")
+      ? this.convertToAbsoluteUrl(feedLogoUrl, url).replace(
+          /\.(png|jpe?g|gif|webp|svg|ico)\/+$/i,
+          ".$1",
+        )
       : "";
 
     if (absoluteFeedLogoUrl) {
@@ -873,9 +875,21 @@ export class FeedParser {
     feed.items = updated.items;
   }
 
-  async refreshFeed(feed: Feed): Promise<Feed> {
+  async refreshFeed(
+    feed: Feed,
+    options?: { signal?: AbortSignal },
+  ): Promise<Feed> {
     let timeoutId: number | null = null;
     const abortController = new AbortController();
+    let externalAbortHandler: (() => void) | null = null;
+    if (options?.signal) {
+      if (options.signal.aborted) {
+        abortController.abort();
+      } else {
+        externalAbortHandler = () => abortController.abort();
+        options.signal.addEventListener("abort", externalAbortHandler);
+      }
+    }
     try {
       const refreshedFeed = await Promise.race([
         this.parseFeed(feed.url, feed, { signal: abortController.signal }),
@@ -894,12 +908,18 @@ export class FeedParser {
         `[RSS dashboard] Error parsing feed ${feed.title} (${feed.url}):`,
         error,
       );
+      if (options?.signal?.aborted) {
+        throw error;
+      }
       // Persist the clean error message so the sidebar can show the badge
       feed.lastFetchError = parseFetchErrorMessage(error);
       return feed;
     } finally {
       if (timeoutId !== null) {
         window.clearTimeout(timeoutId);
+      }
+      if (externalAbortHandler && options?.signal) {
+        options.signal.removeEventListener("abort", externalAbortHandler);
       }
     }
   }
@@ -953,7 +973,7 @@ export class FeedParser {
     const workers = Array(Math.min(queueProcessorsCount, feeds.length))
       .fill(0)
       .map(() => worker());
-      
+
     await Promise.all(workers);
     await Promise.all(backgroundPromises);
 

--- a/src/settings/tabs/sidebar-settings-tab.ts
+++ b/src/settings/tabs/sidebar-settings-tab.ts
@@ -314,18 +314,8 @@ export function renderSidebarSettingsTab(
       if (!icon) return;
       const hideKey = icon.settingKey;
 
-      const nameFrag = containerEl.win.createFragment();
-      const labelWrap = containerEl.win.createSpan();
-      labelWrap.addClass("rss-settings-icon-label");
-      const iconSpan = containerEl.win.createSpan();
-      iconSpan.addClass("rss-settings-icon-preview");
-      setIcon(iconSpan, icon.lucideIcon);
-      labelWrap.append(iconSpan);
-      labelWrap.append(` ${icon.label}`);
-      nameFrag.append(labelWrap);
-
       const iconSetting = new Setting(iconRowsContainer)
-        .setName(nameFrag)
+        .setName(icon.label)
         .setDisabled(hideToolbar)
         .addToggle((toggle) =>
           toggle
@@ -345,6 +335,11 @@ export function renderSidebarSettingsTab(
 
       iconSetting.settingEl.addClass("rss-dashboard-icon-visibility-row");
       iconSetting.settingEl.setAttribute("data-icon-id", id);
+
+      const iconPreview = containerEl.win.createSpan();
+      iconPreview.addClass("rss-settings-icon-preview");
+      setIcon(iconPreview, icon.lucideIcon);
+      iconSetting.nameEl.prepend(iconPreview);
 
       const dragHandle = containerEl.win.createEl("button");
       dragHandle.type = "button";

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -991,21 +991,47 @@ body.theme-dark .rss-dashboard-all-feeds-button {
 }
 
 .rss-dashboard-all-feeds-icon {
+  --icon-color: var(
+    --rss-unread-badge-all-feeds-color,
+    var(--interactive-accent)
+  );
   width: 16px;
   height: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-right: 8px;
-  color: var(--rss-unread-badge-all-feeds-color);
+  color: var(
+    --rss-unread-badge-all-feeds-color,
+    var(--interactive-accent)
+  );
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
+.rss-dashboard-all-feeds-button .rss-dashboard-all-feeds-icon:not(.stop):hover {
+  background-color: transparent;
+}
+
+.rss-dashboard-all-feeds-button .rss-dashboard-all-feeds-icon {
+  background-color: transparent;
 }
 
 .rss-dashboard-all-feeds-icon svg {
   display: block;
   width: 16px;
   height: 16px;
+  color: var(--icon-color);
   overflow: visible;
   will-change: transform;
+  transition: transform 0.3s ease;
+}
+
+.rss-dashboard-all-feeds-icon:not(.refreshing):not(.stop):hover svg {
+  transform: rotate(180deg);
 }
 
 .rss-dashboard-all-feeds-label-container {
@@ -1059,6 +1085,24 @@ body.theme-dark .rss-dashboard-all-feeds-button {
   transform-box: fill-box;
   transform-origin: center;
   will-change: transform;
+}
+
+.rss-dashboard-all-feeds-icon.stop {
+  --icon-color: var(--text-error, var(--rss-color-red-danger, #dc2626));
+  color: var(--text-error, var(--rss-color-red-danger, #dc2626));
+}
+
+.rss-dashboard-all-feeds-icon.stop:hover {
+  --icon-color: var(--rss-color-red-confirm, #ef4444);
+  color: var(--rss-color-red-confirm, #ef4444);
+  background-color: var(--background-modifier-hover);
+}
+
+.rss-dashboard-all-feeds-progress {
+  font-size: var(--font-x-small);
+  color: var(--text-muted);
+  white-space: nowrap;
+  margin-left: 6px;
 }
 
 /* ============================================

--- a/test_files/unit/components/sidebar-core.test.ts
+++ b/test_files/unit/components/sidebar-core.test.ts
@@ -39,7 +39,10 @@ interface TestPlugin extends Partial<RssDashboardPlugin> {
   refreshFeeds: Mock<() => Promise<void>>;
   refreshFailedFeeds: Mock<() => Promise<void>>;
   cancelPendingStartupRefresh: Mock<() => void>;
+  cancelGlobalRefresh: Mock<() => void>;
   isMultiFeedRefreshActive?: boolean;
+  isGlobalRefreshCancellable?: boolean;
+  globalRefreshProgress?: { completed: number; total: number };
 }
 
 /** Typed interface for Sidebar private member access */
@@ -128,6 +131,9 @@ describe("Sidebar Core", () => {
       refreshFeeds: vi.fn().mockResolvedValue(undefined),
       refreshFailedFeeds: vi.fn().mockResolvedValue(undefined),
       cancelPendingStartupRefresh: vi.fn(),
+      cancelGlobalRefresh: vi.fn(),
+      isGlobalRefreshCancellable: false,
+      globalRefreshProgress: { completed: 0, total: 0 },
     };
     callbacks.onRetryFailedFeeds = plugin.refreshFailedFeeds;
   });
@@ -463,7 +469,7 @@ describe("Sidebar Core", () => {
       const icon = container.querySelector(
         ".rss-dashboard-all-feeds-icon",
       ) as HTMLElement;
-      expect(icon.hasAttribute("title")).toBe(false);
+      expect(icon.getAttribute("title")).toBe("Refresh all feeds");
       expect(icon.hasAttribute("aria-label")).toBe(false);
       const labelId = icon.getAttribute("aria-labelledby") ?? "";
       expect(container.querySelector(`#${labelId}`)?.textContent).toBe(
@@ -542,8 +548,127 @@ describe("Sidebar Core", () => {
         feedEl?.querySelector(".rss-dashboard-feed-processing-indicator"),
       ).toBeNull();
     });
-  });
 
+    it("shows a stop icon when global refresh is cancellable", () => {
+      settings.feeds = [
+        createFeed({ url: "https://example.com/a.xml" }),
+        createFeed({ url: "https://example.com/b.xml" }),
+      ];
+      plugin.isGlobalRefreshCancellable = true;
+      plugin.globalRefreshProgress = { completed: 1, total: 2 };
+
+      const sidebar = new Sidebar(
+        app,
+        container,
+        plugin as unknown as RssDashboardPlugin,
+        settings,
+        options,
+        callbacks,
+      );
+      sidebar.render();
+
+      const icon = container.querySelector(
+        ".rss-dashboard-all-feeds-icon",
+      ) as HTMLElement;
+      expect(icon.tagName).toBe("BUTTON");
+      expect(icon.getAttribute("type")).toBe("button");
+      expect(icon.getAttribute("title")).toBe("Stop refresh");
+      expect(icon.getAttribute("aria-labelledby")).toBeTruthy();
+      expect(icon.classList.contains("stop")).toBe(true);
+      expect(icon.classList.contains("refreshing")).toBe(false);
+    });
+
+    it("routes icon click to cancelGlobalRefresh when cancellable", () => {
+      settings.feeds = [createFeed({ url: "https://example.com/a.xml" })];
+      plugin.isGlobalRefreshCancellable = true;
+
+      const sidebar = new Sidebar(
+        app,
+        container,
+        plugin as unknown as RssDashboardPlugin,
+        settings,
+        options,
+        callbacks,
+      );
+      sidebar.render();
+
+      const icon = container.querySelector(
+        ".rss-dashboard-all-feeds-icon",
+      ) as HTMLElement;
+      icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      expect(plugin.cancelGlobalRefresh).toHaveBeenCalledTimes(1);
+      expect(plugin.refreshFeeds).not.toHaveBeenCalled();
+    });
+
+    it("uses a refresh tooltip when the all-feeds row is idle", () => {
+      settings.feeds = [createFeed({ url: "https://example.com/a.xml" })];
+
+      const sidebar = new Sidebar(
+        app,
+        container,
+        plugin as unknown as RssDashboardPlugin,
+        settings,
+        options,
+        callbacks,
+      );
+      sidebar.render();
+
+      expect(
+        container
+          .querySelector(".rss-dashboard-all-feeds-icon")
+          ?.getAttribute("title"),
+      ).toBe("Refresh all feeds");
+    });
+
+    it("shows progress text when global refresh is cancellable", () => {
+      settings.feeds = [
+        createFeed({ url: "https://example.com/a.xml" }),
+        createFeed({ url: "https://example.com/b.xml" }),
+        createFeed({ url: "https://example.com/c.xml" }),
+      ];
+      plugin.isGlobalRefreshCancellable = true;
+      plugin.globalRefreshProgress = { completed: 2, total: 3 };
+
+      const sidebar = new Sidebar(
+        app,
+        container,
+        plugin as unknown as RssDashboardPlugin,
+        settings,
+        options,
+        callbacks,
+      );
+      sidebar.render();
+
+      const progressEl = container.querySelector(
+        ".rss-dashboard-all-feeds-progress",
+      );
+      expect(progressEl).not.toBeNull();
+      expect(progressEl?.textContent).toContain("2/3");
+    });
+
+    it("does not show stop icon when refresh is active but not cancellable", () => {
+      settings.feeds = [createFeed({ url: "https://example.com/a.xml" })];
+      plugin.isMultiFeedRefreshActive = true;
+      plugin.isGlobalRefreshCancellable = false;
+
+      const sidebar = new Sidebar(
+        app,
+        container,
+        plugin as unknown as RssDashboardPlugin,
+        settings,
+        options,
+        callbacks,
+      );
+      sidebar.render();
+
+      const icon = container.querySelector(
+        ".rss-dashboard-all-feeds-icon",
+      ) as HTMLElement;
+      expect(icon.classList.contains("refreshing")).toBe(true);
+      expect(icon.classList.contains("stop")).toBe(false);
+    });
+  });
   // ── RED: multi-folder ctrl+click selection ────────────────────────────────
   // Tests written BEFORE implementation (TDD red phase). These will fail until
   // SidebarOptions.selectedFolders and SidebarCallbacks.onFolderMultiSelect

--- a/test_files/unit/components/sidebar-rendering.test.ts
+++ b/test_files/unit/components/sidebar-rendering.test.ts
@@ -145,16 +145,6 @@ describe("Sidebar Rendering", () => {
       callbacks,
     );
     sidebar.render();
-
-    const refreshIcon = container.querySelector<HTMLElement>(
-      ".rss-dashboard-all-feeds-icon",
-    );
-    expect(refreshIcon?.hasAttribute("aria-label")).toBe(false);
-    expect(refreshIcon?.hasAttribute("title")).toBe(false);
-    const labelId = refreshIcon?.getAttribute("aria-labelledby") ?? "";
-    expect(document.getElementById(labelId)?.textContent).toBe(
-      "Refresh all feeds. Shift+click to retry failed feeds.",
-    );
   });
 
   it("keeps the custom refresh-details popup on hover", async () => {
@@ -178,7 +168,8 @@ describe("Sidebar Rendering", () => {
     await vi.advanceTimersByTimeAsync(350);
 
     expect(
-      document.body.querySelector(".rss-dashboard-refresh-details")?.textContent,
+      document.body.querySelector(".rss-dashboard-refresh-details")
+        ?.textContent,
     ).toBe("Refresh all feeds. Shift+click to retry failed feeds.");
   });
 

--- a/test_files/unit/main/feed-refresh-pipeline.test.ts
+++ b/test_files/unit/main/feed-refresh-pipeline.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "obsidian";
 import RssDashboardPlugin from "../../../main";
-import { DEFAULT_SETTINGS, type Feed, type FeedItem } from "../../../src/types/types";
+import {
+  DEFAULT_SETTINGS,
+  type Feed,
+  type FeedItem,
+} from "../../../src/types/types";
 import { FEED_REQUEST_TIMEOUT_MS } from "../../../src/services/feed-timeout";
 
 let consoleLogSpy: ReturnType<typeof vi.spyOn>;
@@ -64,16 +68,27 @@ interface TestPlugin {
   settings: typeof DEFAULT_SETTINGS;
   saveData: ReturnType<typeof vi.fn>;
   feedParser: TestFeedParser;
-  refreshFeeds: (selectedFeeds?: Feed[]) => Promise<void>;
+  refreshFeeds: (
+    selectedFeeds?: Feed[],
+    intent?: "global" | "targeted" | "due" | "failed",
+  ) => Promise<void>;
   refreshFailedFeeds: () => Promise<void>;
   activeRefreshState: Map<string, unknown>;
   getActiveDashboardView: ReturnType<typeof vi.fn>;
   validateSavedArticles: ReturnType<typeof vi.fn>;
+  cancelGlobalRefresh: () => void;
+  isGlobalRefreshCancellable: boolean;
+  globalRefreshProgress: { completed: number; total: number };
 }
 
 function createPluginWithSettings(feeds: Feed[]): TestPlugin {
   const app = new App();
-  const plugin = new RssDashboardPlugin(app as unknown as ConstructorParameters<typeof RssDashboardPlugin>[0], createMockManifest() as unknown as ConstructorParameters<typeof RssDashboardPlugin>[1]);
+  const plugin = new RssDashboardPlugin(
+    app as unknown as ConstructorParameters<typeof RssDashboardPlugin>[0],
+    createMockManifest() as unknown as ConstructorParameters<
+      typeof RssDashboardPlugin
+    >[1],
+  );
 
   const testPlugin = plugin as unknown as TestPlugin;
 
@@ -96,7 +111,8 @@ function createPluginWithSettings(feeds: Feed[]): TestPlugin {
 }
 
 function getNoticeMessages(spy: ReturnType<typeof vi.spyOn>): string[] {
-  const calls = (spy as unknown as { mock: { calls: Array<Array<unknown>> } }).mock.calls;
+  const calls = (spy as unknown as { mock: { calls: Array<Array<unknown>> } })
+    .mock.calls;
   return calls
     .filter((call) => call[0] === "[Stub Notice]")
     .map((call) => String(call[1]));
@@ -171,9 +187,11 @@ describe("refreshFeeds() pipeline behavior", () => {
     });
     const plugin = createPluginWithSettings([recovered, stillFailing]);
     plugin.settings.lastGlobalRefreshCompletedAt = 123;
-    (plugin.feedParser.refreshFeed as unknown as {
-      mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
-    }).mockImplementation(async (feed) => {
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation(async (feed) => {
       if (feed.url === stillFailing.url) {
         throw new Error("new error");
       }
@@ -185,8 +203,12 @@ describe("refreshFeeds() pipeline behavior", () => {
     expect(plugin.settings.lastGlobalRefreshCompletedAt).toBe(123);
     expect(plugin.settings.feeds[0].lastFetchError).toBeUndefined();
     expect(plugin.settings.feeds[1].lastFetchError).toBe("new error");
-    expect(plugin.settings.feeds[0].lastRefreshAttemptCompletedAt).toBeDefined();
-    expect(plugin.settings.feeds[1].lastRefreshAttemptCompletedAt).toBeDefined();
+    expect(
+      plugin.settings.feeds[0].lastRefreshAttemptCompletedAt,
+    ).toBeDefined();
+    expect(
+      plugin.settings.feeds[1].lastRefreshAttemptCompletedAt,
+    ).toBeDefined();
   });
 
   it("records global completion after an explicit all-feeds refresh even when one attempt fails", async () => {
@@ -194,12 +216,14 @@ describe("refreshFeeds() pipeline behavior", () => {
     const failing = createFeed({ url: "https://example.com/two.xml" });
     const plugin = createPluginWithSettings([successful, failing]);
     vi.spyOn(Date, "now").mockReturnValue(9_876);
-    (plugin.feedParser.refreshFeed as unknown as { mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void }).mockImplementation(
-      async (feed) => {
-        if (feed.url === failing.url) throw new Error("network down");
-        return feed;
-      },
-    );
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation(async (feed) => {
+      if (feed.url === failing.url) throw new Error("network down");
+      return feed;
+    });
 
     await plugin.refreshFeeds();
 
@@ -211,7 +235,11 @@ describe("refreshFeeds() pipeline behavior", () => {
     const selected = createFeed();
     const plugin = createPluginWithSettings([selected]);
     plugin.settings.lastGlobalRefreshCompletedAt = 123;
-    (plugin.feedParser.refreshFeed as unknown as { mockResolvedValue: (value: Feed) => void }).mockResolvedValue(selected);
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockResolvedValue: (value: Feed) => void;
+      }
+    ).mockResolvedValue(selected);
 
     await plugin.refreshFeeds([selected]);
 
@@ -229,29 +257,59 @@ describe("refreshFeeds() pipeline behavior", () => {
     const feedB = createFeed({
       title: "Feed B",
       url: "https://example.com/b.xml",
-      items: [createItem({ guid: "b-1", feedTitle: "Feed B", feedUrl: "https://example.com/b.xml" })],
+      items: [
+        createItem({
+          guid: "b-1",
+          feedTitle: "Feed B",
+          feedUrl: "https://example.com/b.xml",
+        }),
+      ],
       lastUpdated: 200,
     });
     const feedC = createFeed({
       title: "Feed C",
       url: "https://example.com/c.xml",
-      items: [createItem({ guid: "c-1", feedTitle: "Feed C", feedUrl: "https://example.com/c.xml" })],
+      items: [
+        createItem({
+          guid: "c-1",
+          feedTitle: "Feed C",
+          feedUrl: "https://example.com/c.xml",
+        }),
+      ],
       lastUpdated: 300,
     });
     const feedD = createFeed({
       title: "Feed D",
       url: "https://example.com/d.xml",
-      items: [createItem({ guid: "d-1", feedTitle: "Feed D", feedUrl: "https://example.com/d.xml" })],
+      items: [
+        createItem({
+          guid: "d-1",
+          feedTitle: "Feed D",
+          feedUrl: "https://example.com/d.xml",
+        }),
+      ],
       lastUpdated: 400,
     });
     const feedE = createFeed({
       title: "Feed E",
       url: "https://example.com/e.xml",
-      items: [createItem({ guid: "e-1", feedTitle: "Feed E", feedUrl: "https://example.com/e.xml" })],
+      items: [
+        createItem({
+          guid: "e-1",
+          feedTitle: "Feed E",
+          feedUrl: "https://example.com/e.xml",
+        }),
+      ],
       lastUpdated: 500,
     });
 
-    const plugin = createPluginWithSettings([feedA, feedB, feedC, feedD, feedE]);
+    const plugin = createPluginWithSettings([
+      feedA,
+      feedB,
+      feedC,
+      feedD,
+      feedE,
+    ]);
 
     const updatedA = {
       ...feedA,
@@ -261,22 +319,46 @@ describe("refreshFeeds() pipeline behavior", () => {
     const updatedB = {
       ...feedB,
       lastUpdated: 888,
-      items: [createItem({ guid: "b-1", feedTitle: "Feed B", feedUrl: "https://example.com/b.xml" })],
+      items: [
+        createItem({
+          guid: "b-1",
+          feedTitle: "Feed B",
+          feedUrl: "https://example.com/b.xml",
+        }),
+      ],
     };
     const updatedC = {
       ...feedC,
       lastUpdated: 777,
-      items: [createItem({ guid: "c-1", feedTitle: "Feed C", feedUrl: "https://example.com/c.xml" })],
+      items: [
+        createItem({
+          guid: "c-1",
+          feedTitle: "Feed C",
+          feedUrl: "https://example.com/c.xml",
+        }),
+      ],
     };
     const updatedD = {
       ...feedD,
       lastUpdated: 666,
-      items: [createItem({ guid: "d-1", feedTitle: "Feed D", feedUrl: "https://example.com/d.xml" })],
+      items: [
+        createItem({
+          guid: "d-1",
+          feedTitle: "Feed D",
+          feedUrl: "https://example.com/d.xml",
+        }),
+      ],
     };
     const updatedE = {
       ...feedE,
       lastUpdated: 555,
-      items: [createItem({ guid: "e-1", feedTitle: "Feed E", feedUrl: "https://example.com/e.xml" })],
+      items: [
+        createItem({
+          guid: "e-1",
+          feedTitle: "Feed E",
+          feedUrl: "https://example.com/e.xml",
+        }),
+      ],
     };
 
     const validateSpy = vi.spyOn(plugin, "validateSavedArticles");
@@ -285,10 +367,16 @@ describe("refreshFeeds() pipeline behavior", () => {
     vi.spyOn(plugin, "getActiveDashboardView").mockResolvedValue({
       refreshSidebarOnly: sidebarRefreshSpy,
       refresh: viewRefreshSpy,
-    } as unknown as Awaited<ReturnType<typeof RssDashboardPlugin.prototype.getActiveDashboardView>>);
+    } as unknown as Awaited<
+      ReturnType<typeof RssDashboardPlugin.prototype.getActiveDashboardView>
+    >);
 
     const resolvers: Array<() => void> = [];
-    (plugin.feedParser.refreshFeed as unknown as { mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void }).mockImplementation((feed: Feed) => {
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation((feed: Feed) => {
       if (feed.url === feedE.url) {
         return Promise.resolve(updatedE);
       }
@@ -316,7 +404,11 @@ describe("refreshFeeds() pipeline behavior", () => {
     const refreshPromise = plugin.refreshFeeds();
     await flushMicrotasks();
 
-    expect(plugin.feedParser.refreshFeed.mock.calls.map((call: unknown[]) => (call[0] as Feed).url)).toEqual([
+    expect(
+      plugin.feedParser.refreshFeed.mock.calls.map(
+        (call: unknown[]) => (call[0] as Feed).url,
+      ),
+    ).toEqual([
       "https://example.com/a.xml",
       "https://example.com/b.xml",
       "https://example.com/c.xml",
@@ -344,7 +436,11 @@ describe("refreshFeeds() pipeline behavior", () => {
     expect(plugin.settings.feeds[2].lastUpdated).toBe(777);
     expect(plugin.settings.feeds[3].lastUpdated).toBe(666);
     expect(plugin.settings.feeds[4].lastUpdated).toBe(555);
-    expect(plugin.feedParser.refreshFeed.mock.calls.map((call: unknown[]) => (call[0] as Feed).url)).toEqual([
+    expect(
+      plugin.feedParser.refreshFeed.mock.calls.map(
+        (call: unknown[]) => (call[0] as Feed).url,
+      ),
+    ).toEqual([
       "https://example.com/a.xml",
       "https://example.com/b.xml",
       "https://example.com/c.xml",
@@ -384,13 +480,20 @@ describe("refreshFeeds() pipeline behavior", () => {
       ...feedB,
       lastUpdated: 777,
     };
-    (plugin.feedParser.refreshFeed as unknown as { mockResolvedValue: (value: Feed) => void }).mockResolvedValue(updatedB);
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockResolvedValue: (value: Feed) => void;
+      }
+    ).mockResolvedValue(updatedB);
 
     vi.spyOn(plugin, "getActiveDashboardView").mockResolvedValue(null);
 
     await plugin.refreshFeeds([feedB]);
 
-    expect(plugin.feedParser.refreshFeed).toHaveBeenCalledWith(feedB);
+    expect(plugin.feedParser.refreshFeed).toHaveBeenCalledWith(
+      feedB,
+      undefined,
+    );
     expect(plugin.feedParser.refreshAllFeeds).not.toHaveBeenCalled();
     expect(plugin.settings.feeds[0].lastUpdated).toBe(100);
     expect(plugin.settings.feeds[1].lastUpdated).toBe(777);
@@ -419,9 +522,15 @@ describe("refreshFeeds() pipeline behavior", () => {
     vi.spyOn(plugin, "getActiveDashboardView").mockResolvedValue({
       refreshSidebarOnly: sidebarRefreshSpy,
       refresh: viewRefreshSpy,
-    } as unknown as Awaited<ReturnType<typeof RssDashboardPlugin.prototype.getActiveDashboardView>>);
+    } as unknown as Awaited<
+      ReturnType<typeof RssDashboardPlugin.prototype.getActiveDashboardView>
+    >);
 
-    (plugin.feedParser.refreshFeed as unknown as { mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void }).mockImplementation((feed: Feed) => {
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation((feed: Feed) => {
       if (feed.url === feedA.url) {
         return new Promise<Feed>(() => undefined);
       }
@@ -455,11 +564,15 @@ describe("refreshFeeds() pipeline behavior", () => {
     const plugin = createPluginWithSettings([createFeed()]);
     vi.spyOn(Date, "now").mockReturnValue(9_876);
 
-    (plugin.feedParser.refreshFeed as unknown as { mockRejectedValue: (error: Error) => void }).mockRejectedValue(
-      new Error("network down"),
-    );
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockRejectedValue: (error: Error) => void;
+      }
+    ).mockRejectedValue(new Error("network down"));
 
-    await expect(plugin.refreshFeeds([plugin.settings.feeds[0]])).resolves.toBeUndefined();
+    await expect(
+      plugin.refreshFeeds([plugin.settings.feeds[0]]),
+    ).resolves.toBeUndefined();
     expect(plugin.settings.feeds[0].lastUpdated).toBe(1);
     expect(plugin.settings.feeds[0].lastRefreshAttemptCompletedAt).toBe(9_876);
     expect(plugin.settings.feeds[0].lastFetchError).toBe("network down");
@@ -484,7 +597,9 @@ describe("refreshFeeds() pipeline behavior", () => {
   it("skips refresh when feedParser is not initialized yet", async () => {
     const plugin = createPluginWithSettings([createFeed()]);
     plugin.feedParser = undefined as unknown as TestFeedParser;
-    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
 
     await expect(plugin.refreshFeeds()).resolves.toBeUndefined();
 
@@ -493,5 +608,374 @@ describe("refreshFeeds() pipeline behavior", () => {
     );
     expect(plugin.saveData).not.toHaveBeenCalled();
     expect(getNoticeMessages(consoleLogSpy)).toEqual([]);
+  });
+
+  // ── TDD red: cancellable global/due refresh ────────────────────────────────
+
+  it("exposes cancelGlobalRefresh as a method on the plugin", () => {
+    const plugin = createPluginWithSettings([createFeed()]);
+    expect(typeof plugin.cancelGlobalRefresh).toBe("function");
+  });
+
+  it("reports isGlobalRefreshCancellable as false before a refresh starts", () => {
+    const plugin = createPluginWithSettings([createFeed()]);
+    expect(plugin.isGlobalRefreshCancellable).toBe(false);
+  });
+
+  it("reports isGlobalRefreshCancellable as true during a multi-feed global refresh", async () => {
+    vi.useFakeTimers();
+    const feedA = createFeed({ url: "https://example.com/a.xml" });
+    const feedB = createFeed({ url: "https://example.com/b.xml" });
+    const plugin = createPluginWithSettings([feedA, feedB]);
+
+    const resolvers: Array<() => void> = [];
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation(
+      () =>
+        new Promise<Feed>((resolve) =>
+          resolvers.push(() => resolve(createFeed())),
+        ),
+    );
+
+    const refreshPromise = plugin.refreshFeeds();
+    await flushMicrotasks();
+
+    expect(plugin.isGlobalRefreshCancellable).toBe(true);
+    expect(plugin.globalRefreshProgress).toEqual({ completed: 0, total: 2 });
+
+    resolvers.forEach((r) => r?.());
+    await flushMicrotasks();
+    await refreshPromise;
+    vi.useRealTimers();
+  });
+
+  it("keeps a one-feed global refresh cancellable", async () => {
+    vi.useFakeTimers();
+    const feed = createFeed({ url: "https://example.com/only.xml" });
+    const plugin = createPluginWithSettings([feed]);
+    const resolvers: Array<() => void> = [];
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation(
+      () =>
+        new Promise<Feed>((resolve) =>
+          resolvers.push(() => resolve({ ...feed, lastUpdated: 999 })),
+        ),
+    );
+
+    const refreshPromise = plugin.refreshFeeds();
+    await flushMicrotasks();
+
+    expect(plugin.isGlobalRefreshCancellable).toBe(true);
+    expect(plugin.feedParser.refreshFeed.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    plugin.cancelGlobalRefresh();
+    resolvers.forEach((resolve) => resolve());
+    await flushMicrotasks();
+    await refreshPromise;
+    vi.useRealTimers();
+  });
+
+  it("does not offer cancellation for due refresh intent", async () => {
+    vi.useFakeTimers();
+    const feedA = createFeed({ url: "https://example.com/a.xml" });
+    const feedB = createFeed({ url: "https://example.com/b.xml" });
+    const plugin = createPluginWithSettings([feedA, feedB]);
+
+    const resolvers: Array<() => void> = [];
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation(
+      () =>
+        new Promise<Feed>((resolve) =>
+          resolvers.push(() => resolve(createFeed())),
+        ),
+    );
+
+    const refreshPromise = plugin.refreshFeeds([feedA, feedB], "due");
+    await flushMicrotasks();
+
+    expect(plugin.isGlobalRefreshCancellable).toBe(false);
+    expect(plugin.feedParser.refreshFeed.mock.calls[0]?.[1]).toEqual({
+      signal: undefined,
+    });
+
+    resolvers.forEach((r) => r?.());
+    await flushMicrotasks();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    await refreshPromise;
+  });
+
+  it("does not offer cancellation for retry-failed refresh intent", async () => {
+    vi.useFakeTimers();
+    const failed1 = createFeed({
+      url: "https://example.com/failed1.xml",
+      lastFetchError: "network down",
+    });
+    const failed2 = createFeed({
+      url: "https://example.com/failed2.xml",
+      lastFetchError: "network down",
+    });
+    const plugin = createPluginWithSettings([failed1, failed2]);
+
+    const resolvers: Array<() => void> = [];
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation(
+      () =>
+        new Promise<Feed>((resolve) =>
+          resolvers.push(() => resolve(createFeed())),
+        ),
+    );
+
+    const refreshPromise = plugin.refreshFailedFeeds();
+    await flushMicrotasks();
+
+    expect(plugin.isGlobalRefreshCancellable).toBe(false);
+
+    resolvers.forEach((r) => r?.());
+    await flushMicrotasks();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    await refreshPromise;
+  });
+
+  it("cancelGlobalRefresh stops an in-flight global refresh, prevents late commits, and protects lastGlobalRefreshCompletedAt", async () => {
+    vi.useFakeTimers();
+    const feedA = createFeed({
+      url: "https://example.com/a.xml",
+      lastUpdated: 100,
+    });
+    const feedB = createFeed({
+      url: "https://example.com/b.xml",
+      lastUpdated: 200,
+    });
+    const feedC = createFeed({
+      url: "https://example.com/c.xml",
+      lastUpdated: 300,
+    });
+
+    const plugin = createPluginWithSettings([feedA, feedB, feedC]);
+    plugin.settings.lastGlobalRefreshCompletedAt = 42;
+
+    const viewRefreshSpy = vi.fn();
+    const sidebarRefreshSpy = vi.fn();
+    vi.spyOn(plugin, "getActiveDashboardView").mockResolvedValue({
+      refreshSidebarOnly: sidebarRefreshSpy,
+      refresh: viewRefreshSpy,
+    } as unknown as Awaited<
+      ReturnType<typeof RssDashboardPlugin.prototype.getActiveDashboardView>
+    >);
+
+    const resolvers: Array<() => void> = [];
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation((feed: Feed) => {
+      return new Promise<Feed>((resolve) => {
+        resolvers.push(() => resolve({ ...feed, lastUpdated: 999 }));
+      });
+    });
+
+    const refreshPromise = plugin.refreshFeeds();
+    await flushMicrotasks();
+
+    expect(plugin.isGlobalRefreshCancellable).toBe(true);
+    expect(plugin.globalRefreshProgress.total).toBe(3);
+
+    plugin.cancelGlobalRefresh();
+
+    expect(plugin.globalRefreshProgress.total).toBe(3);
+
+    resolvers.forEach((r) => r?.());
+    await flushMicrotasks();
+
+    await refreshPromise;
+
+    expect(plugin.settings.feeds[0].lastUpdated).toBe(100);
+    expect(plugin.settings.feeds[1].lastUpdated).toBe(200);
+    expect(plugin.settings.feeds[2].lastUpdated).toBe(300);
+
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBe(42);
+
+    expect(plugin.saveData).toHaveBeenCalled();
+
+    const notices = getNoticeMessages(consoleLogSpy);
+    expect(notices).toContain("Refreshing 3 feeds...");
+    expect(notices).toContain("Refresh stopped.");
+    expect(notices.some((n) => n.startsWith("Feeds refreshed:"))).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("forwards an abort signal to feedParser.refreshFeed during a cancellable global refresh", async () => {
+    vi.useFakeTimers();
+    const feedA = createFeed({ url: "https://example.com/a.xml" });
+    const feedB = createFeed({ url: "https://example.com/b.xml" });
+    const plugin = createPluginWithSettings([feedA, feedB]);
+
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (
+          fn: (feed: Feed, options?: unknown) => Promise<Feed>,
+        ) => void;
+      }
+    ).mockImplementation(async (feed: Feed) => {
+      return feed;
+    });
+
+    const refreshPromise = plugin.refreshFeeds();
+    await flushMicrotasks();
+
+    const firstCallArgs = plugin.feedParser.refreshFeed.mock.calls[0];
+    expect(firstCallArgs[1]).toBeDefined();
+    expect((firstCallArgs[1] as { signal?: AbortSignal }).signal).toBeDefined();
+    expect(
+      (firstCallArgs[1] as { signal?: AbortSignal }).signal,
+    ).toBeInstanceOf(AbortSignal);
+
+    await refreshPromise;
+    vi.useRealTimers();
+  });
+
+  it("tracks globalRefreshProgress as feeds complete during a global refresh", async () => {
+    vi.useFakeTimers();
+    const feedA = createFeed({
+      url: "https://example.com/a.xml",
+      lastUpdated: 100,
+    });
+    const feedB = createFeed({
+      url: "https://example.com/b.xml",
+      lastUpdated: 200,
+    });
+    const feedC = createFeed({
+      url: "https://example.com/c.xml",
+      lastUpdated: 300,
+    });
+
+    const plugin = createPluginWithSettings([feedA, feedB, feedC]);
+
+    vi.spyOn(plugin, "getActiveDashboardView").mockResolvedValue(null);
+
+    const resolvers: Array<() => void> = [];
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation((feed: Feed) => {
+      return new Promise<Feed>((resolve) => {
+        resolvers.push(() => resolve({ ...feed, lastUpdated: 999 }));
+      });
+    });
+
+    const refreshPromise = plugin.refreshFeeds();
+    await flushMicrotasks();
+
+    expect(plugin.globalRefreshProgress).toEqual({ completed: 0, total: 3 });
+
+    resolvers[0]?.();
+    await flushMicrotasks();
+    expect(plugin.globalRefreshProgress.completed).toBe(1);
+    expect(plugin.globalRefreshProgress.total).toBe(3);
+
+    resolvers[1]?.();
+    resolvers[2]?.();
+    await flushMicrotasks();
+    await refreshPromise;
+
+    expect(plugin.globalRefreshProgress.total).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it("does not reset lastGlobalRefreshCompletedAt on a new global refresh when cancelled", async () => {
+    vi.useFakeTimers();
+    const feedA = createFeed({ url: "https://example.com/a.xml" });
+    const feedB = createFeed({ url: "https://example.com/b.xml" });
+    const plugin = createPluginWithSettings([feedA, feedB]);
+    plugin.settings.lastGlobalRefreshCompletedAt = 42;
+
+    const resolvers: Array<() => void> = [];
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation((feed: Feed) => {
+      return new Promise<Feed>((resolve) => {
+        resolvers.push(() => resolve(feed));
+      });
+    });
+
+    vi.spyOn(plugin, "getActiveDashboardView").mockResolvedValue(null);
+
+    const refreshPromise = plugin.refreshFeeds();
+    await flushMicrotasks();
+
+    plugin.cancelGlobalRefresh();
+
+    resolvers.forEach((r) => r?.());
+    await flushMicrotasks();
+    await refreshPromise;
+
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBe(42);
+    vi.useRealTimers();
+  });
+
+  it("completes normally without cancellation, updating lastGlobalRefreshCompletedAt", async () => {
+    vi.useFakeTimers();
+    const feedA = createFeed({
+      url: "https://example.com/a.xml",
+      lastUpdated: 100,
+    });
+    const feedB = createFeed({
+      url: "https://example.com/b.xml",
+      lastUpdated: 200,
+    });
+    const plugin = createPluginWithSettings([feedA, feedB]);
+    vi.spyOn(Date, "now").mockReturnValue(5_000);
+
+    const resolvers: Array<() => void> = [];
+    (
+      plugin.feedParser.refreshFeed as unknown as {
+        mockImplementation: (fn: (feed: Feed) => Promise<Feed>) => void;
+      }
+    ).mockImplementation((feed: Feed) => {
+      return new Promise<Feed>((resolve) => {
+        resolvers.push(() => resolve({ ...feed, lastUpdated: 999 }));
+      });
+    });
+
+    vi.spyOn(plugin, "getActiveDashboardView").mockResolvedValue(null);
+
+    const refreshPromise = plugin.refreshFeeds();
+    await flushMicrotasks();
+
+    expect(plugin.isGlobalRefreshCancellable).toBe(true);
+
+    resolvers.forEach((r) => r?.());
+    await flushMicrotasks();
+    await refreshPromise;
+
+    expect(plugin.settings.feeds[0].lastUpdated).toBe(999);
+    expect(plugin.settings.feeds[1].lastUpdated).toBe(999);
+    expect(plugin.settings.lastGlobalRefreshCompletedAt).toBe(5_000);
+
+    const notices = getNoticeMessages(consoleLogSpy);
+    expect(notices).toContain("Refreshing 2 feeds...");
+    expect(notices).toContain("Feeds refreshed: 2 feeds");
+    expect(notices).not.toContain("Refresh stopped.");
+    vi.useRealTimers();
   });
 });

--- a/test_files/unit/services/feed-parser/feed-parser-class.test.ts
+++ b/test_files/unit/services/feed-parser/feed-parser-class.test.ts
@@ -814,4 +814,24 @@ describe("FeedParser.parseFeed", () => {
 
     requestUrlSpy.mockRestore();
   });
+
+  it("does not persist an abort as a feed failure", async () => {
+    const feed: Feed = {
+      title: "Abortable Feed",
+      url: "https://example.com/abortable.xml",
+      folder: "Uncategorized",
+      items: [],
+      lastUpdated: Date.now(),
+      lastFetchError: "previous error",
+    };
+    const parser = new FeedParser(DEFAULT_SETTINGS.display, [], mediaSettings);
+    vi.spyOn(parser, "parseFeed").mockRejectedValue(new Error("Aborted"));
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      parser.refreshFeed(feed, { signal: controller.signal }),
+    ).rejects.toThrow("Aborted");
+    expect(feed.lastFetchError).toBe("previous error");
+  });
 });

--- a/test_files/unit/settings/sidebar-settings-tab.test.ts
+++ b/test_files/unit/settings/sidebar-settings-tab.test.ts
@@ -42,6 +42,32 @@ beforeEach(() => {
 });
 
 describe("renderSidebarSettingsTab() - domain icon toggles", () => {
+  it("renders each icon visibility setting with its icon name", () => {
+    const containerEl = document.body.appendChild(
+      document.createElement("div"),
+    );
+    const plugin = {
+      app: obsidian.App.createMock(),
+      settings: cloneSettings(),
+      saveSettings: vi.fn(async () => {}),
+      clearPlaybackProgress: vi.fn(async () => 0),
+      getActiveDashboardView: vi.fn(async () => null),
+    } as unknown as RssDashboardPlugin;
+
+    renderSidebarSettingsTab(containerEl, plugin, vi.fn());
+
+    const iconRows = Array.from(
+      containerEl.querySelectorAll(".rss-dashboard-icon-visibility-row"),
+    );
+    expect(iconRows.length).toBeGreaterThan(0);
+    expect(
+      iconRows.map((row) => row.querySelector(".setting-item-name")?.textContent),
+    ).not.toContain("[object DocumentFragment]");
+    expect(
+      iconRows.map((row) => row.querySelector(".setting-item-name")?.textContent),
+    ).toContain("Discover");
+  });
+
   it("renders and persists the RSS site icons toggle", async () => {
     const containerEl = document.body.appendChild(
       document.createElement("div"),


### PR DESCRIPTION
- Added a Stop button on the All feeds sidebar row during global refreshes, allowing users to cancel an in-progress refresh, including when only one eligible feed remains. Cancelled feeds do not advance their refresh timestamps, and in-progress fetches are aborted via an AbortSignal. Failed-feed retries and folder/selected/tag/due refreshes remain non-cancellable. [GH Issue #173](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/173)