### PR TITLE
fix: show mobile global refresh stop button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed `document.createElement` occurrences by migrating to Obsidian `createEl`, `createDiv`, and `createSpan` DOM helpers.
 - Fixed community plugin audit warning for unknown CSS type selector `mjx-container` by using class and attribute selectors (`[class*="mjx-container"]`, `.MathJax`) in `src/styles/articles.css` and `src/styles/reader.css`.
 - Fixed unnecessary type assertion in `src/utils/settings-loader.ts` by updating `migrateDefaultFilterToDashboardMultiFilters` to accept typed `DisplaySettings`.
+- Fixed the global-refresh Stop button not appearing on mobile/tablet: the sidebar modal's polling loop now applies the `stop` class and swaps the icon to `square-stop` when the refresh is cancellable, matching the desktop sidebar behaviour.
 
 ## 2.6.0 - August 24, 2026
 

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -1051,7 +1051,7 @@ export class Sidebar {
     setIcon(feedIcon, isCancellable ? "square-stop" : "refresh-cw");
     feedIcon.addEventListener("click", (e) => {
       e.stopPropagation();
-      if (isCancellable) {
+      if (this.plugin.isGlobalRefreshCancellable) {
         this.plugin.cancelGlobalRefresh();
         return;
       }

--- a/src/modals/mobile-navigation-modal.ts
+++ b/src/modals/mobile-navigation-modal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Platform } from "obsidian";
+import { App, Modal, Platform, setIcon } from "obsidian";
 import {
   Sidebar,
   SidebarOptions,
@@ -133,15 +133,23 @@ export class MobileNavigationModal extends Modal {
   }
 
   private updateAllFeedsIconRefreshState(): void {
+    const isCancellable = this.plugin.isGlobalRefreshCancellable ?? false;
     const isRefreshActive =
-      this.plugin.isMultiFeedRefreshActive ||
-      (this.plugin.activeRefreshState?.size ?? 0) > 0;
+      !isCancellable &&
+      (this.plugin.isMultiFeedRefreshActive ||
+        (this.plugin.activeRefreshState?.size ?? 0) > 0);
 
     const allFeedsIcon = this.sidebarWrapper.querySelector(
       ".rss-dashboard-all-feeds-icon",
     );
-    if (allFeedsIcon) {
+    if (allFeedsIcon instanceof HTMLElement) {
+      allFeedsIcon.classList.toggle("stop", isCancellable);
       allFeedsIcon.classList.toggle("refreshing", isRefreshActive);
+      allFeedsIcon.setAttribute(
+        "title",
+        isCancellable ? "Stop refresh" : "Refresh all feeds",
+      );
+      setIcon(allFeedsIcon, isCancellable ? "square-stop" : "refresh-cw");
     }
   }
 

--- a/test_files/unit/modals/mobile-navigation-modal.test.ts
+++ b/test_files/unit/modals/mobile-navigation-modal.test.ts
@@ -137,5 +137,118 @@ describe("MobileNavigationModal", () => {
 
     expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
   });
-});
 
+  describe("updateAllFeedsIconRefreshState polling (stop button)", () => {
+    async function openModalWithPlugin(
+      pluginOverrides: Record<string, unknown>,
+    ) {
+      const { MobileNavigationModal } = await import(
+        "../../../src/modals/mobile-navigation-modal"
+      );
+      const app = obsidian.App.createMock();
+      const plugin = {
+        saveSettings: vi.fn(async () => {}),
+        isGlobalRefreshCancellable: false,
+        isMultiFeedRefreshActive: false,
+        activeRefreshState: new Map(),
+        ...pluginOverrides,
+      };
+      const settings = {
+        sidebarWidth: 280,
+      } as unknown as RssDashboardSettings;
+      const callbacks = {
+        onFolderClick: vi.fn(),
+        onFeedClick: vi.fn(),
+        onTagToggle: vi.fn(),
+        onClearTags: vi.fn(),
+        onTagFilterModeChange: vi.fn(),
+      } as unknown as SidebarCallbacks;
+      const modal = new MobileNavigationModal(
+        app as unknown as obsidian.App,
+        plugin as unknown as RssDashboardPlugin,
+        settings,
+        { selectedTags: [] } as unknown as SidebarOptions,
+        callbacks,
+      );
+      modal.open();
+      return { modal, plugin };
+    }
+
+    function injectIcon(modal: { contentEl: HTMLElement }): HTMLButtonElement {
+      // Simulate the icon element that Sidebar.render() creates
+      const icon = createEl("button");
+      icon.className = "rss-dashboard-all-feeds-icon";
+      icon.setAttribute("title", "Refresh all feeds");
+      modal.contentEl
+        .querySelector(".rss-dashboard-sidebar-container")!
+        .appendChild(icon);
+      return icon;
+    }
+
+    it("leaves the icon idle when no refresh is active", async () => {
+      vi.useFakeTimers();
+      let modal: Awaited<ReturnType<typeof openModalWithPlugin>>["modal"] | undefined;
+      try {
+        ({ modal } = await openModalWithPlugin({
+          isGlobalRefreshCancellable: false,
+          isMultiFeedRefreshActive: false,
+        }));
+        const icon = injectIcon(modal);
+
+        vi.advanceTimersByTime(110);
+
+        expect(icon.classList.contains("stop")).toBe(false);
+        expect(icon.classList.contains("refreshing")).toBe(false);
+        expect(icon.getAttribute("title")).toBe("Refresh all feeds");
+        expect(icon.dataset.icon).toBe("refresh-cw");
+      } finally {
+        modal?.close();
+        vi.useRealTimers();
+      }
+    });
+
+    it("adds refreshing class but not stop when a plain multi-feed refresh is active", async () => {
+      vi.useFakeTimers();
+      let modal: Awaited<ReturnType<typeof openModalWithPlugin>>["modal"] | undefined;
+      try {
+        ({ modal } = await openModalWithPlugin({
+          isGlobalRefreshCancellable: false,
+          isMultiFeedRefreshActive: true,
+        }));
+        const icon = injectIcon(modal);
+
+        vi.advanceTimersByTime(110);
+
+        expect(icon.classList.contains("refreshing")).toBe(true);
+        expect(icon.classList.contains("stop")).toBe(false);
+        expect(icon.getAttribute("title")).toBe("Refresh all feeds");
+        expect(icon.dataset.icon).toBe("refresh-cw");
+      } finally {
+        modal?.close();
+        vi.useRealTimers();
+      }
+    });
+
+    it("shows stop state (not refreshing) when global refresh is cancellable", async () => {
+      vi.useFakeTimers();
+      let modal: Awaited<ReturnType<typeof openModalWithPlugin>>["modal"] | undefined;
+      try {
+        ({ modal } = await openModalWithPlugin({
+          isGlobalRefreshCancellable: true,
+          isMultiFeedRefreshActive: true,
+        }));
+        const icon = injectIcon(modal);
+
+        vi.advanceTimersByTime(110);
+
+        expect(icon.classList.contains("stop")).toBe(true);
+        expect(icon.classList.contains("refreshing")).toBe(false);
+        expect(icon.getAttribute("title")).toBe("Stop refresh");
+        expect(icon.dataset.icon).toBe("square-stop");
+      } finally {
+        modal?.close();
+        vi.useRealTimers();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- show a square-stop icon and Stop refresh tooltip in the mobile sidebar while global refresh is cancellable
- keep the standard refresh indicator for non-cancellable refreshes
- add regression coverage for idle, refreshing, and cancellable states

## Validation
- npm.cmd run test:unit -- test_files/unit/modals/mobile-navigation-modal.test.ts
- npm.cmd run build