### PR TITLE
fix: add image preview disk cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Added opt-in local caching for Dashboard Card and Feed preview images, with a 1 MiB per-image limit, a synchronized 1–1024 MiB slider/input or unlimited aggregate cap, cache management controls, remote-image fallback, cache warming after feed additions and OPML/background imports, a dashboard refresh when background warming finishes, protection against refreshes overwriting Discover feeds that are still hydrating, and automatic cache cleanup when all feeds are deleted. [GH Issue #177](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/177)
 - Added a Stop button on the All feeds sidebar row during global refreshes, allowing users to cancel an in-progress refresh, including when only one eligible feed remains. Cancelled feeds do not advance their refresh timestamps, and in-progress fetches are aborted via an AbortSignal. Failed-feed retries and folder/selected/tag/due refreshes remain non-cancellable. [GH Issue #173](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/173)
 - Added Shift+click and an All feeds context-menu action to retry failed, non-excluded feeds without advancing the global refresh timestamp. [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168)
 - Added static refresh-status timestamps and accessible refresh details for all feeds, folders, and feeds. [GH Issue #167](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/167)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- Fixed cached preview images remaining after their feed is deleted from the sidebar.
 - Fixed dashboard Card and Feed preview settings so cover images and summaries can be controlled independently, cover-only cards retain their image on hover, and disabling cover images avoids dashboard preview-image loading. [GH Issue #175](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/175)
 - Fixed sidebar icon visibility settings displaying `[object DocumentFragment]` instead of each icon's name.
 - Fixed the All feeds refresh-details popup showing alongside Obsidian's delayed native tooltip. [GH Issue #168](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/168)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -9,6 +9,7 @@ records the complete 2026-08-16 documentation classification.
 
 | Plan                                                                                   | Completed  | Issue                                                                               | Implementation |
 | -------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------- | -------------- |
+| [Image preview disk cache](plans/unreleased/177-image-preview-disk-cache.md) | 2026-08-21 | [GH Issue #177](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/177) | — |
 | [Independent dashboard preview settings](plans/unreleased/175-independent-dashboard-preview-settings.md) | 2026-08-21 | [GH Issue #175](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/175) | â€”              |
 | [Documentation archive cleanup](plans/unreleased/169-documentation-archive-cleanup.md) | 2026-08-16 | [GH Issue #169](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/169) | `314ae6f`      |
 | [Per-feed auto-refresh scheduling fix](plans/unreleased/166-per-feed-auto-refresh-scheduling.md) | 2026-08-16 | [GH Issue #166](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/166) | `5592c39`      |

--- a/docs/archive/plans/unreleased/177-image-preview-disk-cache.md
+++ b/docs/archive/plans/unreleased/177-image-preview-disk-cache.md
@@ -1,0 +1,278 @@
+---
+status: implemented
+completed: 2026-08-21
+released_in: unreleased
+issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/177
+implementation: ""
+---
+
+# Add Opt-in Disk Caching for Dashboard Preview Images
+
+## Status and scope
+
+- **Classification:** Enhancement.
+- **Risk:** High. The feature writes downloaded content to local storage and
+  touches Display settings, feed-refresh orchestration, dashboard rendering,
+  storage-mode isolation, and desktop/mobile behavior.
+- **Canonical issue:** [#177](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/177).
+- **Milestone recommendation:** `vNext`, **Stretch**. Leave the milestone and
+  release-requirement metadata empty until triage assigns the issue.
+- **Affected surfaces:** Display settings, Card View, Feed View, Discover
+  background ingestion, low-priority post-refresh work, and a plugin-owned
+  cache root.
+- **Unaffected surfaces:** Reader View, article-content images, List View,
+  Discover rendering, feed parsing, image URL discovery, persisted feed record
+  formats, vault-shard formats, settings export, portable export, and saved
+  article data.
+
+## Problem and user value
+
+Dashboard Card and Feed views currently load their cover/preview images from
+remote URLs. Revisiting image-heavy feeds can therefore repeat network work and
+make browsing slower, particularly on constrained connections.
+
+Users who want faster dashboard browsing need an explicitly enabled, bounded
+local image cache without turning preview images into synchronized feed data or
+changing Reader/article behavior. Users who prefer no local media persistence
+must be able to leave caching off or remove every plugin-owned cache file.
+
+## Domain language
+
+- A **preview image** is the existing eligible image rendered by Dashboard Card
+  View or Feed View. It follows each renderer's current source-precedence and
+  URL-eligibility rules.
+- The **image cache** is a device-local, plugin-owned collection of preview
+  image files and its accompanying metadata/index. It is not a feed-data store.
+- A **cache hit** is a present, validated local image for a preview URL. A
+  **cache miss** continues to use the existing remote URL.
+- An **eligible image** is a downloaded JPEG, PNG, WebP, GIF, or AVIF response
+  no larger than 1 MiB (1,048,576 bytes).
+
+## Proposed behavior
+
+### Settings and management
+
+Add an **Allow image caching** toggle to Display settings. It defaults to off
+for every installation. Its description explains that caching can improve
+Card/Feed browsing by storing preview images locally, is limited to 1 MiB per
+image, consumes additional local storage, and is optional.
+
+When enabled, Display settings also show:
+
+- an **Image cache limit** slider and synchronized numeric field, defaulting
+  to 100 MiB and accepting whole values from 1 MiB through 1024 MiB (1 GiB);
+- a **No cache size limit** toggle that removes only the aggregate cap and
+  retains the saved finite value for later use; the 1 MiB per-image limit still
+  applies;
+- **Clear image cache**, which first asks for confirmation and identifies the
+  current cache total;
+- live text such as **Cached image storage: 24.6 MB**; and
+- a success or partial-failure notice after clearing.
+
+The total updates after successful downloads, eviction, clear completion, and
+any reconciliation needed after a partial clear without re-rendering the entire
+settings tab for each write. It may change while a refresh warms or evicts the
+cache, then settles when queued work completes. Lowering a finite limit trims
+least-recently-used entries immediately and never initiates image downloads.
+Turning the toggle off stops
+cache reads and writes, cancels queued cache work, prevents in-flight work from
+writing afterward, clears the verified cache root, and refreshes the displayed
+total.
+
+### Cache use and fetching
+
+Card View and Feed View use a validated local file when the image cache is
+enabled and contains the preview URL; otherwise they retain their present
+remote-image behavior and error fallback. The cache must not alter each view's
+existing candidate precedence, URL filters, lazy-loading behavior, or Feed
+View's image/blur behavior. Reader and article-body images remain source-loaded
+when the article opens.
+
+After a successful manual or scheduled refresh, after a successful feed
+addition (including from Discover), or after a feed is successfully hydrated
+by OPML/background import, enqueue that feed's currently retained eligible
+preview URLs, newest first. URLs are deduplicated. The queue has
+concurrency two, runs at lower priority than feed refresh work, and never starts
+downloads from scrolling, import placeholder creation, or enabling the setting.
+A queue batch that produces usable cache entries refreshes the active Dashboard
+once after both workers drain, so already-rendered Card and Feed previews can
+resolve the new local URLs without re-rendering once per image.
+A Discover/OPML feed remains owned by background ingestion from placeholder
+creation through its queued or in-flight fetch. Manual and scheduled refreshes
+skip those pending URLs, preventing duplicate feed requests and a stale
+placeholder refresh from overwriting hydrated articles. The feeds become
+refreshable normally as soon as background ownership ends.
+A newly enabled cache begins filling after the next successful refresh or import
+hydration only. Do not queue or read cached images while **Show cover images**
+is off.
+
+Do not cache sources declared or measured above 1 MiB. Enforce the limit from
+both a usable declared length and the received bytes; never persist an
+oversized, malformed, unsupported, or failed response. Those cases, and all
+cache read/write failures, keep the existing remote-image fallback.
+
+### Storage, lifetime, and safety
+
+Use a dedicated plugin-owned, device-local cache root separate from
+`RssDashboardSettings`, feed shards, vault-shard metadata, and portable/import
+export data. The cache must not intentionally participate in the plugin's
+settings/feed synchronization paths. A third-party tool configured to copy all
+plugin files may still copy it; document that limitation rather than promising
+that the plugin can prevent external synchronization.
+
+Use a URL-derived cryptographic hash as the filename. Normalize the absolute
+URL, preserve its query string, and ignore only its fragment before hashing.
+This avoids unsafe paths and lets equivalent preview requests share one entry.
+Keep cache index/metadata only with the cache, sufficient to determine size,
+validate ownership, record last use, identify stale entries, and reconcile
+files safely.
+
+Cap the aggregate cache at the user-selected finite limit, 100 MiB by default.
+Before or while admitting an entry, evict least-recently-used entries until the
+new item fits. When **No cache size limit** is enabled, do not apply an aggregate
+cap. A valid cached entry remains usable for 30 days. Once aged, retain that
+valid local image while a
+low-priority replacement attempt is queued; if the old local image is missing,
+corrupt, or fails validation, use the remote URL.
+
+Clear and eviction operations must validate each target against the exact cache
+root, remove only verified cache files/metadata, and leave article data,
+settings, saved articles, feed data, and unrelated vault files untouched.
+When Feed Manager's existing **Delete all feeds** confirmation is accepted,
+clear the verified image cache automatically as dependent plugin-owned data.
+Disclose a nonzero cache total in that same confirmation, do not add a second
+prompt, and report partial deletion failures. Deleting one feed does not clear
+the shared cache.
+
+## Acceptance criteria
+
+1. New installations default **Allow image caching** to off; the setting
+   explains the Card/Feed performance, 1 MiB-per-image, and local-storage
+   trade-off.
+2. The setting exposes confirmed clearing and live, correctly refreshed cache
+   size text.
+3. With caching enabled, Card and Feed use a validated local cache hit without
+   changing existing image candidate precedence or eligibility.
+4. Cache misses and all cache read/download/write/validation failures render
+   through the existing remote-image fallback without breaking the preview.
+5. Only JPEG, PNG, WebP, GIF, and AVIF responses at or below 1 MiB are stored;
+   unsupported, malformed, unknown, SVG, HTML/error, and oversized payloads
+   are never persisted.
+6. Cache downloads are scheduled only after successful manual or automatic feed
+   refreshes or successful OPML/background-import hydration, are
+   URL-deduplicated and newest-first, and run at no more than two concurrent
+   operations.
+7. Card/feed scrolling and enabling the preference do not create a cache
+   download burst; enabling takes effect for cache population at the next
+   successful refresh.
+8. No cache reads or downloads occur while **Show cover images** or **Allow
+   image caching** is off.
+9. Reader/article-content images, List View, Discover, feed parsing, article
+   page fetching, OG/Twitter image discovery, and stored image URL selection
+   remain unchanged.
+10. A hash derived from the normalized URL including query and excluding
+    fragment names cache files; different query-string variants do not collide.
+11. The cache remains at or below the saved finite limit (100 MiB by default)
+    after writes/eviction, and least recently used entries are selected for
+    removal. Selecting no cache size limit removes only this aggregate cap;
+    the per-image limit remains in force and the prior finite value is retained.
+12. Lowering the finite limit immediately trims least-recently-used entries and
+    never re-fetches fresh entries solely because the limit changed.
+13. Entries older than 30 days remain usable when valid while replacement is
+    attempted in the background; missing/corrupt/invalid stale entries fall
+    back remotely.
+14. Cache metadata and bytes remain outside all plugin settings, feed-data,
+    vault-shard, portable-export, and import/export serialization paths.
+15. Disabling or confirming clear cancels queued work, blocks late writes,
+    removes only validated cache-owned data, updates the total, and surfaces
+    partial deletion failures.
+16. Desktop and mobile behavior work with each supported storage mode, without
+    assuming a desktop-only filesystem API or a `file://` image URL.
+17. Confirming **Delete all feeds** discloses nonzero cached-preview storage,
+    clears the verified cache without a second prompt, preserves unrelated
+    plugin data, and reports partial cache-clear failures. Deleting one feed
+    leaves the shared cache intact.
+18. Discover/OPML placeholders that are pending or in flight in background
+    ingestion are excluded from concurrent refreshes; existing feeds continue
+    refreshing, and hydrated articles and their cache-warming callback are not
+    overwritten by stale placeholder results.
+
+## Implementation direction
+
+1. Add focused failing service tests for URL keys, supported response validation,
+   byte limits, cache index reconciliation, size accounting, LRU eviction,
+   30-day refresh behavior, queue deduplication/concurrency, clear/disable
+   cancellation, and remote fallback.
+2. Add a focused cache service using mobile-compatible Obsidian adapter APIs
+   and a plugin-owned root. Keep its metadata entirely alongside cache files;
+   never add cache state to persisted settings or feed types.
+3. Extend `DisplaySettings`, defaults, normalization/migration, and the Display
+   settings tab. Saving relevant toggles refreshes the active dashboard through
+   its established seam.
+4. Integrate the cache resolver with Card and Feed preview rendering without
+   changing source precedence or making global-document/timer assumptions.
+5. Schedule the cache queue after existing refresh-success paths without
+   occupying the refresh semaphore or delaying feed completion.
+6. Prove all storage/synchronization serializers exclude the cache and document
+   the third-party whole-plugin-sync limitation where users can understand it.
+
+Likely files:
+
+- `src/types/types.ts`
+- `src/utils/settings-loader.ts`
+- `src/settings/tabs/display-settings-tab.ts`
+- `src/components/article-list/utils/article-preview-utils.ts`
+- `src/components/article-list/views/card-view.ts`
+- `src/components/article-list/views/feed-view.ts`
+- `main.ts`
+- a new focused cache service under `src/services/`
+- `src/services/feed-storage-repository.ts` and import/export seams, for
+  exclusion verification only
+- matching tests under `test_files/unit/services/`,
+  `test_files/unit/components/article-list/views/`, and settings tests
+
+## Validation and manual checks
+
+- Follow Red -> Green -> Refactor with jsdom tests and Obsidian API stubs.
+- Run focused cache-service, Card View, Feed View, and Display-settings tests.
+- Run `npm run check:platform`, TypeScript checking, `npm run lint`, and
+  `npm run build`; run `npm run test:unit` because refresh, storage, and shared
+  preview behavior are affected.
+- Confirm `git status --short` after validation and remove only verified
+  generated artifacts.
+- On desktop and mobile, test opt-in/default-off, cache hit/miss, remote error,
+  supported/unsupported/oversized sources, finite-limit eviction, no-limit
+  behavior, stale replacement,
+  toggle-off cleanup, clear confirmation/partial failure, queue concurrency,
+  no scroll-triggered downloading, and Card/Feed previews with both settings
+  combinations.
+- In Feed Manager, verify Delete all feeds discloses nonzero cached-preview
+  storage, clears it after the existing confirmation without a second prompt,
+  reports partial deletion failures, and does not clear the shared cache when
+  deleting one feed.
+- Verify every supported storage mode and portable/settings import-export leave
+  cache bytes and metadata out while image URL fallback still works on a second
+  device without a local cache.
+
+## Non-goals, risks, dependencies, and sequencing
+
+- This does not fetch article pages or discover OG/Twitter images. The existing
+  `cover-image-fallback-og-fetch` plan remains separate and is not a dependency;
+  if implemented later, its resolved URLs can become normal cache candidates.
+- This does not synchronize cache bytes between devices, cache every article
+  image, modify Reader images, or promise to defeat third-party tools that
+  synchronize all plugin files.
+- Cache storage, binary response validation, adapter portability, and late
+  writes after clearing are the principal risks; implementation must prove them
+  through service tests and desktop/mobile manual checks.
+- The feature is recommended as `vNext` Stretch. Formal milestone assignment,
+  labels beyond the feature template's `enhancement`, and issue identity await
+  maintainer review and GitHub creation.
+
+## Changelog and lifecycle
+
+After implementation and validation, add a concise **Unreleased -> Added**
+entry with the canonical issue link. Mark the plan implemented, move it to
+`docs/archive/plans/unreleased/`, and update the archive catalog and inbound
+links. At release cut, move it to the applicable version archive and reconcile
+the release notes.

--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,8 @@ import {
   TFolder,
   type EventRef,
   type ObsidianProtocolData,
+  normalizePath,
+  requestUrl,
 } from "obsidian";
 
 import { getSettingManager } from "./src/utils/settings-manager";
@@ -15,6 +17,8 @@ import { getSettingManager } from "./src/utils/settings-manager";
 import {
   RssDashboardSettings,
   DEFAULT_SETTINGS,
+  IMAGE_CACHE_LIMIT_MAX_MIB,
+  IMAGE_CACHE_LIMIT_MIN_MIB,
   Feed,
   FeedItem,
   FeedMetadata,
@@ -63,6 +67,8 @@ import {
 import { globalFetchSemaphore } from "./src/services/feed-parser/fetch-semaphore";
 import { OpmlManager } from "./src/services/opml-manager";
 import { MediaService } from "./src/services/media-service";
+import { ImageCacheService } from "./src/services/image-cache-service";
+import { resolveArticlePreviewImage } from "./src/components/article-list/utils/article-preview-utils";
 
 import { ImportOpmlModal } from "./src/modals/import-opml-modal";
 import { AddFeedModal } from "./src/modals/feed-manager/add-feed-modal";
@@ -284,6 +290,12 @@ export default class RssDashboardPlugin extends Plugin {
   private suppressWatcherUntil = 0;
   private static readonly FEED_REFRESH_RENDER_THROTTLE_MS = 250;
   private readonly feedStorageRepository: FeedStorageRepository;
+  private imageCacheService: ImageCacheService | null = null;
+  private imageCacheQueue: string[] = [];
+  private readonly queuedImageCacheUrls = new Set<string>();
+  private readonly imageCacheChangeListeners = new Set<() => void>();
+  private imageCacheWorkers = 0;
+  private imageCacheBatchHasUsableEntries = false;
 
   constructor(app: App, manifest: ConstructorParameters<typeof Plugin>[1]) {
     super(app, manifest);
@@ -326,7 +338,164 @@ export default class RssDashboardPlugin extends Plugin {
       ensureFolderExists: (folder, opts) =>
         this.ensureFolderExists(folder, opts),
       addStatusBarItem: () => this.addStatusBarItem(),
+      onFeedImported: (feed) => this.queuePreviewImageCaching(feed),
     });
+  }
+
+  private async initializeImageCache(): Promise<void> {
+    if (this.imageCacheService) return;
+
+    const adapter = this.app.vault.adapter;
+    if (
+      typeof adapter.readBinary !== "function" ||
+      typeof adapter.writeBinary !== "function" ||
+      typeof adapter.getResourcePath !== "function"
+    ) {
+      return;
+    }
+
+    this.imageCacheService = new ImageCacheService({
+      adapter,
+      cacheRoot: normalizePath(
+        `${this.app.vault.configDir}/plugins/${this.manifest.id}/image-cache`,
+      ),
+      fetchImage: async (url) => {
+        const response = await requestUrl({ url, method: "GET" });
+        return {
+          status: response.status,
+          headers: response.headers,
+          arrayBuffer: response.arrayBuffer,
+        };
+      },
+      maxCacheBytes: this.getImageCacheLimitBytes(),
+      onChange: () => this.notifyImageCacheChanged(),
+    });
+    await this.imageCacheService.initialize();
+  }
+
+  public resolveCachedImageUrl(remoteUrl: string): string | null {
+    if (!this.settings.display.allowImageCaching) return null;
+    return this.imageCacheService?.resolveCachedUrl(remoteUrl) ?? null;
+  }
+
+  public getImageCacheSizeBytes(): number {
+    return this.imageCacheService?.getSizeBytes() ?? 0;
+  }
+
+  public onImageCacheChanged(listener: () => void): () => void {
+    this.imageCacheChangeListeners.add(listener);
+    return () => this.imageCacheChangeListeners.delete(listener);
+  }
+
+  public async setImageCacheLimit(
+    limitMiB: number,
+    unlimited: boolean,
+  ): Promise<void> {
+    const normalizedLimit =
+      Number.isInteger(limitMiB)
+        ? Math.min(
+            IMAGE_CACHE_LIMIT_MAX_MIB,
+            Math.max(IMAGE_CACHE_LIMIT_MIN_MIB, limitMiB),
+          )
+        : DEFAULT_SETTINGS.display.imageCacheLimitMiB;
+    this.settings.display.imageCacheLimitMiB = normalizedLimit;
+    this.settings.display.imageCacheUnlimited = unlimited;
+    await this.imageCacheService?.setMaxCacheBytes(
+      this.getImageCacheLimitBytes(),
+    );
+    await this.saveSettings();
+  }
+
+  public async clearImageCache(): Promise<{ cleared: number; failed: number }> {
+    this.imageCacheQueue = [];
+    this.queuedImageCacheUrls.clear();
+    this.imageCacheBatchHasUsableEntries = false;
+    this.imageCacheService?.cancelPendingWrites();
+    return (await this.imageCacheService?.clear()) ?? { cleared: 0, failed: 0 };
+  }
+
+  public async setImageCachingEnabled(enabled: boolean): Promise<void> {
+    this.settings.display.allowImageCaching = enabled;
+    if (!enabled) {
+      await this.clearImageCache();
+    }
+    await this.saveSettings();
+  }
+
+  private getImageCacheLimitBytes(): number | null {
+    if (this.settings.display.imageCacheUnlimited) return null;
+    return this.settings.display.imageCacheLimitMiB * 1_024 * 1_024;
+  }
+
+  private notifyImageCacheChanged(): void {
+    for (const listener of this.imageCacheChangeListeners) {
+      listener();
+    }
+  }
+
+  private queuePreviewImageCaching(feed: Feed): void {
+    if (
+      !this.settings.display.allowImageCaching ||
+      !this.settings.display.showCoverImage ||
+      !this.imageCacheService
+    ) {
+      return;
+    }
+
+    for (const item of feed.items) {
+      for (const fieldOrder of [["coverImage", "image"], ["image", "coverImage"]] as const) {
+        const previewUrl = resolveArticlePreviewImage(item, fieldOrder);
+        if (previewUrl && !this.queuedImageCacheUrls.has(previewUrl)) {
+          this.queuedImageCacheUrls.add(previewUrl);
+          this.imageCacheQueue.push(previewUrl);
+        }
+      }
+    }
+
+    this.startImageCacheWorkers();
+  }
+
+  private startImageCacheWorkers(): void {
+    while (this.imageCacheWorkers < 2 && this.imageCacheQueue.length > 0) {
+      this.imageCacheWorkers += 1;
+      void this.runImageCacheWorker();
+    }
+  }
+
+  private async runImageCacheWorker(): Promise<void> {
+    try {
+      while (
+        this.settings.display.allowImageCaching &&
+        this.settings.display.showCoverImage
+      ) {
+        const previewUrl = this.imageCacheQueue.shift();
+        if (!previewUrl) return;
+
+        this.queuedImageCacheUrls.delete(previewUrl);
+        const cached = await this.imageCacheService?.cacheUrl(previewUrl, true);
+        if (cached) {
+          this.imageCacheBatchHasUsableEntries = true;
+        }
+      }
+    } finally {
+      this.imageCacheWorkers -= 1;
+      this.startImageCacheWorkers();
+      if (
+        this.imageCacheWorkers === 0 &&
+        this.imageCacheQueue.length === 0 &&
+        this.imageCacheBatchHasUsableEntries
+      ) {
+        this.imageCacheBatchHasUsableEntries = false;
+        void this.refreshDashboardAfterImageCacheBatch();
+      }
+    }
+  }
+
+  private async refreshDashboardAfterImageCacheBatch(): Promise<void> {
+    const view = await this.getActiveDashboardView();
+    if (view) {
+      void view.refresh();
+    }
   }
 
   private cloneFactoryResetFolders(
@@ -647,6 +816,7 @@ export default class RssDashboardPlugin extends Plugin {
     }
 
     await this.loadSettings();
+    await this.initializeImageCache();
     this.registerVaultMetadataChangeListeners();
 
     const view = await this.getActiveDashboardView();
@@ -2042,6 +2212,7 @@ export default class RssDashboardPlugin extends Plugin {
         // Only add to settings if parsing succeeded
         this.settings.feeds.push(feedWithTags);
         await this.saveSettings();
+        this.queuePreviewImageCaching(feedWithTags);
 
         const view = await this.getActiveDashboardView();
         if (view) {
@@ -2665,7 +2836,11 @@ export default class RssDashboardPlugin extends Plugin {
   }
 
   private getRefreshableFeeds(feeds: Feed[]): Feed[] {
-    return feeds.filter((feed) => !this.isFeedExcludedFromRefresh(feed));
+    return feeds.filter(
+      (feed) =>
+        !this.isFeedExcludedFromRefresh(feed) &&
+        !this.backgroundImportService?.isFeedPendingImport(feed.url),
+    );
   }
 
   private mergeRefreshedFeed(updatedFeed: Feed): void {
@@ -2694,6 +2869,7 @@ export default class RssDashboardPlugin extends Plugin {
         lastRefreshAttemptCompletedAt: completedAt,
         lastFetchError: updatedFeed.lastFetchError,
       });
+      this.queuePreviewImageCaching(updatedFeed);
       return;
     }
 

--- a/main.ts
+++ b/main.ts
@@ -414,6 +414,28 @@ export default class RssDashboardPlugin extends Plugin {
     return (await this.imageCacheService?.clear()) ?? { cleared: 0, failed: 0 };
   }
 
+  public async removeCachedImagesForDeletedFeed(feed: Feed): Promise<void> {
+    const deletedFeedPreviewUrls = this.getPreviewImageUrls(feed);
+    if (deletedFeedPreviewUrls.size === 0) return;
+
+    this.imageCacheQueue = this.imageCacheQueue.filter(
+      (url) => !deletedFeedPreviewUrls.has(url),
+    );
+    for (const url of deletedFeedPreviewUrls) {
+      this.queuedImageCacheUrls.delete(url);
+    }
+
+    const retainedPreviewUrls = new Set(
+      this.settings.feeds.flatMap((remainingFeed) => [
+        ...this.getPreviewImageUrls(remainingFeed),
+      ]),
+    );
+    const orphanedPreviewUrls = Array.from(deletedFeedPreviewUrls).filter(
+      (url) => !retainedPreviewUrls.has(url),
+    );
+    await this.imageCacheService?.removeUrls(orphanedPreviewUrls);
+  }
+
   public async setImageCachingEnabled(enabled: boolean): Promise<void> {
     this.settings.display.allowImageCaching = enabled;
     if (!enabled) {
@@ -442,17 +464,25 @@ export default class RssDashboardPlugin extends Plugin {
       return;
     }
 
-    for (const item of feed.items) {
-      for (const fieldOrder of [["coverImage", "image"], ["image", "coverImage"]] as const) {
-        const previewUrl = resolveArticlePreviewImage(item, fieldOrder);
-        if (previewUrl && !this.queuedImageCacheUrls.has(previewUrl)) {
-          this.queuedImageCacheUrls.add(previewUrl);
-          this.imageCacheQueue.push(previewUrl);
-        }
+    for (const previewUrl of this.getPreviewImageUrls(feed)) {
+      if (!this.queuedImageCacheUrls.has(previewUrl)) {
+        this.queuedImageCacheUrls.add(previewUrl);
+        this.imageCacheQueue.push(previewUrl);
       }
     }
 
     this.startImageCacheWorkers();
+  }
+
+  private getPreviewImageUrls(feed: Feed): Set<string> {
+    const previewUrls = new Set<string>();
+    for (const item of feed.items) {
+      for (const fieldOrder of [["coverImage", "image"], ["image", "coverImage"]] as const) {
+        const previewUrl = resolveArticlePreviewImage(item, fieldOrder);
+        if (previewUrl) previewUrls.add(previewUrl);
+      }
+    }
+    return previewUrls;
   }
 
   private startImageCacheWorkers(): void {

--- a/src/components/article-list.ts
+++ b/src/components/article-list.ts
@@ -63,6 +63,7 @@ interface ArticleListCallbacks {
   onPersistSettings?: () => Promise<void> | void;
   onOpenTagsSettings?: () => Promise<void> | void;
   onTagsMutated?: () => void;
+  onResolveCachedImageUrl?: (remoteUrl: string) => string | null;
 }
 
 export class ArticleList {
@@ -1360,6 +1361,7 @@ export class ArticleList {
       selectedArticle: this.selectedArticle,
       showFeedSource: this.showFeedSource,
       settings: this.settings,
+      resolveCachedImageUrl: this.callbacks.onResolveCachedImageUrl,
       highlightService: this.highlightService,
       callbacks: this.callbacks,
     };

--- a/src/components/article-list/views/card-view.ts
+++ b/src/components/article-list/views/card-view.ts
@@ -83,11 +83,15 @@ export function renderCardView(
     const coverImgSrc = ctx.settings.display.showCoverImage
       ? resolveArticlePreviewImage(article, ["coverImage", "image"])
       : undefined;
+    const displayedCoverImgSrc =
+      coverImgSrc && ctx.settings.display.allowImageCaching
+        ? (ctx.resolveCachedImageUrl?.(coverImgSrc) ?? coverImgSrc)
+        : coverImgSrc;
     const previewSummaryText = ctx.settings.display.showSummary
       ? getArticlePreviewSummaryText(article)
       : "";
 
-    if (coverImgSrc) {
+    if (displayedCoverImgSrc) {
       const previewRegion = cardContent.createDiv({
         cls: "rss-dashboard-card-preview-region",
       });
@@ -99,13 +103,23 @@ export function renderCardView(
       const coverImg = coverContainer.createEl("img", {
         cls: "rss-dashboard-cover-image",
         attr: {
-          src: coverImgSrc,
+          src: displayedCoverImgSrc,
           alt: article.title,
           loading: "lazy",
           decoding: "async",
         },
       });
       coverImg.onerror = () => {
+        if (
+          displayedCoverImgSrc !== coverImgSrc &&
+          coverImgSrc &&
+          coverImg.dataset.rssCacheRemoteFallback !== "true"
+        ) {
+          coverImg.dataset.rssCacheRemoteFallback = "true";
+          coverImg.setAttribute("src", coverImgSrc);
+          return;
+        }
+
         previewRegion.empty();
 
         if (previewSummaryText) {

--- a/src/components/article-list/views/feed-view.ts
+++ b/src/components/article-list/views/feed-view.ts
@@ -40,24 +40,39 @@ function renderArticleCard(
   const coverImgSrc = ctx.settings.display.showCoverImage
     ? resolveArticlePreviewImage(article, ["image", "coverImage"])
     : undefined;
-  if (coverImgSrc) {
+  const displayedCoverImgSrc =
+    coverImgSrc && ctx.settings.display.allowImageCaching
+      ? (ctx.resolveCachedImageUrl?.(coverImgSrc) ?? coverImgSrc)
+      : coverImgSrc;
+  if (displayedCoverImgSrc) {
     const previewRegion = feedContent.createDiv({
       cls: "rss-dashboard-feed-preview-region",
     });
-    previewRegion.createDiv({
+    const heroBlur = previewRegion.createDiv({
       cls: "rss-dashboard-feed-hero-blur",
       attr: {
-        style: `background-image: url('${coverImgSrc}')`,
+        style: `background-image: url('${displayedCoverImgSrc}')`,
       },
     });
-    previewRegion.createEl("img", {
+    const heroImage = previewRegion.createEl("img", {
       cls: "rss-dashboard-feed-hero-image",
       attr: {
-        src: coverImgSrc,
+        src: displayedCoverImgSrc,
         alt: article.title,
         loading: "lazy",
       },
     });
+    heroImage.onerror = () => {
+      if (
+        displayedCoverImgSrc !== coverImgSrc &&
+        coverImgSrc &&
+        heroImage.dataset.rssCacheRemoteFallback !== "true"
+      ) {
+        heroImage.dataset.rssCacheRemoteFallback = "true";
+        heroImage.setAttribute("src", coverImgSrc);
+        heroBlur.setAttribute("style", `background-image: url('${coverImgSrc}')`);
+      }
+    };
   }
 
   const textRegion = feedContent.createDiv({

--- a/src/components/article-list/views/view-types.ts
+++ b/src/components/article-list/views/view-types.ts
@@ -31,6 +31,7 @@ export interface BaseViewContext {
   settings: Pick<RssDashboardSettings, "highlights" | "display"> & {
     collapsedFeedSections?: string[];
   };
+  resolveCachedImageUrl?: (remoteUrl: string) => string | null;
   highlightService: HighlightService | null;
   callbacks: ViewCallbacks;
 }

--- a/src/modals/feed-manager/feed-manager-modal.ts
+++ b/src/modals/feed-manager/feed-manager-modal.ts
@@ -4,6 +4,12 @@ import { ImportOpmlModal } from "../import-opml-modal";
 import { shouldUseMobileSidebarLayout } from "../../utils/platform-utils";
 import { AddFeedModal, type AddFeedRequest } from "./add-feed-modal";
 
+function formatByteSize(bytes: number): string {
+  if (bytes < 1_024) return `${bytes} B`;
+  if (bytes < 1_024 * 1_024) return `${(bytes / 1_024).toFixed(1)} KB`;
+  return `${(bytes / (1_024 * 1_024)).toFixed(1)} MB`;
+}
+
 export class FeedManagerModal extends Modal {
   plugin: RssDashboardPlugin;
 
@@ -97,11 +103,17 @@ export class FeedManagerModal extends Modal {
 
       const { contentEl } = confirmModal;
       contentEl.empty();
+      const imageCacheSizeBytes = this.plugin.getImageCacheSizeBytes();
 
       new Setting(contentEl).setName("Delete all feeds?").setHeading();
       contentEl.createEl("p", {
         text: `This will permanently remove all ${this.plugin.settings.feeds.length} feeds from RSS Dashboard. Your folder structure and plugin settings will remain intact.`,
       });
+      if (imageCacheSizeBytes > 0) {
+        contentEl.createEl("p", {
+          text: `Cached preview images (${formatByteSize(imageCacheSizeBytes)}) will also be cleared.`,
+        });
+      }
 
       const buttonsSetting = new Setting(contentEl);
       buttonsSetting.controlEl.addClass("rss-dashboard-modal-buttons");
@@ -118,6 +130,7 @@ export class FeedManagerModal extends Modal {
             .onClick(async () => {
               this.plugin.settings.feeds = [];
               await this.plugin.saveSettings();
+              const cacheClearResult = await this.plugin.clearImageCache();
               
               const dashboardView = await this.plugin.getActiveDashboardView();
               if (dashboardView) {
@@ -126,7 +139,17 @@ export class FeedManagerModal extends Modal {
 
               this.close();
               confirmModal.close();
-              new Notice("All feeds deleted");
+              if (cacheClearResult.failed > 0) {
+                const failedLabel =
+                  cacheClearResult.failed === 1
+                    ? "1 cached image could not be removed."
+                    : `${cacheClearResult.failed} cached images could not be removed.`;
+                new Notice(`All feeds deleted, but ${failedLabel}`);
+              } else if (imageCacheSizeBytes > 0) {
+                new Notice("All feeds and cached preview images deleted.");
+              } else {
+                new Notice("All feeds deleted");
+              }
             }),
         );
 

--- a/src/services/background-import-service.ts
+++ b/src/services/background-import-service.ts
@@ -45,6 +45,7 @@ export interface BackgroundImportServiceDeps {
     opts: { saveSettings: boolean; refreshView: boolean },
   ) => Promise<boolean>;
   addStatusBarItem: () => HTMLElement;
+  onFeedImported?: (feed: Feed) => void;
 }
 
 // ── Service ──────────────────────────────────────────────────────────────────
@@ -65,13 +66,16 @@ export class BackgroundImportService {
     opts: { saveSettings: boolean; refreshView: boolean },
   ) => Promise<boolean>;
   private readonly addStatusBarItem: () => HTMLElement;
+  private readonly onFeedImported?: (feed: Feed) => void;
 
   // ── State ──────────────────────────────────────────────────────────────────
 
   private importStatusBarItem: HTMLElement | null = null;
   public backgroundImportQueue: FeedMetadata[] = [];
   public isBackgroundImporting = false;
+  private backgroundImportQueuedUrls = new Set<string>();
   private backgroundImportInFlightUrls = new Set<string>();
+  private backgroundImportPendingIngestionUrls = new Set<string>();
   private backgroundImportProcessedCount = 0;
   private backgroundImportTotalCount = 0;
   private backgroundImportPersistMode:
@@ -85,6 +89,7 @@ export class BackgroundImportService {
     this.saveSettings = deps.saveSettings;
     this.ensureFolderExists = deps.ensureFolderExists;
     this.addStatusBarItem = deps.addStatusBarItem;
+    this.onFeedImported = deps.onFeedImported;
   }
 
   // ── Public API ─────────────────────────────────────────────────────────────
@@ -93,6 +98,7 @@ export class BackgroundImportService {
     const queuedUrls = new Set(
       this.backgroundImportQueue.map((feed) => feed.url),
     );
+    this.backgroundImportQueuedUrls = queuedUrls;
     const newQueueItems = feeds
       .filter(
         (feed) =>
@@ -116,11 +122,22 @@ export class BackgroundImportService {
     }
 
     this.backgroundImportQueue.push(...newQueueItems);
+    for (const feed of newQueueItems) {
+      this.backgroundImportQueuedUrls.add(feed.url);
+    }
     this.backgroundImportTotalCount += newQueueItems.length;
 
     if (!this.isBackgroundImporting) {
       void this.processBackgroundImportQueue();
     }
+  }
+
+  public isFeedPendingImport(url: string): boolean {
+    return (
+      this.backgroundImportPendingIngestionUrls.has(url) ||
+      this.backgroundImportInFlightUrls.has(url) ||
+      this.backgroundImportQueuedUrls.has(url)
+    );
   }
 
   public async ingestFeedsForBackgroundImport(
@@ -167,6 +184,7 @@ export class BackgroundImportService {
       const placeholder = this.createPlaceholderFeed(candidate);
       placeholders.push(placeholder);
       this.getSettings().feeds.push(placeholder);
+      this.backgroundImportPendingIngestionUrls.add(candidate.url);
       existingUrls.add(candidate.url);
       seenUrls.add(candidate.url);
 
@@ -183,14 +201,20 @@ export class BackgroundImportService {
       );
     }
 
-    await this.saveSettingsWithMode(importPersistMode);
-    const view = await this.getView();
-    if (view) {
-      view.refresh?.();
-    }
+    try {
+      await this.saveSettingsWithMode(importPersistMode);
+      const view = await this.getView();
+      if (view) {
+        view.refresh?.();
+      }
 
-    this.backgroundImportPersistMode = importPersistMode;
-    this.startBackgroundImport(placeholders);
+      this.backgroundImportPersistMode = importPersistMode;
+      this.startBackgroundImport(placeholders);
+    } finally {
+      for (const placeholder of placeholders) {
+        this.backgroundImportPendingIngestionUrls.delete(placeholder.url);
+      }
+    }
 
     return {
       addedCount: placeholders.length,
@@ -301,6 +325,7 @@ export class BackgroundImportService {
         globalFetchSemaphore.release();
         return;
       }
+      this.backgroundImportQueuedUrls.delete(feedMetadata.url);
 
       const importPromise = this.processBackgroundImportFeed(
         feedMetadata,
@@ -339,7 +364,13 @@ export class BackgroundImportService {
       );
 
       const parsedFeed = await this.parseFeedWithTimeout(feedMetadata.url);
-      this.mergeBackgroundImportedFeed(feedMetadata, parsedFeed);
+      const importedFeed = this.mergeBackgroundImportedFeed(
+        feedMetadata,
+        parsedFeed,
+      );
+      if (importedFeed) {
+        this.onFeedImported?.(importedFeed);
+      }
       feedMetadata.importStatus = "completed";
     } catch (error) {
       if (error instanceof Error && error.message === "Timed out") {
@@ -434,16 +465,16 @@ export class BackgroundImportService {
   private mergeBackgroundImportedFeed(
     feedMetadata: FeedMetadata,
     parsedFeed: Feed,
-  ): void {
+  ): Feed | null {
     const feedIndex = this.getSettings().feeds.findIndex(
       (f) => f.url === feedMetadata.url,
     );
     if (feedIndex < 0) {
-      return;
+      return null;
     }
 
     const existingFeed = this.getSettings().feeds[feedIndex];
-    this.getSettings().feeds[feedIndex] = {
+    const importedFeed: Feed = {
       ...existingFeed,
       title: parsedFeed.title || existingFeed.title || feedMetadata.title,
       author: parsedFeed.author ?? existingFeed.author,
@@ -456,6 +487,8 @@ export class BackgroundImportService {
       ),
       lastUpdated: Date.now(),
     };
+    this.getSettings().feeds[feedIndex] = importedFeed;
+    return importedFeed;
   }
 
   private updateBackgroundImportProgress(

--- a/src/services/image-cache-service.ts
+++ b/src/services/image-cache-service.ts
@@ -1,0 +1,323 @@
+import { normalizePath } from "obsidian";
+
+export const MAX_CACHED_IMAGE_BYTES = 1_048_576;
+export const MAX_IMAGE_CACHE_BYTES = 100 * 1_024 * 1_024;
+export const IMAGE_CACHE_STALE_AFTER_MS = 30 * 24 * 60 * 60 * 1_000;
+
+const CACHE_INDEX_FILENAME = "index.json";
+const CACHE_INDEX_VERSION = 1;
+
+const IMAGE_TYPES = new Map<string, string>([
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/webp", "webp"],
+  ["image/gif", "gif"],
+  ["image/avif", "avif"],
+]);
+
+export interface ImageCacheAdapter {
+  exists(path: string): Promise<boolean>;
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+  writeBinary(path: string, content: ArrayBuffer): Promise<void>;
+  mkdir(path: string): Promise<void>;
+  remove(path: string): Promise<void>;
+  rmdir(path: string, recursive: boolean): Promise<void>;
+  getResourcePath(path: string): string;
+}
+
+export interface ImageCacheFetchResponse {
+  status: number;
+  headers: Record<string, string>;
+  arrayBuffer: ArrayBuffer;
+}
+
+export interface ImageCacheEntry {
+  fileName: string;
+  byteLength: number;
+  cachedAt: number;
+  lastAccessedAt: number;
+}
+
+interface ImageCacheIndex {
+  version: number;
+  entries: Record<string, ImageCacheEntry>;
+}
+
+interface ImageCacheServiceOptions {
+  adapter: ImageCacheAdapter;
+  cacheRoot: string;
+  fetchImage(url: string): Promise<ImageCacheFetchResponse>;
+  maxCacheBytes?: number | null;
+  now?: () => number;
+  onChange?: () => void;
+}
+
+export class ImageCacheService {
+  private readonly adapter: ImageCacheAdapter;
+  private readonly cacheRoot: string;
+  private readonly fetchImage: (url: string) => Promise<ImageCacheFetchResponse>;
+  private maxCacheBytes: number | null;
+  private readonly now: () => number;
+  private readonly onChange?: () => void;
+  private readonly entries = new Map<string, ImageCacheEntry>();
+  private initialized = false;
+  private writeGeneration = 0;
+
+  constructor(options: ImageCacheServiceOptions) {
+    this.adapter = options.adapter;
+    this.cacheRoot = normalizePath(options.cacheRoot);
+    this.fetchImage = (url) => options.fetchImage(url);
+    this.maxCacheBytes =
+      options.maxCacheBytes === undefined
+        ? MAX_IMAGE_CACHE_BYTES
+        : options.maxCacheBytes;
+    this.now = options.now ?? (() => Date.now());
+    this.onChange = options.onChange;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    if (!(await this.adapter.exists(this.cacheRoot))) {
+      await this.adapter.mkdir(this.cacheRoot);
+    }
+
+    const indexPath = this.getIndexPath();
+    if (await this.adapter.exists(indexPath)) {
+      try {
+        const index = JSON.parse(await this.adapter.read(indexPath)) as ImageCacheIndex;
+        if (index.version === CACHE_INDEX_VERSION && index.entries) {
+          for (const [url, entry] of Object.entries(index.entries)) {
+            if (this.isSafeEntry(entry) && (await this.adapter.exists(this.getEntryPath(entry)))) {
+              this.entries.set(url, entry);
+            }
+          }
+        }
+      } catch (error) {
+        console.warn("[RSS dashboard] Unable to read image cache index", error);
+      }
+    }
+
+    this.initialized = true;
+    await this.persistIndex();
+  }
+
+  resolveCachedUrl(rawUrl: string): string | null {
+    if (!this.initialized) return null;
+    const url = this.normalizeUrl(rawUrl);
+    if (!url) return null;
+
+    const entry = this.entries.get(url);
+    if (!entry) return null;
+
+    entry.lastAccessedAt = this.now();
+    return this.adapter.getResourcePath(this.getEntryPath(entry));
+  }
+
+  getSizeBytes(): number {
+    return Array.from(this.entries.values()).reduce(
+      (total, entry) => total + entry.byteLength,
+      0,
+    );
+  }
+
+  async setMaxCacheBytes(maxCacheBytes: number | null): Promise<void> {
+    this.maxCacheBytes = maxCacheBytes;
+    if (this.initialized && maxCacheBytes !== null) {
+      await this.evictUntilFits(0, 0);
+      await this.persistIndex();
+    }
+    this.onChange?.();
+  }
+
+  isStale(rawUrl: string): boolean {
+    const url = this.normalizeUrl(rawUrl);
+    const entry = url ? this.entries.get(url) : undefined;
+    return !!entry && this.now() - entry.cachedAt >= IMAGE_CACHE_STALE_AFTER_MS;
+  }
+
+  async cacheUrl(rawUrl: string, refreshStale = false): Promise<boolean> {
+    if (!this.initialized) return false;
+    const url = this.normalizeUrl(rawUrl);
+    if (!url) return false;
+    const existingEntry = this.entries.get(url);
+    if (existingEntry && (!refreshStale || !this.isStale(url))) return true;
+
+    let response: ImageCacheFetchResponse;
+    const writeGeneration = this.writeGeneration;
+    try {
+      response = await this.fetchImage(url);
+    } catch (error) {
+      console.warn("[RSS dashboard] Unable to cache preview image", error);
+      return false;
+    }
+
+    const extension = this.getImageExtension(response);
+    if (
+      response.status < 200 ||
+      response.status >= 300 ||
+      !extension ||
+      response.arrayBuffer.byteLength > MAX_CACHED_IMAGE_BYTES ||
+      !this.hasValidImageSignature(response.arrayBuffer, extension)
+    ) {
+      return false;
+    }
+
+    const declaredLength = this.getDeclaredLength(response.headers);
+    if (declaredLength !== null && declaredLength > MAX_CACHED_IMAGE_BYTES) {
+      return false;
+    }
+
+    const fileName = `${await this.hashUrl(url)}.${extension}`;
+    const entry: ImageCacheEntry = {
+      fileName,
+      byteLength: response.arrayBuffer.byteLength,
+      cachedAt: this.now(),
+      lastAccessedAt: this.now(),
+    };
+
+    if (writeGeneration !== this.writeGeneration) return false;
+    await this.evictUntilFits(entry.byteLength, existingEntry?.byteLength ?? 0);
+    if (writeGeneration !== this.writeGeneration) return false;
+    try {
+      await this.adapter.writeBinary(this.getEntryPath(entry), response.arrayBuffer);
+      if (writeGeneration !== this.writeGeneration) {
+        await this.adapter.remove(this.getEntryPath(entry));
+        return false;
+      }
+      this.entries.set(url, entry);
+      if (existingEntry && existingEntry.fileName !== entry.fileName) {
+        await this.adapter.remove(this.getEntryPath(existingEntry));
+      }
+      await this.persistIndex();
+      this.onChange?.();
+      return true;
+    } catch (error) {
+      console.warn("[RSS dashboard] Unable to write cached preview image", error);
+      return false;
+    }
+  }
+
+  async clear(): Promise<{ cleared: number; failed: number }> {
+    this.cancelPendingWrites();
+    let cleared = 0;
+    let failed = 0;
+
+    for (const [url, entry] of this.entries) {
+      try {
+        await this.adapter.remove(this.getEntryPath(entry));
+        this.entries.delete(url);
+        cleared += 1;
+      } catch (error) {
+        console.warn("[RSS dashboard] Unable to clear cached preview image", error);
+        failed += 1;
+      }
+    }
+
+    await this.persistIndex();
+    this.onChange?.();
+    return { cleared, failed };
+  }
+
+  cancelPendingWrites(): void {
+    this.writeGeneration += 1;
+  }
+
+  private normalizeUrl(rawUrl: string): string | null {
+    try {
+      const url = new URL(rawUrl);
+      if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+      url.hash = "";
+      return url.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  private getIndexPath(): string {
+    return normalizePath(`${this.cacheRoot}/${CACHE_INDEX_FILENAME}`);
+  }
+
+  private getEntryPath(entry: ImageCacheEntry): string {
+    return normalizePath(`${this.cacheRoot}/${entry.fileName}`);
+  }
+
+  private isSafeEntry(entry: unknown): entry is ImageCacheEntry {
+    if (!entry || typeof entry !== "object") return false;
+    const candidate = entry as ImageCacheEntry;
+    return (
+      /^[a-f0-9]{64}\.(jpg|png|webp|gif|avif)$/.test(candidate.fileName) &&
+      Number.isInteger(candidate.byteLength) &&
+      candidate.byteLength > 0 &&
+      candidate.byteLength <= MAX_CACHED_IMAGE_BYTES &&
+      Number.isFinite(candidate.cachedAt) &&
+      Number.isFinite(candidate.lastAccessedAt)
+    );
+  }
+
+  private async persistIndex(): Promise<void> {
+    const entries = Object.fromEntries(this.entries);
+    await this.adapter.write(
+      this.getIndexPath(),
+      JSON.stringify({ version: CACHE_INDEX_VERSION, entries } satisfies ImageCacheIndex),
+    );
+  }
+
+  private async evictUntilFits(
+    incomingBytes: number,
+    replacingBytes: number,
+  ): Promise<void> {
+    if (this.maxCacheBytes === null) return;
+
+    const entries = Array.from(this.entries.entries()).sort(
+      ([, left], [, right]) => left.lastAccessedAt - right.lastAccessedAt,
+    );
+    let size = this.getSizeBytes() - replacingBytes;
+
+    for (const [url, entry] of entries) {
+      if (size + incomingBytes <= this.maxCacheBytes) break;
+      await this.adapter.remove(this.getEntryPath(entry));
+      this.entries.delete(url);
+      size -= entry.byteLength;
+    }
+  }
+
+  private getImageExtension(response: ImageCacheFetchResponse): string | null {
+    const contentType = Object.entries(response.headers).find(
+      ([name]) => name.toLowerCase() === "content-type",
+    )?.[1];
+    return IMAGE_TYPES.get(contentType?.split(";", 1)[0].trim().toLowerCase() ?? "") ?? null;
+  }
+
+  private getDeclaredLength(headers: Record<string, string>): number | null {
+    const contentLength = Object.entries(headers).find(
+      ([name]) => name.toLowerCase() === "content-length",
+    )?.[1];
+    if (!contentLength) return null;
+    const parsed = Number.parseInt(contentLength, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  }
+
+  private hasValidImageSignature(data: ArrayBuffer, extension: string): boolean {
+    const bytes = new Uint8Array(data);
+    if (extension === "jpg") {
+      return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+    }
+    if (extension === "png") {
+      return bytes.length >= 8 && [137, 80, 78, 71, 13, 10, 26, 10].every((byte, index) => bytes[index] === byte);
+    }
+    if (extension === "gif") {
+      return bytes.length >= 6 && ("GIF87a" === String.fromCharCode(...bytes.slice(0, 6)) || "GIF89a" === String.fromCharCode(...bytes.slice(0, 6)));
+    }
+    if (extension === "webp") {
+      return bytes.length >= 12 && String.fromCharCode(...bytes.slice(0, 4)) === "RIFF" && String.fromCharCode(...bytes.slice(8, 12)) === "WEBP";
+    }
+    return bytes.length >= 12 && String.fromCharCode(...bytes.slice(4, 8)) === "ftyp" && String.fromCharCode(...bytes.slice(8, 12)).startsWith("avif");
+  }
+
+  private async hashUrl(url: string): Promise<string> {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(url));
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+}

--- a/src/services/image-cache-service.ts
+++ b/src/services/image-cache-service.ts
@@ -220,6 +220,37 @@ export class ImageCacheService {
     return { cleared, failed };
   }
 
+  async removeUrls(rawUrls: Iterable<string>): Promise<{ cleared: number; failed: number }> {
+    const urls = new Set(
+      Array.from(rawUrls, (rawUrl) => this.normalizeUrl(rawUrl)).filter(
+        (url): url is string => url !== null,
+      ),
+    );
+    if (urls.size === 0) return { cleared: 0, failed: 0 };
+
+    this.cancelPendingWrites();
+    let cleared = 0;
+    let failed = 0;
+
+    for (const url of urls) {
+      const entry = this.entries.get(url);
+      if (!entry) continue;
+
+      try {
+        await this.adapter.remove(this.getEntryPath(entry));
+        this.entries.delete(url);
+        cleared += 1;
+      } catch (error) {
+        console.warn("[RSS dashboard] Unable to clear cached preview image", error);
+        failed += 1;
+      }
+    }
+
+    await this.persistIndex();
+    this.onChange?.();
+    return { cleared, failed };
+  }
+
   cancelPendingWrites(): void {
     this.writeGeneration += 1;
   }

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -43,6 +43,7 @@ export class RssDashboardSettingTab extends PluginSettingTab {
   plugin: RssDashboardPlugin;
   private currentTab: SettingsTabName = getInitialTab();
   private pendingSection: string | null = null;
+  private displaySettingsCleanup: (() => void) | null = null;
 
   constructor(app: App, plugin: RssDashboardPlugin) {
     super(app, plugin);
@@ -59,6 +60,8 @@ export class RssDashboardSettingTab extends PluginSettingTab {
   }
 
   display(): void {
+    this.displaySettingsCleanup?.();
+    this.displaySettingsCleanup = null;
     const { containerEl } = this;
     containerEl.empty();
 
@@ -99,7 +102,7 @@ export class RssDashboardSettingTab extends PluginSettingTab {
         this.pendingSection = null;
         break;
       case "Display":
-        renderDisplaySettingsTab(
+        this.displaySettingsCleanup = renderDisplaySettingsTab(
           tabContent,
           this.plugin,
           onRefresh,

--- a/src/settings/tabs/display-settings-tab.ts
+++ b/src/settings/tabs/display-settings-tab.ts
@@ -5,9 +5,13 @@
  * Exports:
  *   - renderDisplaySettingsTab(containerEl, plugin, onRefresh) — main render fn
  */
-import { Setting, setIcon } from "obsidian";
+import { Modal, Notice, Setting, setIcon } from "obsidian";
 import RssDashboardPlugin from "../../../main";
-import { DEFAULT_SETTINGS } from "../../types/types";
+import {
+  DEFAULT_SETTINGS,
+  IMAGE_CACHE_LIMIT_MAX_MIB,
+  IMAGE_CACHE_LIMIT_MIN_MIB,
+} from "../../types/types";
 import { formatDashboardMultiFiltersSummaryCompact } from "../../utils/filter-title-format";
 import {
   computePopoverPosition,
@@ -16,6 +20,49 @@ import {
 
 // Re-export pure helpers from sidebar-settings-tab for backward compatibility
 export { moveIconOrder, normalizeHexColor } from "./sidebar-settings-tab";
+
+class ClearImageCacheConfirmModal extends Modal {
+  private confirmed = false;
+  private resolvePromise: ((value: boolean) => void) | null = null;
+
+  onOpen(): void {
+    this.contentEl.empty();
+    this.contentEl.createEl("h2", { text: "Clear image cache?" });
+    this.contentEl.createEl("p", {
+      text: "This removes only cached dashboard preview images. Feed data, settings, and saved articles are unchanged.",
+    });
+    new Setting(this.contentEl)
+      .addButton((button) =>
+        button.setButtonText("Cancel").onClick(() => this.close()),
+      )
+      .addButton((button) =>
+        button
+          .setButtonText("Clear image cache")
+          .setWarning()
+          .onClick(() => {
+            this.confirmed = true;
+            this.close();
+          }),
+      );
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+    this.resolvePromise?.(this.confirmed);
+  }
+
+  waitForClose(): Promise<boolean> {
+    return new Promise((resolve) => {
+      this.resolvePromise = resolve;
+    });
+  }
+}
+
+function formatByteSize(bytes: number): string {
+  if (bytes < 1_024) return `${bytes} B`;
+  if (bytes < 1_024 * 1_024) return `${(bytes / 1_024).toFixed(1)} KB`;
+  return `${(bytes / (1_024 * 1_024)).toFixed(1)} MB`;
+}
 
 // ── Tab renderer ──────────────────────────────────────────────────────────────
 
@@ -29,7 +76,7 @@ export function renderDisplaySettingsTab(
   plugin: RssDashboardPlugin,
   onRefresh: () => void,
   targetSection?: string,
-): void {
+): () => void {
   const rerenderActiveReaderView = async (): Promise<void> => {
     const readerView = await plugin.getActiveReaderView?.();
     if (!readerView) {
@@ -76,6 +123,132 @@ export function renderDisplaySettingsTab(
           await plugin.saveSettings();
           await rerenderActiveDashboardView();
         }),
+    );
+
+  new Setting(containerEl)
+    .setName("Allow image caching")
+    .setDesc(
+      "Store card and feed preview images locally to improve browsing performance. Each image is limited to one megabyte and uses additional vault storage. RSS dashboard does not include this cache in feed or settings sync, but a sync tool that copies plugin files may copy it.",
+    )
+    .addToggle((toggle) =>
+      toggle
+        .setValue(plugin.settings.display.allowImageCaching)
+        .onChange(async (value) => {
+          await plugin.setImageCachingEnabled(value);
+          await rerenderActiveDashboardView();
+          onRefresh();
+        }),
+    );
+
+  let isSyncingImageCacheLimitControls = false;
+  let imageCacheLimitSlider: { setValue: (value: number) => void } | null =
+    null;
+  let imageCacheLimitInput: import("obsidian").TextComponent | null = null;
+  const applyImageCacheLimit = async (value: number): Promise<void> => {
+    await plugin.setImageCacheLimit(value, false);
+  };
+
+  const cacheLimitSetting = new Setting(containerEl)
+    .setName("Image cache limit")
+    .setDesc(
+      "Maximum storage for cached dashboard preview images, in MiB. Lowering this limit removes least-recently-used cached images immediately.",
+    )
+    .addSlider((slider) => {
+      imageCacheLimitSlider = slider;
+      slider
+        .setLimits(IMAGE_CACHE_LIMIT_MIN_MIB, IMAGE_CACHE_LIMIT_MAX_MIB, 1)
+        .setValue(plugin.settings.display.imageCacheLimitMiB)
+        .setDynamicTooltip()
+        .onChange(async (value) => {
+          if (isSyncingImageCacheLimitControls) return;
+          isSyncingImageCacheLimitControls = true;
+          imageCacheLimitInput?.setValue(String(value));
+          isSyncingImageCacheLimitControls = false;
+          await applyImageCacheLimit(value);
+        });
+      slider.sliderEl.disabled = plugin.settings.display.imageCacheUnlimited;
+    })
+    .addText((text) => {
+      imageCacheLimitInput = text;
+      text
+        .setValue(String(plugin.settings.display.imageCacheLimitMiB))
+        .setPlaceholder("100");
+      text.inputEl.type = "number";
+      text.inputEl.min = String(IMAGE_CACHE_LIMIT_MIN_MIB);
+      text.inputEl.max = String(IMAGE_CACHE_LIMIT_MAX_MIB);
+      text.inputEl.step = "1";
+      text.inputEl.disabled = plugin.settings.display.imageCacheUnlimited;
+      text.inputEl.addClass("rss-dashboard-settings-number-input");
+      text.inputEl.addEventListener("blur", () => {
+        const value = Number(text.getValue());
+        if (
+          !Number.isInteger(value) ||
+          value < IMAGE_CACHE_LIMIT_MIN_MIB ||
+          value > IMAGE_CACHE_LIMIT_MAX_MIB
+        ) {
+          text.setValue(String(plugin.settings.display.imageCacheLimitMiB));
+          return;
+        }
+        isSyncingImageCacheLimitControls = true;
+        imageCacheLimitSlider?.setValue(value);
+        isSyncingImageCacheLimitControls = false;
+        void applyImageCacheLimit(value);
+      });
+    });
+  cacheLimitSetting.settingEl.addClass("rss-dashboard-settings-two-row");
+
+  new Setting(containerEl)
+    .setName("No cache size limit")
+    .setDesc(
+      "Do not limit total image-cache storage. The one-megabyte limit for each image still applies.",
+    )
+    .addToggle((toggle) =>
+      toggle
+        .setValue(plugin.settings.display.imageCacheUnlimited)
+        .onChange(async (value) => {
+          await plugin.setImageCacheLimit(
+            plugin.settings.display.imageCacheLimitMiB,
+            value,
+          );
+          onRefresh();
+        }),
+    );
+
+  const clearImageCacheSetting = new Setting(containerEl)
+    .setName("Clear image cache")
+    .setDesc(
+      `Cached image storage: ${formatByteSize(plugin.getImageCacheSizeBytes?.() ?? 0)}.`,
+    );
+  const cacheSizeDescriptionEl = clearImageCacheSetting.descEl;
+  const settingsWindow = containerEl.ownerDocument.defaultView;
+  let cacheSizeUpdateTimer: number | null = null;
+  const refreshCacheSize = (): void => {
+    if (!settingsWindow || cacheSizeUpdateTimer !== null) return;
+    cacheSizeUpdateTimer = settingsWindow.setTimeout(() => {
+      cacheSizeUpdateTimer = null;
+      cacheSizeDescriptionEl.setText(
+        `Cached image storage: ${formatByteSize(plugin.getImageCacheSizeBytes?.() ?? 0)}.`,
+      );
+    }, 250);
+  };
+  const unregisterImageCacheChange =
+    plugin.onImageCacheChanged?.(refreshCacheSize) ?? (() => {});
+
+  clearImageCacheSetting.addButton((button) =>
+      button.setButtonText("Clear image cache").onClick(async () => {
+        const modal = new ClearImageCacheConfirmModal(plugin.app);
+        const confirmation = modal.waitForClose();
+        modal.open();
+        if (!(await confirmation)) return;
+
+        const result = await plugin.clearImageCache();
+        new Notice(
+          result.failed === 0
+            ? "Image cache cleared."
+            : `Cleared ${result.cleared} cached images; ${result.failed} could not be removed.`,
+        );
+        onRefresh();
+      }),
     );
 
   new Setting(containerEl)
@@ -973,4 +1146,11 @@ export function renderDisplaySettingsTab(
   );
 
   containerEl.createEl("hr", { cls: "rss-dashboard-settings-separator" });
+
+  return () => {
+    unregisterImageCacheChange();
+    if (settingsWindow && cacheSizeUpdateTimer !== null) {
+      settingsWindow.clearTimeout(cacheSizeUpdateTimer);
+    }
+  };
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -257,8 +257,14 @@ export interface ArticleSavingSettings {
   savedTemplates: SavedTemplate[];
 }
 
+export const IMAGE_CACHE_LIMIT_MIN_MIB = 1;
+export const IMAGE_CACHE_LIMIT_MAX_MIB = 1_024;
+
 export interface DisplaySettings {
   showCoverImage: boolean;
+  allowImageCaching: boolean;
+  imageCacheLimitMiB: number;
+  imageCacheUnlimited: boolean;
   showSummary: boolean;
   showFilterStatusBar: boolean;
   paginationPosition: "top" | "bottom";
@@ -699,6 +705,9 @@ export const DEFAULT_SETTINGS: RssDashboardSettings = {
   },
   display: {
     showCoverImage: true,
+    allowImageCaching: false,
+    imageCacheLimitMiB: 100,
+    imageCacheUnlimited: false,
     showSummary: true,
     showFilterStatusBar: true,
     paginationPosition: "bottom",

--- a/src/utils/settings-loader.ts
+++ b/src/utils/settings-loader.ts
@@ -4,7 +4,11 @@ import type {
   Folder,
   RssDashboardSettings,
 } from "../types/types";
-import { DEFAULT_SETTINGS } from "../types/types";
+import {
+  DEFAULT_SETTINGS,
+  IMAGE_CACHE_LIMIT_MAX_MIB,
+  IMAGE_CACHE_LIMIT_MIN_MIB,
+} from "../types/types";
 import {
   migrateDisplaySettings,
   migrateDefaultFilterToDashboardMultiFilters,
@@ -155,6 +159,20 @@ export function loadAndNormalizeSettings(
     DEFAULT_SETTINGS.display,
     settings.display ?? {},
   );
+  if (
+    !Number.isInteger(settings.display.imageCacheLimitMiB) ||
+    settings.display.imageCacheLimitMiB < IMAGE_CACHE_LIMIT_MIN_MIB
+  ) {
+    settings.display.imageCacheLimitMiB =
+      DEFAULT_SETTINGS.display.imageCacheLimitMiB;
+  }
+  if (settings.display.imageCacheLimitMiB > IMAGE_CACHE_LIMIT_MAX_MIB) {
+    settings.display.imageCacheLimitMiB = IMAGE_CACHE_LIMIT_MAX_MIB;
+  }
+  if (typeof settings.display.imageCacheUnlimited !== "boolean") {
+    settings.display.imageCacheUnlimited =
+      DEFAULT_SETTINGS.display.imageCacheUnlimited;
+  }
   settings.readerFormat = Object.assign(
     {},
     DEFAULT_SETTINGS.readerFormat,
@@ -296,6 +314,23 @@ export function migrateSettings(settings: RssDashboardSettings): boolean {
   migrateDisplaySettings(
     settings.display as unknown as Record<string, unknown>,
   );
+  if (
+    !Number.isInteger(settings.display.imageCacheLimitMiB) ||
+    settings.display.imageCacheLimitMiB < IMAGE_CACHE_LIMIT_MIN_MIB
+  ) {
+    settings.display.imageCacheLimitMiB =
+      DEFAULT_SETTINGS.display.imageCacheLimitMiB;
+    didChange = true;
+  }
+  if (settings.display.imageCacheLimitMiB > IMAGE_CACHE_LIMIT_MAX_MIB) {
+    settings.display.imageCacheLimitMiB = IMAGE_CACHE_LIMIT_MAX_MIB;
+    didChange = true;
+  }
+  if (typeof settings.display.imageCacheUnlimited !== "boolean") {
+    settings.display.imageCacheUnlimited =
+      DEFAULT_SETTINGS.display.imageCacheUnlimited;
+    didChange = true;
+  }
 
   settings.keywordRules = Object.assign(
     {},

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -2445,6 +2445,7 @@ export class RssDashboardView extends ItemView {
     this.plugin.settings.feeds = this.plugin.settings.feeds.filter(
       (f: Feed) => f !== feed,
     );
+    void this.plugin.removeCachedImagesForDeletedFeed(feed);
     void this.plugin.saveSettings();
 
     if (this.currentFeed === feed) {

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -1002,6 +1002,8 @@ export class RssDashboardView extends ItemView {
           onPersistSettings: async () => {
             await this.plugin.saveSettings();
           },
+          onResolveCachedImageUrl: (remoteUrl) =>
+            this.plugin.resolveCachedImageUrl(remoteUrl),
           onMarkAllAsRead: () => {
             this.actionMarkAllAsRead();
           },

--- a/test_files/unit/components/article-list/views/card-view.test.ts
+++ b/test_files/unit/components/article-list/views/card-view.test.ts
@@ -88,6 +88,57 @@ describe("card-view", () => {
     expect(container.querySelector(".rss-dashboard-cover-image")).toBeTruthy();
   });
 
+  it("uses a cached preview URL only when image caching is enabled", () => {
+    const resolveCachedImageUrl = vi.fn(() => "app://local/cache/cover.jpg");
+    renderCardView(
+      container,
+      [makeArticle({ coverImage: "https://example.com/cover.jpg" })],
+      {
+        ...baseViewContext(),
+        settings: {
+          ...baseViewContext().settings,
+          display: {
+            ...baseViewContext().settings.display,
+            allowImageCaching: true,
+          },
+        },
+        resolveCachedImageUrl,
+        showCardToolbar: true,
+      },
+      baseViewDeps(),
+    );
+
+    expect(resolveCachedImageUrl).toHaveBeenCalledWith("https://example.com/cover.jpg");
+    expect(
+      container.querySelector(".rss-dashboard-cover-image")?.getAttribute("src"),
+    ).toBe("app://local/cache/cover.jpg");
+  });
+
+  it("retries the remote preview URL when a cached Card image fails", () => {
+    renderCardView(
+      container,
+      [makeArticle({ coverImage: "https://example.com/cover.jpg" })],
+      {
+        ...baseViewContext(),
+        settings: {
+          ...baseViewContext().settings,
+          display: {
+            ...baseViewContext().settings.display,
+            allowImageCaching: true,
+          },
+        },
+        resolveCachedImageUrl: () => "app://local/cache/cover.jpg",
+        showCardToolbar: true,
+      },
+      baseViewDeps(),
+    );
+
+    const image = container.querySelector(".rss-dashboard-cover-image") as HTMLImageElement;
+    image.dispatchEvent(new Event("error"));
+
+    expect(image.getAttribute("src")).toBe("https://example.com/cover.jpg");
+  });
+
   it.each([
     { showCoverImage: true, showSummary: true, image: true, summary: true },
     { showCoverImage: true, showSummary: false, image: true, summary: false },

--- a/test_files/unit/components/article-list/views/feed-view.test.ts
+++ b/test_files/unit/components/article-list/views/feed-view.test.ts
@@ -73,6 +73,61 @@ describe("feed-view", () => {
     ).toBeTruthy();
   });
 
+  it("uses one cached preview URL for the Feed image and blur", () => {
+    const resolveCachedImageUrl = vi.fn(() => "app://local/cache/cover.jpg");
+    renderFeedView(
+      container,
+      [makeArticle({ coverImage: "https://example.com/cover.jpg" })],
+      {
+        ...baseViewContext(),
+        settings: {
+          ...baseViewContext().settings,
+          display: {
+            ...baseViewContext().settings.display,
+            allowImageCaching: true,
+          },
+        },
+        resolveCachedImageUrl,
+      },
+      baseViewDeps(),
+    );
+
+    expect(resolveCachedImageUrl).toHaveBeenCalledWith("https://example.com/cover.jpg");
+    expect(
+      container.querySelector(".rss-dashboard-feed-hero-image")?.getAttribute("src"),
+    ).toBe("app://local/cache/cover.jpg");
+    expect(
+      container.querySelector(".rss-dashboard-feed-hero-blur")?.getAttribute("style"),
+    ).toContain("app://local/cache/cover.jpg");
+  });
+
+  it("retries the remote preview URL when a cached Feed image fails", () => {
+    renderFeedView(
+      container,
+      [makeArticle({ coverImage: "https://example.com/cover.jpg" })],
+      {
+        ...baseViewContext(),
+        settings: {
+          ...baseViewContext().settings,
+          display: {
+            ...baseViewContext().settings.display,
+            allowImageCaching: true,
+          },
+        },
+        resolveCachedImageUrl: () => "app://local/cache/cover.jpg",
+      },
+      baseViewDeps(),
+    );
+
+    const image = container.querySelector(".rss-dashboard-feed-hero-image") as HTMLImageElement;
+    image.dispatchEvent(new Event("error"));
+
+    expect(image.getAttribute("src")).toBe("https://example.com/cover.jpg");
+    expect(
+      container.querySelector(".rss-dashboard-feed-hero-blur")?.getAttribute("style"),
+    ).toContain("https://example.com/cover.jpg");
+  });
+
   it.each([
     { showCoverImage: true, showSummary: true, image: true, summary: true },
     { showCoverImage: true, showSummary: false, image: true, summary: false },

--- a/test_files/unit/main/background-import-orchestration.test.ts
+++ b/test_files/unit/main/background-import-orchestration.test.ts
@@ -16,10 +16,12 @@ import { BackgroundImportService } from "../../../src/services/background-import
 import RssDashboardPlugin from "../../../main";
 
 const mockParseFeed = vi.fn();
+const mockRefreshFeed = vi.fn();
 
 vi.mock("../../../src/services/feed-parser", () => ({
   FeedParser: class FeedParser {
     parseFeed = mockParseFeed;
+    refreshFeed = mockRefreshFeed;
     refreshAllFeeds = vi.fn();
     constructor(_media?: unknown, _availableTags?: unknown) {}
   },
@@ -48,6 +50,7 @@ interface PluginWithInternal {
   addStatusBarItem(): HTMLElement;
   feedParser: {
     parseFeed: typeof mockParseFeed;
+    refreshFeed: typeof mockRefreshFeed;
     refreshAllFeeds: ReturnType<typeof vi.fn>;
   };
 }
@@ -74,6 +77,7 @@ function createPlugin(): RssDashboardPlugin {
   pluginInternal.addStatusBarItem = vi.fn(() => document.createElement("div"));
   pluginInternal.feedParser = {
     parseFeed: mockParseFeed,
+    refreshFeed: mockRefreshFeed,
     refreshAllFeeds: vi.fn(),
   };
 
@@ -85,6 +89,12 @@ function createPlugin(): RssDashboardPlugin {
     saveSettings: () => plugin.saveSettings(),
     ensureFolderExists: vi.fn().mockResolvedValue(false),
     addStatusBarItem: () => pluginInternal.addStatusBarItem(),
+    onFeedImported: (feed) =>
+      (
+        plugin as unknown as {
+          queuePreviewImageCaching(importedFeed: Feed): void;
+        }
+      ).queuePreviewImageCaching(feed),
   });
 
   return plugin;
@@ -122,6 +132,140 @@ describe("background import orchestration", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "debug").mockImplementation(() => {});
     mockParseFeed.mockReset();
+    mockRefreshFeed.mockReset();
+  });
+
+  it("does not let refresh overwrite a Discover feed while background hydration owns it", async () => {
+    const plugin = createPlugin();
+    const existingFeed = {
+      ...createPlaceholderFeed("https://example.com/existing.xml"),
+      items: [
+        {
+          title: "Existing article",
+          link: "https://example.com/existing/article",
+          description: "Existing description",
+          pubDate: "2026-08-21T12:00:00.000Z",
+          guid: "existing-article",
+          read: false,
+          starred: false,
+          tags: [],
+          feedTitle: "Existing feed",
+          feedUrl: "https://example.com/existing.xml",
+        },
+      ],
+    } satisfies Feed;
+    plugin.settings.feeds = [existingFeed];
+    plugin.settings.display = {
+      ...plugin.settings.display,
+      allowImageCaching: true,
+      showCoverImage: true,
+    };
+    const cacheUrl = vi.fn().mockResolvedValue(true);
+    (
+      plugin as unknown as {
+        imageCacheService: { cacheUrl: typeof cacheUrl };
+      }
+    ).imageCacheService = { cacheUrl };
+
+    let resolveInitialSave: (() => void) | undefined;
+    vi.mocked(plugin.saveData)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveInitialSave = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+
+    let resolveImport: ((feed: Feed) => void) | undefined;
+    mockParseFeed.mockReturnValue(
+      new Promise<Feed>((resolve) => {
+        resolveImport = resolve;
+      }),
+    );
+
+    let resolvePlaceholderRefresh: ((feed: Feed) => void) | undefined;
+    mockRefreshFeed.mockImplementation((feed: Feed) => {
+      if (feed.url === existingFeed.url) {
+        return Promise.resolve(feed);
+      }
+
+      return new Promise<Feed>((resolve) => {
+        resolvePlaceholderRefresh = resolve;
+      });
+    });
+
+    const ingestPromise = plugin.ingestFeedsForBackgroundImport([
+      {
+        title: "Discovered feed",
+        url: "https://example.com/discovered.xml",
+        folder: "Discover",
+      },
+    ]);
+    await flushMicrotasks();
+    expect(mockParseFeed).not.toHaveBeenCalled();
+
+    const refreshPromise = plugin.refreshFeeds();
+    await flushMicrotasks();
+
+    expect(mockRefreshFeed).toHaveBeenCalledWith(existingFeed, {
+      signal: expect.any(AbortSignal),
+    });
+
+    resolveInitialSave?.();
+    await ingestPromise;
+    await flushMicrotasks();
+
+    const importedArticle = {
+      title: "Imported article",
+      link: "https://example.com/discovered/article",
+      description: "Imported description",
+      pubDate: "2026-01-01T12:00:00.000Z",
+      guid: "imported-article",
+      read: false,
+      starred: false,
+      tags: [],
+      feedTitle: "Discovered feed",
+      feedUrl: "https://example.com/discovered.xml",
+      coverImage: "https://example.com/discovered-cover.jpg",
+    };
+    resolveImport?.({
+      ...createPlaceholderFeed("https://example.com/discovered.xml"),
+      title: "Discovered feed",
+      items: [importedArticle],
+    });
+    await flushMicrotasks();
+
+    resolvePlaceholderRefresh?.({
+      ...createPlaceholderFeed("https://example.com/discovered.xml"),
+      title: "Discovered feed",
+      items: [],
+    });
+    await refreshPromise;
+    await vi.waitFor(
+      () => {
+        expect(
+          (plugin as unknown as PluginWithInternal).isBackgroundImporting,
+        ).toBe(false);
+      },
+      { timeout: 3000 },
+    );
+
+    expect(plugin.settings.feeds.find((feed) => feed.url === existingFeed.url)?.items)
+      .toEqual(existingFeed.items);
+    expect(
+      plugin.settings.feeds.find(
+        (feed) => feed.url === "https://example.com/discovered.xml",
+      )?.items,
+    ).toEqual([importedArticle]);
+    expect(cacheUrl).toHaveBeenCalledWith(
+      "https://example.com/discovered-cover.jpg",
+      true,
+    );
+    expect(mockRefreshFeed).not.toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/discovered.xml" }),
+      expect.anything(),
+    );
   });
 
   it("processes queued feeds with bounded concurrency", async () => {

--- a/test_files/unit/main/plugin-lifecycle.test.ts
+++ b/test_files/unit/main/plugin-lifecycle.test.ts
@@ -1372,6 +1372,63 @@ describe("addFeed()", () => {
     expect(plugin.settings.feeds).toHaveLength(2);
   });
 
+  it("refreshes the dashboard after a newly added feed finishes warming preview images", async () => {
+    const newUrl = "https://example.com/discovered-feed.xml";
+    let finishCaching: ((cached: boolean) => void) | undefined;
+    const cacheUrl = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishCaching = resolve;
+        }),
+    );
+    const refresh = vi.fn();
+    plugin.settings.display.allowImageCaching = true;
+    plugin.settings.display.showCoverImage = true;
+    vi.mocked(plugin.getActiveDashboardView).mockResolvedValue({
+      refresh,
+    } as unknown as Awaited<ReturnType<typeof plugin.getActiveDashboardView>>);
+    (
+      plugin as unknown as {
+        imageCacheService: {
+          cacheUrl: (url: string, force: boolean) => Promise<boolean>;
+        };
+      }
+    ).imageCacheService = { cacheUrl };
+    mockParseFeed.mockResolvedValue({
+      title: "Discovered Feed",
+      url: newUrl,
+      folder: "Uncategorized",
+      items: [
+        {
+          ...sampleFeed.items[0],
+          feedUrl: newUrl,
+          feedTitle: "Discovered Feed",
+          coverImage: "https://example.com/discovered-cover.jpg",
+        },
+      ],
+      lastUpdated: Date.now(),
+      mediaType: "article",
+    });
+
+    const added = await plugin.addFeed(
+      "Discovered Feed",
+      newUrl,
+      "Uncategorized",
+    );
+
+    expect(added).toBe(true);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(cacheUrl).toHaveBeenCalledWith(
+      "https://example.com/discovered-cover.jpg",
+      true,
+    );
+
+    finishCaching?.(true);
+    await flushPromises();
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
   it("detects media type based on folder (YouTube)", async () => {
     // Given: Feed in YouTube folder
     const youtubeUrl = "https://youtube.com/feed.xml";

--- a/test_files/unit/modals/feed-manager-modal.test.ts
+++ b/test_files/unit/modals/feed-manager-modal.test.ts
@@ -13,6 +13,10 @@ function cloneSettings(): RssDashboardSettings {
   return JSON.parse(JSON.stringify(DEFAULT_SETTINGS)) as RssDashboardSettings;
 }
 
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
   installObsidianDomPolyfills();
   document.body.empty();
@@ -24,6 +28,107 @@ beforeEach(() => {
 });
 
 describe("FeedManagerModal", () => {
+  it("discloses and clears cached preview images when all feeds are deleted", async () => {
+    const app = obsidian.App.createMock();
+    const settings = cloneSettings();
+    settings.feeds = [
+      {
+        title: "Feed",
+        url: "https://example.com/feed.xml",
+        folder: "Inbox",
+        items: [],
+        lastUpdated: 0,
+        mediaType: "article",
+      },
+    ];
+    const clearImageCache = vi.fn(async () => ({ cleared: 3, failed: 0 }));
+    const plugin = {
+      app,
+      settings,
+      saveSettings: vi.fn(async () => {}),
+      getImageCacheSizeBytes: vi.fn(() => 1_024),
+      clearImageCache,
+      getActiveDashboardView: vi.fn(async () => null),
+      exportOpml: vi.fn(),
+      addFeed: vi.fn(async () => true),
+    };
+    const modal = new FeedManagerModal(
+      app as unknown as obsidian.App,
+      plugin as unknown as RssDashboardPlugin,
+    );
+    modal.open();
+
+    const deleteAllButton = modal.contentEl.querySelector(
+      ".feed-manager-delete-all-button",
+    ) as HTMLButtonElement;
+    deleteAllButton.click();
+
+    const confirmation = Array.from(
+      document.querySelectorAll(".rss-dashboard-confirm-modal"),
+    )[0] as HTMLElement;
+    expect(confirmation.textContent).toContain("1.0 KB");
+
+    const confirmButton = Array.from(confirmation.querySelectorAll("button")).find(
+      (button) => button.textContent === "Delete all feeds",
+    ) as HTMLButtonElement;
+    confirmButton.click();
+    await flushPromises();
+
+    expect(settings.feeds).toEqual([]);
+    expect(clearImageCache).toHaveBeenCalledTimes(1);
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports cache-clear failures after deleting all feeds", async () => {
+    const app = obsidian.App.createMock();
+    const settings = cloneSettings();
+    settings.feeds = [
+      {
+        title: "Feed",
+        url: "https://example.com/feed.xml",
+        folder: "Inbox",
+        items: [],
+        lastUpdated: 0,
+        mediaType: "article",
+      },
+    ];
+    const plugin = {
+      app,
+      settings,
+      saveSettings: vi.fn(async () => {}),
+      getImageCacheSizeBytes: vi.fn(() => 1),
+      clearImageCache: vi.fn(async () => ({ cleared: 2, failed: 1 })),
+      getActiveDashboardView: vi.fn(async () => null),
+      exportOpml: vi.fn(),
+      addFeed: vi.fn(async () => true),
+    };
+    const noticeSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const modal = new FeedManagerModal(
+      app as unknown as obsidian.App,
+      plugin as unknown as RssDashboardPlugin,
+    );
+    modal.open();
+    (modal.contentEl.querySelector(
+      ".feed-manager-delete-all-button",
+    ) as HTMLButtonElement).click();
+
+    const confirmation = document.querySelector(
+      ".rss-dashboard-confirm-modal",
+    ) as HTMLElement;
+    (Array.from(confirmation.querySelectorAll("button")).find(
+      (button) => button.textContent === "Delete all feeds",
+    ) as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(
+      noticeSpy.mock.calls.some(
+        ([prefix, message]) =>
+          prefix === "[Stub Notice]" &&
+          message === "All feeds deleted, but 1 cached image could not be removed.",
+      ),
+    ).toBe(true);
+  });
+
   it("closes after the OPML import modal reports import started", () => {
     const app = obsidian.App.createMock();
     const plugin = {

--- a/test_files/unit/services/background-import-service.test.ts
+++ b/test_files/unit/services/background-import-service.test.ts
@@ -212,6 +212,65 @@ describe("BackgroundImportService", () => {
   });
 
   describe("parseFeedWithTimeout", () => {
+    it("reports a successfully hydrated imported feed for post-import work", async () => {
+      const { BackgroundImportService } =
+        await import("../../../src/services/background-import-service");
+      const onFeedImported = vi.fn();
+      const importedFeed: Feed = {
+        title: "Imported Feed",
+        url: "https://example.com/imported.xml",
+        folder: "Inbox",
+        items: [
+          {
+            title: "Article",
+            link: "https://example.com/article",
+            description: "",
+            pubDate: "2026-08-21",
+            guid: "article",
+            read: false,
+            starred: false,
+            tags: [],
+            feedTitle: "Imported Feed",
+            feedUrl: "https://example.com/imported.xml",
+            coverImage: "https://example.com/cover.jpg",
+          },
+        ],
+        lastUpdated: 0,
+        mediaType: "article",
+      };
+      const deps = makeDeps({
+        feeds: [
+          {
+            ...importedFeed,
+            items: [],
+          },
+        ],
+      });
+      deps.feedParser.parseFeed = vi.fn().mockResolvedValue(importedFeed);
+      const service = new BackgroundImportService({
+        ...deps,
+        onFeedImported,
+      });
+
+      (
+        service as unknown as TestableBackgroundImportService
+      ).backgroundImportQueue = [deps._settings.feeds[0]];
+      (
+        service as unknown as TestableBackgroundImportService
+      ).backgroundImportTotalCount = 1;
+
+      await (
+        service as unknown as TestableBackgroundImportService
+      ).processBackgroundImportWorker(1, 1, false);
+
+      expect(onFeedImported).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/imported.xml",
+          items: [expect.objectContaining({ coverImage: "https://example.com/cover.jpg" })],
+        }),
+      );
+    });
+
     it("does not retry timeout failures", async () => {
       const { BackgroundImportService } =
         await import("../../../src/services/background-import-service");

--- a/test_files/unit/services/image-cache-service.test.ts
+++ b/test_files/unit/services/image-cache-service.test.ts
@@ -211,6 +211,28 @@ describe("ImageCacheService", () => {
     expect(cache.resolveCachedUrl("https://example.com/cover.jpg")).toBeNull();
   });
 
+  it("removes only the requested cached preview URLs", async () => {
+    const adapter = createAdapter();
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage: async () => jpegResponse(),
+      now: () => 100,
+    });
+
+    await cache.initialize();
+    await cache.cacheUrl("https://example.com/deleted.jpg");
+    await cache.cacheUrl("https://example.com/retained.jpg");
+
+    await expect(
+      cache.removeUrls(["https://example.com/deleted.jpg#fragment"]),
+    ).resolves.toEqual({ cleared: 1, failed: 0 });
+    expect(cache.resolveCachedUrl("https://example.com/deleted.jpg")).toBeNull();
+    expect(cache.resolveCachedUrl("https://example.com/retained.jpg")).toContain(
+      ".jpg",
+    );
+  });
+
   it("replaces an aged entry only when refresh work explicitly requests it", async () => {
     const adapter = createAdapter();
     let currentTime = 100;

--- a/test_files/unit/services/image-cache-service.test.ts
+++ b/test_files/unit/services/image-cache-service.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ImageCacheService,
+  type ImageCacheAdapter,
+  type ImageCacheFetchResponse,
+} from "../../../src/services/image-cache-service";
+
+function createAdapter(): ImageCacheAdapter {
+  const textFiles = new Map<string, string>();
+  const binaryFiles = new Map<string, ArrayBuffer>();
+  const directories = new Set<string>();
+
+  return {
+    exists: vi.fn(async (path: string) =>
+      textFiles.has(path) || binaryFiles.has(path) || directories.has(path),
+    ),
+    read: vi.fn(async (path: string) => textFiles.get(path) ?? ""),
+    write: vi.fn(async (path: string, content: string) => {
+      textFiles.set(path, content);
+    }),
+    writeBinary: vi.fn(async (path: string, content: ArrayBuffer) => {
+      binaryFiles.set(path, content);
+    }),
+    mkdir: vi.fn(async (path: string) => {
+      directories.add(path);
+    }),
+    remove: vi.fn(async (path: string) => {
+      textFiles.delete(path);
+      binaryFiles.delete(path);
+    }),
+    rmdir: vi.fn(async (path: string) => {
+      directories.delete(path);
+    }),
+    getResourcePath: vi.fn((path: string) => `app://local/${path}`),
+  };
+}
+
+function jpegResponse(byteLength = 8): ImageCacheFetchResponse {
+  const bytes = new Uint8Array(byteLength);
+  bytes.set([0xff, 0xd8, 0xff]);
+  return {
+    status: 200,
+    headers: { "content-type": "image/jpeg" },
+    arrayBuffer: bytes.buffer,
+  };
+}
+
+describe("ImageCacheService", () => {
+  it("preserves an explicit unlimited aggregate limit during initialization", () => {
+    const cache = new ImageCacheService({
+      adapter: createAdapter(),
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage: async () => jpegResponse(),
+      maxCacheBytes: null,
+    });
+
+    expect(
+      (cache as unknown as { maxCacheBytes: number | null }).maxCacheBytes,
+    ).toBeNull();
+  });
+
+  it("uses one cache entry for URLs that differ only by fragment", async () => {
+    const adapter = createAdapter();
+    const fetchImage = vi.fn(async () => jpegResponse());
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage,
+      now: () => 100,
+    });
+
+    await cache.initialize();
+    await cache.cacheUrl("https://example.com/cover.jpg?size=large#first");
+
+    expect(
+      cache.resolveCachedUrl("https://example.com/cover.jpg?size=large#second"),
+    ).toContain(".jpg");
+    expect(fetchImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not store responses larger than one MiB", async () => {
+    const adapter = createAdapter();
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage: async () => jpegResponse(1_048_577),
+      now: () => 100,
+    });
+
+    await cache.initialize();
+
+    await expect(cache.cacheUrl("https://example.com/large.jpg")).resolves.toBe(
+      false,
+    );
+    expect(cache.getSizeBytes()).toBe(0);
+    expect(cache.resolveCachedUrl("https://example.com/large.jpg")).toBeNull();
+  });
+
+  it("rejects an HTML response that claims to be a preview image", async () => {
+    const adapter = createAdapter();
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage: async () => ({
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+        arrayBuffer: new TextEncoder().encode("<html>not an image</html>").buffer,
+      }),
+      now: () => 100,
+    });
+
+    await cache.initialize();
+
+    await expect(cache.cacheUrl("https://example.com/error.jpg")).resolves.toBe(
+      false,
+    );
+    expect(cache.getSizeBytes()).toBe(0);
+  });
+
+  it("evicts the least recently used entry before exceeding its total limit", async () => {
+    const adapter = createAdapter();
+    let currentTime = 100;
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage: async () => jpegResponse(8),
+      maxCacheBytes: 12,
+      now: () => currentTime,
+    });
+
+    await cache.initialize();
+    await cache.cacheUrl("https://example.com/older.jpg");
+    currentTime = 200;
+    await cache.cacheUrl("https://example.com/newer.jpg");
+
+    expect(cache.resolveCachedUrl("https://example.com/older.jpg")).toBeNull();
+    expect(cache.resolveCachedUrl("https://example.com/newer.jpg")).toContain(
+      ".jpg",
+    );
+    expect(cache.getSizeBytes()).toBe(8);
+  });
+
+  it("trims least recently used entries immediately when a lower finite limit is saved", async () => {
+    const adapter = createAdapter();
+    let currentTime = 100;
+    const fetchImage = vi.fn(async () => jpegResponse(8));
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage,
+      maxCacheBytes: 24,
+      now: () => currentTime,
+    });
+
+    await cache.initialize();
+    await cache.cacheUrl("https://example.com/older.jpg");
+    currentTime = 200;
+    await cache.cacheUrl("https://example.com/newer.jpg");
+
+    await cache.setMaxCacheBytes(8);
+
+    expect(cache.resolveCachedUrl("https://example.com/older.jpg")).toBeNull();
+    expect(cache.resolveCachedUrl("https://example.com/newer.jpg")).toContain(
+      ".jpg",
+    );
+    expect(cache.getSizeBytes()).toBe(8);
+    expect(fetchImage).toHaveBeenCalledTimes(2);
+  });
+
+  it("supports an unlimited aggregate limit without refetching fresh entries", async () => {
+    const adapter = createAdapter();
+    const fetchImage = vi.fn(async () => jpegResponse(8));
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage,
+      maxCacheBytes: 8,
+      now: () => 100,
+    });
+
+    await cache.initialize();
+    await cache.cacheUrl("https://example.com/first.jpg");
+    await cache.setMaxCacheBytes(null);
+    await cache.cacheUrl("https://example.com/second.jpg");
+    await cache.cacheUrl("https://example.com/first.jpg");
+
+    expect(cache.getSizeBytes()).toBe(16);
+    expect(cache.resolveCachedUrl("https://example.com/first.jpg")).toContain(
+      ".jpg",
+    );
+    expect(cache.resolveCachedUrl("https://example.com/second.jpg")).toContain(
+      ".jpg",
+    );
+    expect(fetchImage).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears only indexed image files and resets the cache size", async () => {
+    const adapter = createAdapter();
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage: async () => jpegResponse(),
+      now: () => 100,
+    });
+
+    await cache.initialize();
+    await cache.cacheUrl("https://example.com/cover.jpg");
+
+    await expect(cache.clear()).resolves.toEqual({ cleared: 1, failed: 0 });
+    expect(cache.getSizeBytes()).toBe(0);
+    expect(cache.resolveCachedUrl("https://example.com/cover.jpg")).toBeNull();
+  });
+
+  it("replaces an aged entry only when refresh work explicitly requests it", async () => {
+    const adapter = createAdapter();
+    let currentTime = 100;
+    const fetchImage = vi.fn(async () => jpegResponse());
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage,
+      now: () => currentTime,
+    });
+
+    await cache.initialize();
+    await cache.cacheUrl("https://example.com/cover.jpg");
+    currentTime += 31 * 24 * 60 * 60 * 1_000;
+
+    expect(cache.isStale("https://example.com/cover.jpg")).toBe(true);
+    await cache.cacheUrl("https://example.com/cover.jpg");
+    await cache.cacheUrl("https://example.com/cover.jpg", true);
+
+    expect(fetchImage).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not write a response that completes after pending writes are cancelled", async () => {
+    const adapter = createAdapter();
+    let resolveFetch: ((response: ImageCacheFetchResponse) => void) | null = null;
+    const cache = new ImageCacheService({
+      adapter,
+      cacheRoot: "config/plugins/rss-dashboard/image-cache",
+      fetchImage: () =>
+        new Promise<ImageCacheFetchResponse>((resolve) => {
+          resolveFetch = resolve;
+        }),
+      now: () => 100,
+    });
+
+    await cache.initialize();
+    const pending = cache.cacheUrl("https://example.com/cover.jpg");
+    cache.cancelPendingWrites();
+    resolveFetch?.(jpegResponse());
+
+    await expect(pending).resolves.toBe(false);
+    expect(cache.getSizeBytes()).toBe(0);
+  });
+});

--- a/test_files/unit/settings/display-reader-settings-tab.test.ts
+++ b/test_files/unit/settings/display-reader-settings-tab.test.ts
@@ -31,6 +31,95 @@ beforeEach(() => {
 });
 
 describe("renderDisplaySettingsTab() reader section", () => {
+  it("defaults image caching off and delegates enablement to the plugin", async () => {
+    const containerEl = document.createElement("div");
+    document.body.appendChild(containerEl);
+    const settings = cloneSettings();
+    const setImageCachingEnabled = vi.fn(async () => {});
+    const plugin = {
+      app: { workspace: { revealLeaf: vi.fn(async () => {}) } },
+      settings,
+      saveSettings: vi.fn(async () => {}),
+      setImageCachingEnabled,
+      getImageCacheSizeBytes: vi.fn(() => 1_024),
+      getActiveDashboardView: vi.fn(async () => ({ leaf: {}, render: vi.fn() })),
+      getActiveReaderView: vi.fn(async () => null),
+    } as unknown as RssDashboardPlugin;
+
+    renderDisplaySettingsTab(containerEl, plugin, () => {});
+
+    const cacheSetting = getSettingByName(containerEl, "Allow image caching");
+    expect(cacheSetting.querySelector(".setting-item-description")?.textContent).toContain(
+      "one megabyte",
+    );
+    const toggle = cacheSetting.querySelector("input") as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event("change"));
+    await flushPromises();
+
+    expect(setImageCachingEnabled).toHaveBeenCalledWith(true);
+    expect(
+      getSettingByName(containerEl, "Clear image cache").textContent,
+    ).toContain("Cached image storage: 1.0 KB.");
+  });
+
+  it("saves a custom finite cache limit and lets users remove the aggregate cap", async () => {
+    const containerEl = document.createElement("div");
+    document.body.appendChild(containerEl);
+    const settings = cloneSettings();
+    const setImageCacheLimit = vi.fn(async () => {});
+    const plugin = {
+      app: { workspace: { revealLeaf: vi.fn(async () => {}) } },
+      settings,
+      saveSettings: vi.fn(async () => {}),
+      setImageCachingEnabled: vi.fn(async () => {}),
+      setImageCacheLimit,
+      getImageCacheSizeBytes: vi.fn(() => 0),
+      getActiveDashboardView: vi.fn(async () => null),
+      getActiveReaderView: vi.fn(async () => null),
+    } as unknown as RssDashboardPlugin;
+
+    renderDisplaySettingsTab(containerEl, plugin, () => {});
+
+    const limitSetting = getSettingByName(containerEl, "Image cache limit");
+    const limitInput = limitSetting.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+    const limitSlider = limitSetting.querySelector(
+      'input[type="range"]',
+    ) as HTMLInputElement;
+    expect(limitInput.value).toBe("100");
+    expect(limitSlider.min).toBe("1");
+    expect(limitSlider.max).toBe("1024");
+    limitSlider.value = "512";
+    limitSlider.dispatchEvent(new Event("input"));
+    await flushPromises();
+
+    expect(limitInput.value).toBe("512");
+    expect(setImageCacheLimit).toHaveBeenCalledWith(512, false);
+    limitInput.value = "25";
+    limitInput.dispatchEvent(new Event("blur"));
+    await flushPromises();
+
+    expect(setImageCacheLimit).toHaveBeenLastCalledWith(25, false);
+
+    limitInput.value = "25.5";
+    limitInput.dispatchEvent(new Event("blur"));
+    await flushPromises();
+
+    expect(setImageCacheLimit).toHaveBeenCalledTimes(2);
+    expect(limitInput.value).toBe("100");
+
+    const unlimitedSetting = getSettingByName(containerEl, "No cache size limit");
+    const unlimitedToggle = unlimitedSetting.querySelector("input") as HTMLInputElement;
+    unlimitedToggle.checked = true;
+    unlimitedToggle.dispatchEvent(new Event("change"));
+    await flushPromises();
+
+    expect(setImageCacheLimit).toHaveBeenLastCalledWith(100, true);
+  });
+
   it("describes dashboard previews and rerenders the active Feed dashboard after either preview preference changes", async () => {
     const containerEl = document.createElement("div");
     document.body.appendChild(containerEl);

--- a/test_files/unit/utils/settings-loader.test.ts
+++ b/test_files/unit/utils/settings-loader.test.ts
@@ -71,6 +71,33 @@ describe("settings-loader", () => {
   // ── loadAndNormalizeSettings ─────────────────────────────────────────────────
 
   describe("loadAndNormalizeSettings", () => {
+    it("defaults invalid image cache limits while retaining a valid unlimited preference", async () => {
+      const { loadAndNormalizeSettings } =
+        await import("../../../src/utils/settings-loader");
+
+      const result = loadAndNormalizeSettings({
+        display: {
+          imageCacheLimitMiB: 0,
+          imageCacheUnlimited: true,
+        } as Partial<RssDashboardSettings["display"]>,
+      });
+
+      expect(result.display.imageCacheLimitMiB).toBe(100);
+      expect(result.display.imageCacheUnlimited).toBe(true);
+    });
+
+    it("caps persisted image cache limits at one GiB", async () => {
+      const { loadAndNormalizeSettings } =
+        await import("../../../src/utils/settings-loader");
+
+      const result = loadAndNormalizeSettings({
+        display: {
+          imageCacheLimitMiB: 2_048,
+        } as Partial<RssDashboardSettings["display"]>,
+      });
+
+      expect(result.display.imageCacheLimitMiB).toBe(1_024);
+    });
     it("merges DEFAULT_SETTINGS with raw data", async () => {
       const { loadAndNormalizeSettings } =
         await import("../../../src/utils/settings-loader");

--- a/test_files/unit/views/dashboard-lifecycle.test.ts
+++ b/test_files/unit/views/dashboard-lifecycle.test.ts
@@ -141,7 +141,11 @@ async function makeView(
   const { RssDashboardView } =
     await import("../../../src/views/dashboard-view");
   const app = new App();
-  const plugin = { settings, saveSettings: vi.fn(async () => {}) };
+  const plugin = {
+    settings,
+    saveSettings: vi.fn(async () => {}),
+    removeCachedImagesForDeletedFeed: vi.fn(async () => {}),
+  };
   const leaf = { app } as unknown as import("obsidian").WorkspaceLeaf;
   const view = new RssDashboardView(leaf, plugin as never);
   view.render = vi.fn();
@@ -665,20 +669,24 @@ describe("Dashboard lifecycle", () => {
       expect(settings.feeds[0].url).toBe("https://b.com/feed");
     });
 
-    it("leaves the shared image cache intact", async () => {
+    it("removes cached preview images for the deleted feed", async () => {
       const settings = cloneSettings();
-      const feed1 = makeFeed("https://a.com/feed");
+      const feed1 = makeFeed("https://a.com/feed", "", [
+        { coverImage: "https://images.example.com/deleted.jpg" },
+      ]);
       const feed2 = makeFeed("https://b.com/feed");
       settings.feeds = [feed1, feed2];
       const view = await makeView(settings);
-      const clearImageCache = vi.fn();
+      const removeCachedImagesForDeletedFeed = vi.fn();
       (
-        view.plugin as unknown as { clearImageCache: () => void }
-      ).clearImageCache = clearImageCache;
+        view.plugin as unknown as {
+          removeCachedImagesForDeletedFeed: (feed: Feed) => Promise<void>;
+        }
+      ).removeCachedImagesForDeletedFeed = removeCachedImagesForDeletedFeed;
 
       view.handleDeleteFeed(feed1);
 
-      expect(clearImageCache).not.toHaveBeenCalled();
+      expect(removeCachedImagesForDeletedFeed).toHaveBeenCalledWith(feed1);
     });
 
     it("clears currentFeed if the deleted feed was active", async () => {

--- a/test_files/unit/views/dashboard-lifecycle.test.ts
+++ b/test_files/unit/views/dashboard-lifecycle.test.ts
@@ -168,7 +168,7 @@ describe("Dashboard lifecycle", () => {
 
       expect(view.settings.feeds).toHaveLength(1);
       expect(view.render).toHaveBeenCalled();
-    });
+    }, 10_000);
   });
 
   describe("refreshSidebarOnly()", () => {
@@ -663,6 +663,22 @@ describe("Dashboard lifecycle", () => {
       view.handleDeleteFeed(feed1);
       expect(settings.feeds).toHaveLength(1);
       expect(settings.feeds[0].url).toBe("https://b.com/feed");
+    });
+
+    it("leaves the shared image cache intact", async () => {
+      const settings = cloneSettings();
+      const feed1 = makeFeed("https://a.com/feed");
+      const feed2 = makeFeed("https://b.com/feed");
+      settings.feeds = [feed1, feed2];
+      const view = await makeView(settings);
+      const clearImageCache = vi.fn();
+      (
+        view.plugin as unknown as { clearImageCache: () => void }
+      ).clearImageCache = clearImageCache;
+
+      view.handleDeleteFeed(feed1);
+
+      expect(clearImageCache).not.toHaveBeenCalled();
     });
 
     it("clears currentFeed if the deleted feed was active", async () => {


### PR DESCRIPTION
## Summary
- add opt-in local caching for dashboard card and feed preview images
- enforce per-image and aggregate cache limits with management controls
- warm the cache after feed additions and OPML/background imports
- clean cached previews when feeds are deleted
- protect Discover feeds that are still hydrating from refresh overwrites

Closes #177