### PR TITLE
Fix dashboard header Mark all read/unread controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- Fixed dashboard header Mark all read/unread controls so they update and persist the stored articles in the current filtered view. [GH Issue #185](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/185)
 - Removed duplicate close controls from mobile Dashboard and Discover sidebars, retaining Obsidian's standard modal header close button.
 - Standardized sidebar and mobile navigation scrolling on native Obsidian scrollbars, removing the retired scrollbar-visibility preference and custom scrollbar styling.
 - Fixed OPML imports and Discover Add actions so their feed fetching uses the global sidebar spinner and Stop action, cancels active and queued work, preserves completed results, and ignores late results after cancellation. [GH Issue #179](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/179)

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -9,6 +9,7 @@ records the complete 2026-08-16 documentation classification.
 
 | Plan                                                                                   | Completed  | Issue                                                                               | Implementation |
 | -------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------- | -------------- |
+| [Mark all read/unread controls](plans/unreleased/185-mark-all-read-unread-controls.md) | 2026-08-24 | [GH Issue #185](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/185) | â€” |
 | [Podcast playlist windowing](plans/unreleased/183-podcast-playlist-windowing.md) | 2026-08-22 | [GH Issue #183](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/183) | [PR #184](https://github.com/amatya-aditya/obsidian-rss-dashboard/pull/184) |
 | [CI security hardening baseline](plans/unreleased/181-ci-security-hardening.md) | 2026-08-22 | [GH Issue #181](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/181) | — |
 | [Image preview disk cache](plans/unreleased/177-image-preview-disk-cache.md) | 2026-08-21 | [GH Issue #177](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/177) | — |

--- a/docs/archive/plans/unreleased/185-mark-all-read-unread-controls.md
+++ b/docs/archive/plans/unreleased/185-mark-all-read-unread-controls.md
@@ -1,0 +1,87 @@
+---
+status: implemented
+completed: 2026-08-24
+released_in: unreleased
+issue: https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/185
+implementation: ""
+---
+
+# Make Mark all read/unread controls update article state
+
+## Problem
+
+Issue #185 reports that choosing **Mark all: Read** from the article-header
+controls only refreshes the dashboard: unread cards remain visible. The same
+action is exposed from the responsive hamburger menu and the desktop header,
+so their behavior must remain equivalent.
+
+## Scope and intended behavior
+
+Both the hamburger-menu controls in `ArticleHeaderMenu` and the desktop
+controls in `ArticleHeader` must apply their requested read state to every
+article in the current filtered dashboard view. The filter boundary includes
+the active feed/folder/tag selection, search query, status filters, age filter,
+and other existing dashboard filters.
+
+- **Read** marks each currently visible-in-scope unread article as read.
+- **Unread** marks each currently visible-in-scope read article as unread.
+- The UI updates to reflect the new state, including status-filtered results,
+  badges, and empty-state messaging where relevant.
+- The mutation persists through the plugin's established settings/storage path,
+  so reopening the dashboard does not restore the previous state.
+- A no-op action retains the existing user-facing feedback when no matching
+  articles are available.
+
+## Implementation direction
+
+1. Reproduce the state transition through each header control and trace the
+   callbacks through `src/components/article-header-menu.ts`,
+   `src/components/article-header.ts`, `src/components/article-list.ts`, and
+   `src/views/dashboard-view.ts`.
+2. Repair the shared dashboard action/state-render boundary rather than adding
+   divergent mutations to individual controls.
+3. Keep the existing action boundary (`getFilteredArticles()`); this work does
+   not change all stored articles outside the active dashboard view.
+4. Preserve responsive and popout-safe DOM ownership conventions.
+
+## Implemented approach
+
+`getFilteredArticles()` deliberately creates display copies so it can attach
+feed context without mutating stored feed items. The original bulk actions
+mutated those copies, then saved and rendered the unchanged stored state.
+
+The shared read-state action now resolves every filtered display item through
+the existing `findBackingArticleForDisplayItem()` helper before changing its
+`read` value. Both Read and Unread call that shared action and retain their
+existing notices, persistence, and render scheduling.
+
+## Validation
+
+- Added jsdom regression coverage for read and unread transitions against the
+  stored backing items, including unread-filter scoping. Existing header tests
+  cover forwarding from both hamburger and desktop controls.
+- Passed `npm.cmd run test:unit -- test_files/unit/views/dashboard-filter-persistence.test.ts`.
+- Passed changed-file ESLint with zero warnings and `npm.cmd run check:platform`.
+- Passed `npm.cmd run build`, including compliance checks, full lint,
+  TypeScript checking, and production bundling.
+- Manual desktop, narrow/mobile, and reopen checks remain recommended before
+  release because this environment does not run an Obsidian client.
+
+## Non-goals and risks
+
+- Do not redefine **Mark all** to affect articles outside the current filtered
+  dashboard view.
+- Do not add a new persistence mechanism or alter article storage formats.
+- Main risk: a render may recreate controls while a state mutation is pending;
+  tests must assert observable article state and post-render results rather
+  than only callback invocation.
+- Risk classification: **medium**. This changes dashboard UI state and its
+  persisted backing items, but reuses an existing backing-item lookup and
+  introduces no storage-format or lifecycle changes.
+
+## Triage
+
+This is an open bug with no milestone. Recommend evaluating it for `vNext` as
+release-required because it repairs a visible, core article-state control;
+leave the milestone and release requirement blank until maintainers confirm
+release scope.

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -536,14 +536,7 @@ export class RssDashboardView extends ItemView {
    * @internal
    */
   public actionMarkAllAsRead(): void {
-    const articles = this.getFilteredArticles();
-    let count = 0;
-    articles.forEach((item) => {
-      if (!item.read) {
-        item.read = true;
-        count++;
-      }
-    });
+    const count = this.updateFilteredArticleReadStatus(true);
 
     if (count > 0) {
       void this.plugin.saveSettings();
@@ -552,6 +545,37 @@ export class RssDashboardView extends ItemView {
     } else {
       new Notice("No unread items in current view");
     }
+  }
+
+  /**
+   * Action: Mark all filtered articles as unread.
+   * @internal
+   */
+  public actionMarkAllAsUnread(): void {
+    const count = this.updateFilteredArticleReadStatus(false);
+
+    if (count > 0) {
+      void this.plugin.saveSettings();
+      this.scheduleRender();
+      new Notice(`Marked ${count} items as unread`);
+    } else {
+      new Notice("No read items in current view");
+    }
+  }
+
+  private updateFilteredArticleReadStatus(read: boolean): number {
+    let count = 0;
+
+    this.getFilteredArticles().forEach((article) => {
+      const backingArticle = this.findBackingArticleForDisplayItem(article);
+      if (backingArticle && backingArticle.read !== read) {
+        backingArticle.read = read;
+        article.read = read;
+        count++;
+      }
+    });
+
+    return count;
   }
 
   /**
@@ -1008,22 +1032,7 @@ export class RssDashboardView extends ItemView {
             this.actionMarkAllAsRead();
           },
           onMarkAllAsUnread: () => {
-            const articles = this.getFilteredArticles();
-            let count = 0;
-            articles.forEach((item) => {
-              if (item.read) {
-                item.read = false;
-                count++;
-              }
-            });
-
-            if (count > 0) {
-              void this.plugin.saveSettings();
-              this.scheduleRender();
-              new Notice(`Marked ${count} items as unread`);
-            } else {
-              new Notice("No read items in current view");
-            }
+            this.actionMarkAllAsUnread();
           },
         },
         currentPage,

--- a/test_files/unit/views/dashboard-filter-persistence.test.ts
+++ b/test_files/unit/views/dashboard-filter-persistence.test.ts
@@ -152,4 +152,50 @@ describe("Dashboard multi-filter persistence (TDD)", () => {
     expect(Array.from((view as unknown as { activeTagFilters: Set<string> }).activeTagFilters)).toEqual(["Work"]);
     expect((view as unknown as { filterLogic: "AND" | "OR" }).filterLogic).toBe("AND");
   });
+
+  it("marks the stored articles in the current view as read", async () => {
+    const { RssDashboardView } = await import("../../../src/views/dashboard-view");
+
+    const app = new App();
+    const settings = cloneSettings();
+    const unreadItem = {
+      guid: "unread-item",
+      title: "Unread item",
+      read: false,
+    };
+    const readItem = {
+      guid: "read-item",
+      title: "Read item",
+      read: true,
+    };
+    settings.feeds = [
+      {
+        ...createMockFeed("https://example.com/feed"),
+        items: [unreadItem, readItem],
+      },
+    ];
+    const plugin = {
+      settings,
+      saveSettings: vi.fn(async () => {}),
+    };
+
+    const leaf = { app } as unknown as import("obsidian").WorkspaceLeaf;
+    const view = new RssDashboardView(leaf, plugin as never);
+    (view as unknown as { scheduleRender: () => void }).scheduleRender = vi.fn();
+    (view as unknown as { activeStatusFilters: Set<string> }).activeStatusFilters = new Set(["unread"]);
+
+    view.actionMarkAllAsRead();
+
+    expect(settings.feeds[0].items[0].read).toBe(true);
+    expect(settings.feeds[0].items[1].read).toBe(true);
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+
+    (view as unknown as { activeStatusFilters: Set<string> }).activeStatusFilters.clear();
+
+    view.actionMarkAllAsUnread();
+
+    expect(settings.feeds[0].items[0].read).toBe(false);
+    expect(settings.feeds[0].items[1].read).toBe(false);
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary

- persist read-state changes to the stored backing articles rather than filtered display copies
- route Read and Unread through one shared dashboard action
- add filtered-state regression coverage and archive the Issue #185 plan

Closes #185

## Validation

- `npm.cmd run test:unit -- test_files/unit/views/dashboard-filter-persistence.test.ts test_files/unit/components/article-header-menu.test.ts test_files/unit/components/article-header.test.ts`
- changed-file ESLint with zero warnings
- `npm.cmd run check:platform`
- `npm.cmd run build`
- manual Obsidian inspection passed