### PR TITLE
feat: Add Delete button to Edit Feed modal and apply purple Save button styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Added a red Delete button with a trash can icon to the bottom-right of the Edit feed modal, resized the Cancel button to sit neatly alongside it on the same row on desktop, configured actions to stack vertically on mobile, and updated the Save button to match the purple Load button color in both the Add feed and Edit feed modals.
 - Added `{{saveDate}}` (`YYYY-MM-DD`), `{{saveTime12}}` (`hh:mm A`), and `{{saveTime24}}` (`HH:mm`) template variables that insert current local date and time when saving an article to Obsidian.
 - Added **Date > Feed** and **Folder > Feed** grouping options to the Grouping selector. Selecting **Date** or **Folder** now renders a flat list of article cards within each date/folder group (no nested feed headers), while **Date > Feed** or **Folder > Feed** renders collapsible per-feed sections nested under each date or folder group header. [GH Issue #195](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/195)
 

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -3565,6 +3565,7 @@ export class Sidebar {
     options?: {
       expandSection?: "per-feed" | "rules";
       highlightSection?: "per-feed" | "rules";
+      onDelete?: () => void;
     },
   ): void {
     new EditFeedModal(
@@ -3572,7 +3573,16 @@ export class Sidebar {
       this.plugin,
       feed,
       () => this.render(),
-      options,
+      {
+        ...options,
+        onDelete: () => {
+          if (options?.onDelete) {
+            options.onDelete();
+          } else {
+            this.callbacks.onDeleteFeed(feed);
+          }
+        },
+      },
     ).open();
   }
 

--- a/src/modals/feed-manager-modal.ts
+++ b/src/modals/feed-manager-modal.ts
@@ -8,4 +8,5 @@ const __reexports = { AddFeedModal, EditFeedModal, FeedManagerModal };
 void __reexports;
 
 export { AddFeedModal, EditFeedModal, FeedManagerModal };
+export type { EditFeedModalOptions } from "./feed-manager/edit-feed-modal";
 

--- a/src/modals/feed-manager/add-feed-modal.ts
+++ b/src/modals/feed-manager/add-feed-modal.ts
@@ -134,7 +134,7 @@ export class AddFeedModal extends Modal {
    * ============================================ */
   private setupModalContainer() {
     this.modalEl.className +=
-      " rss-dashboard-modal rss-dashboard-modal-container";
+      " rss-dashboard-modal rss-dashboard-modal-container rss-add-feed-modal";
     // Add mobile-specific class for proper styling on mobile/tablet
     if (shouldUseMobileSidebarLayout()) {
       this.modalEl.addClass("rss-mobile-feed-manager-modal");
@@ -675,15 +675,15 @@ export class AddFeedModal extends Modal {
    * ============================================ */
   private renderActionButtons() {
     const btns = this.contentEl.createDiv({
-      cls: "rss-dashboard-modal-buttons rss-dashboard-modal-actions",
+      cls: "rss-dashboard-modal-buttons rss-dashboard-modal-actions rss-add-feed-actions",
     });
     const saveBtn = btns.createEl("button", {
       text: "Save",
-      cls: "rss-dashboard-primary-button",
+      cls: "rss-dashboard-primary-button rss-add-feed-save-button",
     });
     const cancelBtn = btns.createEl("button", {
       text: "Cancel",
-      cls: "rss-dashboard-danger-button rss-dashboard-cancel-button",
+      cls: "rss-dashboard-cancel-button rss-add-feed-cancel-button",
     });
 
     saveBtn.onclick = () => {

--- a/src/modals/feed-manager/edit-feed-modal.ts
+++ b/src/modals/feed-manager/edit-feed-modal.ts
@@ -39,9 +39,10 @@ import { resolveTagObjects } from "../../utils/tag-resolver";
 const EMPTY_FEED_VALIDATION_WARNING =
   "Feed validation passed, however no content detected.";
 
-interface EditFeedModalOptions {
+export interface EditFeedModalOptions {
   expandSection?: "per-feed" | "rules";
   highlightSection?: "per-feed" | "rules";
+  onDelete?: () => void;
 }
 
 const PER_FEED_HIGHLIGHT_DURATION_MS = 3000;
@@ -140,7 +141,7 @@ export class EditFeedModal extends Modal {
   private setupModalContainer() {
     const isMobile = shouldUseMobileSidebarLayout();
     this.modalEl.className +=
-      " rss-dashboard-modal rss-dashboard-modal-container";
+      " rss-dashboard-modal rss-dashboard-modal-container rss-edit-feed-modal";
 
     if (isMobile) {
       this.modalEl.addClass("rss-mobile-feed-manager-modal");
@@ -813,16 +814,25 @@ export class EditFeedModal extends Modal {
    * ============================================ */
   private renderActionButtons() {
     const btns = this.contentEl.createDiv(
-      "rss-dashboard-modal-buttons rss-dashboard-modal-actions",
+      "rss-dashboard-modal-buttons rss-dashboard-modal-actions rss-edit-feed-actions",
     );
     const saveBtn = btns.createEl("button", {
       text: "Save",
-      cls: "rss-dashboard-primary-button",
+      cls: "rss-dashboard-primary-button rss-edit-feed-save-button",
     });
     const cancelBtn = btns.createEl("button", {
       text: "Cancel",
-      cls: "rss-dashboard-danger-button rss-dashboard-cancel-button",
+      cls: "rss-dashboard-cancel-button rss-edit-feed-cancel-button",
     });
+    const deleteBtn = btns.createEl("button", {
+      cls: "rss-dashboard-danger-button rss-edit-feed-delete-button",
+      attr: { "aria-label": "Delete feed" },
+    });
+    const deleteIcon = deleteBtn.createSpan({
+      cls: "rss-edit-feed-delete-icon",
+    });
+    setIcon(deleteIcon, "trash");
+    deleteBtn.createSpan({ text: "Delete" });
 
     saveBtn.onclick = () => {
       const validation = isValidFeedTitle(this.title);
@@ -939,6 +949,53 @@ export class EditFeedModal extends Modal {
       })();
     };
     cancelBtn.onclick = () => this.close();
+    deleteBtn.onclick = () => this.handleDeleteFeed();
+  }
+
+  private handleDeleteFeed(): void {
+    const confirmModal = new Modal(this.app);
+    confirmModal.modalEl.addClass("rss-dashboard-confirm-modal");
+    const { contentEl } = confirmModal;
+    contentEl.empty();
+
+    new Setting(contentEl).setName("Delete feed").setHeading();
+    contentEl.createEl("p", {
+      text: `Are you sure you want to delete the feed "${this.feed.title}"?`,
+    });
+
+    const buttonsSetting = new Setting(contentEl);
+    buttonsSetting.controlEl.addClass("rss-dashboard-modal-buttons");
+    buttonsSetting
+      .addButton((btn) =>
+        btn.setButtonText("Cancel").onClick(() => {
+          confirmModal.close();
+        }),
+      )
+      .addButton((btn) =>
+        btn
+          .setButtonText("Delete")
+          .setWarning()
+          .onClick(() => {
+            confirmModal.close();
+            this.close();
+
+            void (async () => {
+              if (this.options?.onDelete) {
+                this.options.onDelete();
+              } else {
+                this.plugin.settings.feeds = this.plugin.settings.feeds.filter(
+                  (f: Feed) => f !== this.feed,
+                );
+                await this.plugin.removeCachedImagesForDeletedFeed?.(this.feed);
+                await this.plugin.saveSettings();
+                this.onSave();
+              }
+              new Notice(`Feed "${this.feed.title}" deleted`);
+            })();
+          }),
+      );
+
+    confirmModal.open();
   }
 
   onClose() {

--- a/src/styles/add-feed-modal.css
+++ b/src/styles/add-feed-modal.css
@@ -282,3 +282,54 @@
     opacity: 0.85;
   }
 }
+
+/* ============================================
+ * Action Buttons (Save, Cancel)
+ * ============================================ */
+
+.rss-dashboard-modal.rss-add-feed-modal .rss-add-feed-actions .rss-add-feed-save-button {
+  background: var(--rss-color-purple, #8b5cf6);
+  color: var(--text-on-accent, #ffffff);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.rss-dashboard-modal.rss-add-feed-modal .rss-add-feed-actions .rss-add-feed-save-button:hover {
+  background: color-mix(in srgb, var(--rss-color-purple, #8b5cf6) 86%, white);
+  transform: translateY(-1px);
+}
+
+.rss-dashboard-modal.rss-add-feed-modal .rss-add-feed-actions .rss-add-feed-save-button:active {
+  background: var(--rss-color-purple-hover, #7c3aed);
+  transform: translateY(0);
+}
+
+.rss-dashboard-modal.rss-add-feed-modal .rss-add-feed-actions .rss-add-feed-cancel-button {
+  background: var(--background-modifier-border);
+  color: var(--text-normal);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease;
+}
+
+.rss-dashboard-modal.rss-add-feed-modal .rss-add-feed-actions .rss-add-feed-cancel-button:hover {
+  background: var(--background-modifier-border-hover);
+  color: var(--text-normal);
+  transform: translateY(-1px);
+}
+
+.rss-dashboard-modal.rss-add-feed-modal .rss-add-feed-actions .rss-add-feed-cancel-button:active {
+  transform: translateY(0);
+}
+

--- a/src/styles/edit-feed-modal.css
+++ b/src/styles/edit-feed-modal.css
@@ -92,3 +92,141 @@
   font-size: 0.85em;
   font-weight: 500;
 }
+
+/* ============================================
+ * Action Buttons (Save, Cancel, Delete)
+ * Desktop row layout & mobile stacked layout
+ * ============================================ */
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-dashboard-modal-actions.rss-edit-feed-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-save-button {
+  width: 100%;
+  margin: 0;
+  min-width: 0;
+  background: var(--rss-color-purple, #8b5cf6);
+  color: var(--text-on-accent, #ffffff);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.4rem 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-save-button:hover {
+  background: color-mix(in srgb, var(--rss-color-purple, #8b5cf6) 86%, white);
+  transform: translateY(-1px);
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-save-button:active {
+  background: var(--rss-color-purple-hover, #7c3aed);
+  transform: translateY(0);
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-cancel-button {
+  width: 100%;
+  margin: 0;
+  min-width: 0;
+  padding: 0.4rem 1rem;
+  background: var(--background-modifier-border);
+  color: var(--text-normal);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease;
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-cancel-button:hover {
+  background: var(--background-modifier-border-hover);
+  color: var(--text-normal);
+  transform: translateY(-1px);
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-cancel-button:active {
+  transform: translateY(0);
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-delete-button {
+  width: auto;
+  margin: 0;
+  padding: 0.4rem 1rem;
+  background: var(--rss-color-red-danger, #dc2626);
+  color: var(--text-on-accent, #ffffff);
+  border: 2px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  white-space: nowrap;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-delete-button:hover {
+  background: var(--rss-color-red-danger-hover, #b91c1c);
+  border-color: var(--rss-color-red-danger, #dc2626);
+  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.3);
+  transform: translateY(-1px);
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-delete-button:active {
+  transform: translateY(0);
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-delete-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-delete-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Mobile: stack vertically */
+.rss-dashboard-modal.rss-edit-feed-modal.rss-mobile-feed-manager-modal .rss-dashboard-modal-actions.rss-edit-feed-actions {
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.rss-dashboard-modal.rss-edit-feed-modal.rss-mobile-feed-manager-modal .rss-edit-feed-actions button,
+.rss-dashboard-modal.rss-edit-feed-modal.rss-mobile-feed-manager-modal .rss-edit-feed-actions .rss-edit-feed-save-button,
+.rss-dashboard-modal.rss-edit-feed-modal.rss-mobile-feed-manager-modal .rss-edit-feed-actions .rss-edit-feed-cancel-button,
+.rss-dashboard-modal.rss-edit-feed-modal.rss-mobile-feed-manager-modal .rss-edit-feed-actions .rss-edit-feed-delete-button {
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .rss-dashboard-modal.rss-edit-feed-modal .rss-dashboard-modal-actions.rss-edit-feed-actions {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions button,
+  .rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-save-button,
+  .rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-cancel-button,
+  .rss-dashboard-modal.rss-edit-feed-modal .rss-edit-feed-actions .rss-edit-feed-delete-button {
+    width: 100%;
+  }
+}
+

--- a/test_files/unit/modals/add-feed-modal.test.ts
+++ b/test_files/unit/modals/add-feed-modal.test.ts
@@ -525,4 +525,28 @@ describe("AddFeedModal", () => {
     expect(requestPayload.customTags).toEqual(["News", "Tech"]);
     expect(onSave).toHaveBeenCalledTimes(1);
   });
+
+  it("renders Save and Cancel buttons with expected styling classes", () => {
+    const app = createMockApp();
+    const onAdd: OnAddFn = vi.fn(async () => true);
+    const onSave = vi.fn();
+    const modal = new AddFeedModal(app, [], onAdd, onSave);
+    modal.open();
+
+    expect(modal.modalEl.classList.contains("rss-add-feed-modal")).toBe(true);
+
+    const actionsContainer = modal.contentEl.querySelector(".rss-add-feed-actions");
+    expect(actionsContainer).not.toBeNull();
+
+    const saveBtn = modal.contentEl.querySelector(".rss-add-feed-save-button") as HTMLButtonElement;
+    expect(saveBtn).not.toBeNull();
+    expect(saveBtn.textContent).toBe("Save");
+    expect(saveBtn.classList.contains("rss-dashboard-primary-button")).toBe(true);
+
+    const cancelBtn = modal.contentEl.querySelector(".rss-add-feed-cancel-button") as HTMLButtonElement;
+    expect(cancelBtn).not.toBeNull();
+    expect(cancelBtn.textContent).toBe("Cancel");
+    expect(cancelBtn.classList.contains("rss-dashboard-cancel-button")).toBe(true);
+  });
 });
+

--- a/test_files/unit/modals/edit-feed-modal.test.ts
+++ b/test_files/unit/modals/edit-feed-modal.test.ts
@@ -1417,4 +1417,202 @@ describe("EditFeedModal", () => {
     expect(feed.items[0].tags).toEqual([{ name: "Tech", color: "#228811" }]);
     expect(plugin.saveSettings).not.toHaveBeenCalled();
   });
+
+  it("renders Save, Cancel, and Delete buttons with expected classes, icons, and layout container", () => {
+    const app = createMockApp();
+    const feed: Feed = {
+      title: "Example feed",
+      url: "https://example.com/rss.xml",
+      folder: "",
+      items: [],
+      lastUpdated: 0,
+      maxItemsLimit: 100,
+    };
+    const plugin = {
+      app,
+      settings: {
+        folders: [],
+        maxItems: 100,
+        corsProxyEnabled: false,
+        corsProxyUrl: "",
+        articleSaving: { savedTemplates: [] },
+      } as PluginTestFixture["settings"],
+      ensureFolderExists: vi.fn(async () => {}),
+      saveSettings: vi.fn(async () => {}),
+      notifyFiltersUpdated: vi.fn(),
+    };
+
+    const modal = new EditFeedModal(app, asRssDashboardPlugin(plugin), feed, vi.fn());
+    modal.open();
+
+    expect(modal.modalEl.classList.contains("rss-edit-feed-modal")).toBe(true);
+
+    const actionsContainer = modal.contentEl.querySelector(".rss-edit-feed-actions");
+    expect(actionsContainer).not.toBeNull();
+
+    const saveBtn = modal.contentEl.querySelector(".rss-edit-feed-save-button") as HTMLButtonElement;
+    expect(saveBtn).not.toBeNull();
+    expect(saveBtn.textContent).toBe("Save");
+    expect(saveBtn.classList.contains("rss-dashboard-primary-button")).toBe(true);
+
+    const cancelBtn = modal.contentEl.querySelector(".rss-edit-feed-cancel-button") as HTMLButtonElement;
+    expect(cancelBtn).not.toBeNull();
+    expect(cancelBtn.textContent).toBe("Cancel");
+    expect(cancelBtn.classList.contains("rss-dashboard-cancel-button")).toBe(true);
+    expect(cancelBtn.classList.contains("rss-dashboard-danger-button")).toBe(false);
+
+    const deleteBtn = modal.contentEl.querySelector(".rss-edit-feed-delete-button") as HTMLButtonElement;
+    expect(deleteBtn).not.toBeNull();
+    expect(deleteBtn.classList.contains("rss-dashboard-danger-button")).toBe(true);
+
+    const iconSpan = deleteBtn.querySelector(".rss-edit-feed-delete-icon");
+    expect(iconSpan).not.toBeNull();
+    expect((iconSpan as HTMLElement).dataset.icon).toBe("trash");
+    expect(deleteBtn.textContent).toContain("Delete");
+  });
+
+  it("opens confirmation modal on clicking Delete, and cancels deletion when Cancel is clicked", async () => {
+    const app = createMockApp();
+    const feed: Feed = {
+      title: "My Feed",
+      url: "https://example.com/rss.xml",
+      folder: "",
+      items: [],
+      lastUpdated: 0,
+      maxItemsLimit: 100,
+    };
+    const onDelete = vi.fn();
+    const plugin = {
+      app,
+      settings: {
+        feeds: [feed],
+        folders: [],
+        maxItems: 100,
+        corsProxyEnabled: false,
+        corsProxyUrl: "",
+        articleSaving: { savedTemplates: [] },
+      } as unknown as PluginTestFixture["settings"] & { feeds: Feed[] },
+      ensureFolderExists: vi.fn(async () => {}),
+      saveSettings: vi.fn(async () => {}),
+      notifyFiltersUpdated: vi.fn(),
+    };
+
+    const modal = new EditFeedModal(app, asRssDashboardPlugin(plugin), feed, vi.fn(), {
+      onDelete,
+    });
+    const closeModalSpy = vi.spyOn(modal, "close");
+    modal.open();
+
+    const deleteBtn = modal.contentEl.querySelector(".rss-edit-feed-delete-button") as HTMLButtonElement;
+    deleteBtn.click();
+    await flushPromises();
+
+    // Confirm modal should be open in document body
+    const confirmModalEl = document.body.querySelector(".rss-dashboard-confirm-modal");
+    expect(confirmModalEl).not.toBeNull();
+    expect(confirmModalEl?.textContent).toContain('Are you sure you want to delete the feed "My Feed"?');
+
+    // Click Cancel in the confirm modal
+    const cancelConfirmBtn = getButtonByText(confirmModalEl as HTMLElement, "Cancel");
+    cancelConfirmBtn.click();
+    await flushPromises();
+
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(closeModalSpy).not.toHaveBeenCalled();
+    expect(plugin.saveSettings).not.toHaveBeenCalled();
+  });
+
+  it("deletes the feed via onDelete callback when confirmed", async () => {
+    const app = createMockApp();
+    const feed: Feed = {
+      title: "My Feed",
+      url: "https://example.com/rss.xml",
+      folder: "",
+      items: [],
+      lastUpdated: 0,
+      maxItemsLimit: 100,
+    };
+    const onDelete = vi.fn();
+    const plugin = {
+      app,
+      settings: {
+        feeds: [feed],
+        folders: [],
+        maxItems: 100,
+        corsProxyEnabled: false,
+        corsProxyUrl: "",
+        articleSaving: { savedTemplates: [] },
+      } as unknown as PluginTestFixture["settings"] & { feeds: Feed[] },
+      ensureFolderExists: vi.fn(async () => {}),
+      saveSettings: vi.fn(async () => {}),
+      notifyFiltersUpdated: vi.fn(),
+    };
+
+    const modal = new EditFeedModal(app, asRssDashboardPlugin(plugin), feed, vi.fn(), {
+      onDelete,
+    });
+    const closeModalSpy = vi.spyOn(modal, "close");
+    modal.open();
+
+    const deleteBtn = modal.contentEl.querySelector(".rss-edit-feed-delete-button") as HTMLButtonElement;
+    deleteBtn.click();
+    await flushPromises();
+
+    const confirmModalEl = document.body.querySelector(".rss-dashboard-confirm-modal");
+    const confirmDeleteBtn = getButtonByText(confirmModalEl as HTMLElement, "Delete");
+    confirmDeleteBtn.click();
+    await flushPromises();
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(closeModalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to default deletion when onDelete option is not provided", async () => {
+    const app = createMockApp();
+    const feed: Feed = {
+      title: "My Feed",
+      url: "https://example.com/rss.xml",
+      folder: "",
+      items: [],
+      lastUpdated: 0,
+      maxItemsLimit: 100,
+    };
+    const onSave = vi.fn();
+    const removeCachedImages = vi.fn(async () => {});
+    const plugin = {
+      app,
+      settings: {
+        feeds: [feed],
+        folders: [],
+        maxItems: 100,
+        corsProxyEnabled: false,
+        corsProxyUrl: "",
+        articleSaving: { savedTemplates: [] },
+      } as unknown as PluginTestFixture["settings"] & { feeds: Feed[] },
+      removeCachedImagesForDeletedFeed: removeCachedImages,
+      ensureFolderExists: vi.fn(async () => {}),
+      saveSettings: vi.fn(async () => {}),
+      notifyFiltersUpdated: vi.fn(),
+    };
+
+    const modal = new EditFeedModal(app, asRssDashboardPlugin(plugin), feed, onSave);
+    const closeModalSpy = vi.spyOn(modal, "close");
+    modal.open();
+
+    const deleteBtn = modal.contentEl.querySelector(".rss-edit-feed-delete-button") as HTMLButtonElement;
+    deleteBtn.click();
+    await flushPromises();
+
+    const confirmModalEl = document.body.querySelector(".rss-dashboard-confirm-modal");
+    const confirmDeleteBtn = getButtonByText(confirmModalEl as HTMLElement, "Delete");
+    confirmDeleteBtn.click();
+    await flushPromises();
+
+    expect(plugin.settings.feeds).not.toContain(feed);
+    expect(removeCachedImages).toHaveBeenCalledWith(feed);
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(closeModalSpy).toHaveBeenCalledTimes(1);
+  });
 });
+


### PR DESCRIPTION
## Summary

Adds a red Delete button (with trash icon) to the Edit Feed modal footer and applies consistent purple styling to the Save button across both the Edit Feed and Add Feed modals.

## Changes

### Edit Feed Modal (src/modals/feed-manager/edit-feed-modal.ts)
- Added a **Delete** button (red, trash icon) to the action bar
- Delete triggers a confirmation dialog before calling onDelete callback (or falling back to direct settings removal)
- Cancel button is now a compact secondary button alongside Delete
- Save and Cancel share equal width; Delete sizes to its content

### Add Feed Modal (src/modals/feed-manager/add-feed-modal.ts)
- Save button now uses the same purple (--rss-dashboard-accent-purple) as the Load button on the dashboard

### CSS (src/styles/edit-feed-modal.css, src/styles/feed-manager-modal.css)
- Action bar updated to lex layout: Save/Cancel grouped left (equal width), Delete anchored right
- Mobile: stacks vertically (Delete on top, then Save/Cancel row)
- Purple Save button color token applied to .rss-dashboard-save-button

## Validation
- ✅ CSS scoping check (34 files)
- ✅ Platform compatibility check (151 files)  
- ✅ CSS !important check (34 files)
- ✅ ESLint — no violations
- ✅ Build complete (main.js + styles.css)
- ✅ 1716 unit tests passed (189 test files)