### PR TITLE
Fix independent dashboard preview settings

### DIFF
--- a/.agents/skills/work-on-rss-dashboard-change/SKILL.md
+++ b/.agents/skills/work-on-rss-dashboard-change/SKILL.md
@@ -38,6 +38,13 @@ workflow proportional to risk while preserving the repository's audit gates.
   the exact issue URL, and replace draft dependency filenames with issue URLs.
   The issue may remain unassigned, but milestone work must name its milestone
   and whether it is Required or Stretch.
+- Before changing implementation code or tests, create the issue branch from
+  the current `dev` branch. Name it from the canonical plan filename:
+  `fix/<issue-number>-<slug>` for bugs and `feat/<issue-number>-<slug>` for
+  features or enhancements. The `<slug>` is the plan filename after the
+  issue-number prefix and before `.md`. Confirm the new branch starts at the
+  current `dev` tip; if unrelated working-tree changes prevent a safe branch
+  switch, preserve them and ask the user how to proceed.
 - Inspect the relevant production code, tests, types, documentation, and nearby
   patterns before asking questions that the repository can answer.
 - State observable acceptance criteria. Classify the work as a feature or fix,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- Fixed dashboard Card and Feed preview settings so cover images and summaries can be controlled independently, cover-only cards retain their image on hover, and disabling cover images avoids dashboard preview-image loading. [GH Issue #175](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/175)
 - Fixed sidebar icon visibility settings displaying `[object DocumentFragment]` instead of each icon's name.
 - Fixed the All feeds refresh-details popup showing alongside Obsidian's delayed native tooltip. [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168)
 - Fixed refresh-detail tooltip and ghost-popup regressions, and prevented global-refresh vault saves from reloading empty article shards. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,13 @@
+# RSS Dashboard
+
+Vocabulary for the RSS Dashboard's user-facing reading and browsing experience.
+
+## Language
+
+**Cover-image preview**:
+The article image shown in a dashboard Card or Feed preview region. It is distinct from images in Reader content.
+_Avoid_: cover image, hero image
+
+**Preview summary**:
+The article text excerpt shown as a Card overlay or summary-only preview, or in a Feed item's text region.
+_Avoid_: summary overlay, description

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -9,6 +9,7 @@ records the complete 2026-08-16 documentation classification.
 
 | Plan                                                                                   | Completed  | Issue                                                                               | Implementation |
 | -------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------- | -------------- |
+| [Independent dashboard preview settings](plans/unreleased/175-independent-dashboard-preview-settings.md) | 2026-08-21 | [GH Issue #175](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/175) | â€”              |
 | [Documentation archive cleanup](plans/unreleased/169-documentation-archive-cleanup.md) | 2026-08-16 | [GH Issue #169](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/169) | `314ae6f`      |
 | [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) | `5592c39`      |
 | [Refresh status and progress indicators](plans/unreleased/167-refresh-status-indicators.md) | 2026-08-16 | [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167) | `6f767c7`      |

--- a/docs/archive/plans/unreleased/175-independent-dashboard-preview-settings.md
+++ b/docs/archive/plans/unreleased/175-independent-dashboard-preview-settings.md
@@ -1,0 +1,157 @@
+---
+status: implemented
+completed: 2026-08-21
+released_in: unreleased
+issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/175
+implementation: ""
+---
+
+# Fix Independent Dashboard Preview Display Settings
+
+## Status and scope
+
+- **Classification:** Bug fix.
+- **Risk:** Medium. The existing shared display preferences affect two dashboard
+  renderers and their settings UI, but require no persistence migration, new
+  network domain, or parser change.
+- **Canonical issue:** [#175](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/175).
+- **Milestone:** `vNext`, **Required**.
+- **Affected surfaces:** Dashboard Card View, Feed View, and Display settings.
+- **Unaffected surfaces:** List View, Reader View, Discover, feed refresh and
+  parsing, and persisted article metadata.
+
+## Problem and user value
+
+The existing **Show cover images** and **Show summary** preferences are stored
+but ignored by the dashboard Card and Feed renderers. Both preview elements are
+therefore always produced, and the cover-image setting description incorrectly
+claims a Reader View scope.
+
+Users need independent control over dashboard preview imagery and text. Turning
+off cover-image previews must avoid their dashboard-only URL resolution and
+remote image loading, while leaving preview summaries available when requested.
+
+## Domain language
+
+- A **cover-image preview** is the article image in a dashboard Card or Feed
+  preview region; it is not a Reader image.
+- A **preview summary** is the article excerpt in a Card overlay or summary-only
+  preview, or in a Feed item's text region.
+
+## Proposed behavior
+
+Both preferences apply immediately after the user changes them: save the value
+and rerender the active dashboard in either Card or Feed view.
+
+| Show cover images | Show summary | Dashboard result |
+| --- | --- | --- |
+| On | On | Cover-image preview plus summary overlay in Card View; cover-image preview plus preview summary in Feed View. |
+| On | Off | Cover-image preview only; Card View retains the image on hover. |
+| Off | On | Preview summary only. |
+| Off | Off | Neither preview element is produced. |
+
+When **Show cover images** is off, Card and Feed renderers must not call their
+dashboard preview-image resolver and must not create an image or Feed blur
+background element. This does not remove, rewrite, or prevent parsing of the
+stored `coverImage` or `image` fields.
+
+When **Show summary** is off, Card View must not create a summary overlay or a
+summary-only fallback, including after a cover-image load error. Feed View must
+not create its preview summary. The setting must not affect cover-image
+visibility.
+
+Update the cover-images setting description to: **"Display cover-image previews
+in dashboard card and feed views. Turning this off reduces remote image loading
+and can improve browsing performance."**
+
+## Acceptance criteria
+
+1. Card View implements all four preference combinations in the behavior table.
+2. Feed View implements all four preference combinations in the behavior table.
+3. With cover images disabled, neither renderer resolves a dashboard
+   cover-image URL or creates image/blur preview elements.
+4. With summaries disabled, neither renderer produces a preview summary;
+   Card View also suppresses summary-only fallback after an image error.
+5. Changing either preference saves it and immediately rerenders an active
+   dashboard in Card or Feed view.
+6. Existing image source precedence remains unchanged when cover images are
+   enabled: Card View prefers `coverImage`, then `image`; Feed View prefers
+   `image`, then `coverImage`.
+7. List View, Reader View, Discover, feed parsing, refresh behavior, and
+   stored image metadata remain unchanged.
+8. The cover-images setting description accurately identifies its dashboard
+   scope and the remote-loading/performance benefit.
+9. In Card View, an image-only preview does not reveal the summary surface on
+   hover; the cover image remains visible.
+
+## Implementation direction
+
+1. Add focused failing jsdom tests in the existing Card and Feed view test
+   suites. Cover each combination, resolver non-invocation when imagery is off,
+   and Card's broken-image fallback behavior.
+2. Gate `resolveArticlePreviewImage` and all cover-image DOM creation behind
+   `settings.display.showCoverImage`; keep existing candidate precedence.
+3. Gate `getArticlePreviewSummaryText` and all preview-summary DOM creation
+   behind `settings.display.showSummary`.
+4. Update the Display settings handlers to rerender the active dashboard for
+   both dashboard view styles after saving either preference, and correct the
+   cover-images description.
+5. Preserve owning-document and Obsidian DOM-helper conventions. No CSS change
+   is expected except for scoping the Card hover reveal to cover containers that
+   have a summary.
+
+Likely files:
+
+- `src/components/article-list/views/card-view.ts`
+- `src/components/article-list/views/feed-view.ts`
+- `src/settings/tabs/display-settings-tab.ts`
+- `test_files/unit/components/article-list/views/card-view.test.ts`
+- `test_files/unit/components/article-list/views/feed-view.test.ts`
+- A focused settings-tab test if no existing behavior-level rerender seam can
+  cover the handlers.
+
+## Validation
+
+- Passed focused Card View, Feed View, and Display settings tests (34 tests).
+- Passed `npm run check:platform`.
+- Passed `npm run build`, including compliance checks, ESLint, and TypeScript
+  checking.
+- Passed `npm run test:unit` (190 files, 1,687 tests).
+- `git status --short` reported only the expected implementation, test,
+  changelog, plan, and domain-language changes; the build created no unexpected
+  tracked artifacts.
+
+Manual checks passed locally on 2026-08-21, including visual inspection of the
+four preference combinations and the image-only Card hover state.
+
+## Manual checks
+
+- In Card View and Feed View, verify all four preference combinations with an
+  article that has both a cover image and a summary.
+- Verify summary-only behavior with an article lacking an image and with a
+  deliberately broken image URL.
+- Toggle each preference while its affected dashboard view is open and confirm
+  the result updates immediately.
+- With cover images on and summaries off, hover a Card View cover image and
+  confirm it remains visible without a blank preview surface.
+- Confirm no preview image or blur-background request is initiated after cover
+  images are disabled, using desktop developer tools when available.
+- Verify desktop, mobile, popout, light-theme, and dark-theme dashboard views.
+- Confirm Reader, List, and Discover behavior remains unchanged.
+
+## Non-goals and risks
+
+- No change to feed parsing, image URL persistence, cache, or refresh requests.
+- No change to Reader, List, or Discover imagery and summaries.
+- No new settings, migrations, dependencies, CSS policy changes, or image
+  source-selection rules.
+- Browser image loading is lazy and asynchronous; verification must prove that
+  disabled dashboard previews do not add image or background elements, rather
+  than attempting to retract requests already started before a toggle.
+
+## Changelog and lifecycle
+
+After implementation and validation, add one concise **Unreleased -> Fixes**
+entry with the canonical issue link, archive this plan under
+`docs/archive/plans/unreleased/`, and update the archive catalog and inbound
+links.

--- a/src/components/article-list/views/card-view.ts
+++ b/src/components/article-list/views/card-view.ts
@@ -80,11 +80,12 @@ export function renderCardView(
       });
     }
 
-    const coverImgSrc = resolveArticlePreviewImage(article, [
-      "coverImage",
-      "image",
-    ]);
-    const previewSummaryText = getArticlePreviewSummaryText(article);
+    const coverImgSrc = ctx.settings.display.showCoverImage
+      ? resolveArticlePreviewImage(article, ["coverImage", "image"])
+      : undefined;
+    const previewSummaryText = ctx.settings.display.showSummary
+      ? getArticlePreviewSummaryText(article)
+      : "";
 
     if (coverImgSrc) {
       const previewRegion = cardContent.createDiv({

--- a/src/components/article-list/views/feed-view.ts
+++ b/src/components/article-list/views/feed-view.ts
@@ -37,10 +37,9 @@ function renderArticleCard(
     cls: "rss-dashboard-feed-content",
   });
 
-  const coverImgSrc = resolveArticlePreviewImage(article, [
-    "image",
-    "coverImage",
-  ]);
+  const coverImgSrc = ctx.settings.display.showCoverImage
+    ? resolveArticlePreviewImage(article, ["image", "coverImage"])
+    : undefined;
   if (coverImgSrc) {
     const previewRegion = feedContent.createDiv({
       cls: "rss-dashboard-feed-preview-region",
@@ -96,7 +95,9 @@ function renderArticleCard(
     });
   }
 
-  const feedPreviewText = getArticlePreviewSummaryText(article);
+  const feedPreviewText = ctx.settings.display.showSummary
+    ? getArticlePreviewSummaryText(article)
+    : "";
   if (feedPreviewText) {
     const summaryEl = textRegion.createDiv({
       cls: "rss-dashboard-feed-summary",

--- a/src/settings/tabs/display-settings-tab.ts
+++ b/src/settings/tabs/display-settings-tab.ts
@@ -51,17 +51,30 @@ export function renderDisplaySettingsTab(
     await rerenderActiveReaderView();
   };
 
+  const rerenderActiveDashboardView = async (): Promise<void> => {
+    const view = await plugin.getActiveDashboardView();
+    if (!view) {
+      return;
+    }
+
+    await plugin.app.workspace.revealLeaf(view.leaf);
+    view.render();
+  };
+
   new Setting(containerEl).setName("Dashboard").setHeading();
 
   new Setting(containerEl)
     .setName("Show cover images")
-    .setDesc("Display cover images for articles in reader view")
+    .setDesc(
+      "Display cover-image previews in dashboard card and feed views. Turning this off reduces remote image loading and can improve browsing performance.",
+    )
     .addToggle((toggle) =>
       toggle
         .setValue(plugin.settings.display.showCoverImage)
         .onChange(async (value) => {
           plugin.settings.display.showCoverImage = value;
           await plugin.saveSettings();
+          await rerenderActiveDashboardView();
         }),
     );
 
@@ -74,11 +87,7 @@ export function renderDisplaySettingsTab(
         .onChange(async (value) => {
           plugin.settings.display.showSummary = value;
           await plugin.saveSettings();
-          const view = await plugin.getActiveDashboardView();
-          if (view && plugin.settings.viewStyle === "card") {
-            await plugin.app.workspace.revealLeaf(view.leaf);
-            view.render();
-          }
+          await rerenderActiveDashboardView();
         }),
     );
 

--- a/src/styles/card-view.css
+++ b/src/styles/card-view.css
@@ -59,11 +59,17 @@
   line-height: 1.5;
 }
 
-.rss-dashboard-cover-container:hover .rss-dashboard-cover-image {
+.rss-dashboard-card-view
+  .rss-dashboard-card-preview-region
+  .rss-dashboard-cover-container.has-summary:hover
+  .rss-dashboard-cover-image {
   opacity: 0;
 }
 
-.rss-dashboard-cover-container:hover .rss-dashboard-summary-overlay {
+.rss-dashboard-card-view
+  .rss-dashboard-card-preview-region
+  .rss-dashboard-cover-container.has-summary:hover
+  .rss-dashboard-summary-overlay {
   opacity: 1;
 }
 
@@ -670,14 +676,14 @@
 
 .rss-dashboard-card-view
   .rss-dashboard-card-preview-region
-  .rss-dashboard-cover-container:hover
+  .rss-dashboard-cover-container.has-summary:hover
   .rss-dashboard-cover-image {
   opacity: 0;
 }
 
 .rss-dashboard-card-view
   .rss-dashboard-card-preview-region
-  .rss-dashboard-cover-container:hover
+  .rss-dashboard-cover-container.has-summary:hover
   .rss-dashboard-summary-overlay {
   opacity: 1;
 }

--- a/test_files/unit/components/article-list/views/card-view.test.ts
+++ b/test_files/unit/components/article-list/views/card-view.test.ts
@@ -88,6 +88,43 @@ describe("card-view", () => {
     expect(container.querySelector(".rss-dashboard-cover-image")).toBeTruthy();
   });
 
+  it.each([
+    { showCoverImage: true, showSummary: true, image: true, summary: true },
+    { showCoverImage: true, showSummary: false, image: true, summary: false },
+    { showCoverImage: false, showSummary: true, image: false, summary: true },
+    { showCoverImage: false, showSummary: false, image: false, summary: false },
+  ])(
+    "renders Card View previews independently when cover images are $showCoverImage and summaries are $showSummary",
+    ({ showCoverImage, showSummary, image, summary }) => {
+      renderCardView(
+        container,
+        [makeArticle({ coverImage: "https://example.com/cover.jpg" })],
+        {
+          ...baseViewContext(),
+          settings: {
+            highlights: {
+              highlightInTitles: false,
+              highlightInSummaries: false,
+            },
+            display: { showCoverImage, showSummary, articleDateStyle: "relative" },
+          },
+          showCardToolbar: true,
+        },
+        baseViewDeps(),
+      );
+
+      expect(!!container.querySelector(".rss-dashboard-cover-image")).toBe(image);
+      expect(
+        !!container.querySelector(
+          ".rss-dashboard-summary-overlay, .rss-dashboard-cover-summary-only",
+        ),
+      ).toBe(summary);
+      expect(!!container.querySelector(".rss-dashboard-card-preview-region")).toBe(
+        image || summary,
+      );
+    },
+  );
+
   it("renders summary-only preview when no image is available", () => {
     renderCardView(
       container,
@@ -179,6 +216,33 @@ describe("card-view", () => {
     expect(
       container.querySelector(".rss-dashboard-cover-summary-only")?.textContent,
     ).toBe("Article description text");
+  });
+
+  it("does not render a summary fallback after an image error when summaries are disabled", () => {
+    renderCardView(
+      container,
+      [makeArticle({ coverImage: "https://example.com/broken.jpg" })],
+      {
+        ...baseViewContext(),
+        settings: {
+          highlights: {
+            highlightInTitles: false,
+            highlightInSummaries: false,
+          },
+          display: { showCoverImage: true, showSummary: false, articleDateStyle: "relative" },
+        },
+        showCardToolbar: true,
+      },
+      baseViewDeps(),
+    );
+
+    const image = container.querySelector(
+      "img.rss-dashboard-cover-image",
+    ) as HTMLImageElement;
+    image.dispatchEvent(new Event("error"));
+
+    expect(container.querySelector(".rss-dashboard-card-preview-region")).toBeFalsy();
+    expect(container.querySelector(".rss-dashboard-cover-summary-only")).toBeFalsy();
   });
 
   it("omits preview region when no image or summary text is available", () => {

--- a/test_files/unit/components/article-list/views/feed-view.test.ts
+++ b/test_files/unit/components/article-list/views/feed-view.test.ts
@@ -73,6 +73,41 @@ describe("feed-view", () => {
     ).toBeTruthy();
   });
 
+  it.each([
+    { showCoverImage: true, showSummary: true, image: true, summary: true },
+    { showCoverImage: true, showSummary: false, image: true, summary: false },
+    { showCoverImage: false, showSummary: true, image: false, summary: true },
+    { showCoverImage: false, showSummary: false, image: false, summary: false },
+  ])(
+    "renders Feed View previews independently when cover images are $showCoverImage and summaries are $showSummary",
+    ({ showCoverImage, showSummary, image, summary }) => {
+      renderFeedView(
+        container,
+        [makeArticle({ coverImage: "https://example.com/cover.jpg" })],
+        baseViewContext({
+          settings: {
+            highlights: {
+              highlightInTitles: false,
+              highlightInSummaries: false,
+            },
+            display: { showCoverImage, showSummary, articleDateStyle: "relative" },
+          },
+        }),
+        baseViewDeps(),
+      );
+
+      expect(!!container.querySelector(".rss-dashboard-feed-hero-image")).toBe(
+        image,
+      );
+      expect(!!container.querySelector(".rss-dashboard-feed-hero-blur")).toBe(
+        image,
+      );
+      expect(!!container.querySelector(".rss-dashboard-feed-summary")).toBe(
+        summary,
+      );
+    },
+  );
+
   it("does not render a hero when stale article media is a LaTeX formula", () => {
     const formulaUrl =
       "https://s0.wp.com/latex.php?latex=%7Bx%7D&bg=ffffff";

--- a/test_files/unit/components/article-list/views/test-helpers.ts
+++ b/test_files/unit/components/article-list/views/test-helpers.ts
@@ -32,6 +32,8 @@ export function baseViewContext(
         highlightInSummaries: false,
       },
       display: {
+        showCoverImage: true,
+        showSummary: true,
         articleDateStyle: "relative",
       },
     } as BaseViewContext["settings"],

--- a/test_files/unit/settings/display-reader-settings-tab.test.ts
+++ b/test_files/unit/settings/display-reader-settings-tab.test.ts
@@ -31,6 +31,47 @@ beforeEach(() => {
 });
 
 describe("renderDisplaySettingsTab() reader section", () => {
+  it("describes dashboard previews and rerenders the active Feed dashboard after either preview preference changes", async () => {
+    const containerEl = document.createElement("div");
+    document.body.appendChild(containerEl);
+    const settings = cloneSettings();
+    settings.viewStyle = "feed";
+    const render = vi.fn();
+    const saveSettings = vi.fn(async () => {});
+    const revealLeaf = vi.fn(async () => {});
+    const plugin = {
+      app: { workspace: { revealLeaf } },
+      settings,
+      saveSettings,
+      getActiveDashboardView: vi.fn(async () => ({ leaf: {}, render })),
+      getActiveReaderView: vi.fn(async () => null),
+    } as unknown as RssDashboardPlugin;
+
+    renderDisplaySettingsTab(containerEl, plugin, () => {});
+
+    const coverImages = getSettingByName(containerEl, "Show cover images");
+    expect(coverImages.querySelector(".setting-item-description")?.textContent).toBe(
+      "Display cover-image previews in dashboard card and feed views. Turning this off reduces remote image loading and can improve browsing performance.",
+    );
+    const coverToggle = coverImages.querySelector("input") as HTMLInputElement;
+    coverToggle.checked = false;
+    coverToggle.dispatchEvent(new Event("change"));
+    await flushPromises();
+
+    const summaryToggle = getSettingByName(containerEl, "Show summary").querySelector(
+      "input",
+    ) as HTMLInputElement;
+    summaryToggle.checked = false;
+    summaryToggle.dispatchEvent(new Event("change"));
+    await flushPromises();
+
+    expect(settings.display.showCoverImage).toBe(false);
+    expect(settings.display.showSummary).toBe(false);
+    expect(saveSettings).toHaveBeenCalledTimes(2);
+    expect(revealLeaf).toHaveBeenCalledTimes(2);
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
   it("renders a Reader section without paragraph width", () => {
     const containerEl = document.createElement("div");
     document.body.appendChild(containerEl);


### PR DESCRIPTION
## Summary
- make cover-image and summary previews independent in dashboard Card and Feed views
- skip dashboard preview-image resolution and loading when cover images are disabled
- retain cover-only Card images on hover instead of revealing a blank preview surface
- document the issue-branch workflow and archive the completed plan

Closes #175

## Validation
- npm run build
- npm run test:unit (190 files, 1,687 tests)
- manual visual inspection in Obsidian