### PR TITLE
fix: batch move multi-selected feeds via drag-and-drop and context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 - Added `{{saveDate}}` (`YYYY-MM-DD`), `{{saveTime12}}` (`hh:mm A`), and `{{saveTime24}}` (`HH:mm`) template variables that insert current local date and time when saving an article to Obsidian.
 - Added **Date > Feed** and **Folder > Feed** grouping options to the Grouping selector. Selecting **Date** or **Folder** now renders a flat list of article cards within each date/folder group (no nested feed headers), while **Date > Feed** or **Folder > Feed** renders collapsible per-feed sections nested under each date or folder group header. [GH Issue #195](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/195)
+- Added **Move selection to folder** to the sidebar multi-selection context menu, allowing users to relocate multiple selected feeds and folders directly to a chosen folder or root without drag-and-drop.
 
 ### Fixes
 
+- Fixed an issue where dragging and dropping multiple selected feeds in the sidebar only moved a single feed; dragging now moves all selected feeds together, preserving their relative order across folder headers, folder lists, root, and feed reordering drops.
 - Fixed Feed View grouping so **Grouping: Disabled** renders a flat article sequence and **Grouping: Feed** displays one collapsible header per feed. [GH Issue #195](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/195)
 - Removed Nitter integration, automatic X/Twitter-to-Nitter RSS feed conversion, and obsolete Twitter/X settings and fallbacks following the permanent shutdown of Nitter instances and the project repository on August 24, 2026 due to cease and desist demands from X Corp. (https://github.com/zedeus/nitter). Attempting to add an `x.com`, `twitter.com`, or any `nitter.*` URL now shows a clear error message explaining the situation and suggesting third-party RSS bridges (e.g. RSSHub) as an alternative.
 - Fixed `document.createElement` occurrences by migrating to Obsidian `createEl`, `createDiv`, and `createSpan` DOM helpers.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,3 +23,14 @@ _Avoid_: Skipping, episode navigation
 **Window navigation**:
 Moving playlist browsing by one playlist-window length in playlist order. It is presented as Previous/Next rather than chronological Older/Newer.
 _Avoid_: Pagination, chronological navigation
+
+## Sidebar feed management
+
+**Sidebar selection**:
+The active group of feeds and folders selected in the sidebar via click, modifier-click, or range-selection.
+_Avoid_: Active feeds, multi-selection target, highlighted list
+
+**Batch move**:
+Relocating multiple selected feeds or folders together into a target destination folder or root in a single operation.
+_Avoid_: Bulk drag, mass reorder, multi-drop
+

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -39,8 +39,8 @@ import {
   getFaviconUrl,
 } from "../utils/favicon-utils";
 import {
-  moveFeedAndInsert,
-  moveFeedToFolderAppend,
+  moveFeedsAndInsert,
+  moveFeedsToFolderAppend,
   moveFolder,
   setFolderFeedSortCustom,
   setFolderSortCustom,
@@ -741,6 +741,12 @@ export class Sidebar {
       e.preventDefault();
       feedFoldersSection.classList.remove("drag-over");
       if (e.dataTransfer) {
+        const { feedUrls, folderPaths } = this.extractDragPayload(e.dataTransfer);
+        if (feedUrls.length > 0 || folderPaths.length > 1) {
+          this.batchMoveFeedsAndFoldersToFolder("", feedUrls, folderPaths);
+          return;
+        }
+
         const draggedFolderPath = e.dataTransfer.getData("folder-path");
         if (draggedFolderPath) {
           const result = moveFolder(this.settings, {
@@ -788,22 +794,7 @@ export class Sidebar {
 
         const feedUrl = e.dataTransfer.getData("feed-url");
         if (feedUrl) {
-          const feed = this.settings.feeds.find((f) => f.url === feedUrl);
-          if (!feed || !feed.folder) return;
-
-          const oldFolderPath = feed.folder;
-          const result = moveFeedToFolderAppend(this.settings, {
-            draggedUrl: feedUrl,
-            destinationFolderPath: "",
-          });
-          if (!result.ok) {
-            new Notice(result.error || "Unable to move feed.");
-            return;
-          }
-
-          const oldFolder = this.findFolderByPath(oldFolderPath);
-          if (oldFolder) oldFolder.modifiedAt = Date.now();
-          void this.plugin.saveSettings().then(() => this.render());
+          this.batchMoveFeedsAndFoldersToFolder("", [feedUrl], []);
         }
       }
     });
@@ -1339,7 +1330,23 @@ export class Sidebar {
 
     folderHeader.addEventListener("dragstart", (e) => {
       if (!e.dataTransfer) return;
+      let folderPaths: string[] = [];
+      const selectedFolders = this.options.selectedFolders || [];
+      if (selectedFolders.length > 0) {
+        if (!selectedFolders.includes(fullPath)) {
+          selectedFolders.push(fullPath);
+        }
+        folderPaths = [...selectedFolders];
+      } else {
+        folderPaths = [fullPath];
+      }
       e.dataTransfer.setData("folder-path", fullPath);
+      e.dataTransfer.setData("folder-paths", JSON.stringify(folderPaths));
+
+      const selectedFeeds = this.options.selectedFeeds || [];
+      if (selectedFeeds.length > 0) {
+        e.dataTransfer.setData("feed-urls", JSON.stringify(selectedFeeds));
+      }
       e.dataTransfer.effectAllowed = "move";
     });
 
@@ -1364,8 +1371,12 @@ export class Sidebar {
       e.preventDefault();
       e.stopPropagation(); // Prevent event from bubbling up to root section
 
-      const isFolderDrag = e.dataTransfer.types.includes("folder-path");
-      const isFeedDrag = e.dataTransfer.types.includes("feed-url");
+      const isFolderDrag =
+        e.dataTransfer.types.includes("folder-path") ||
+        e.dataTransfer.types.includes("folder-paths");
+      const isFeedDrag =
+        e.dataTransfer.types.includes("feed-url") ||
+        e.dataTransfer.types.includes("feed-urls");
       if (!isFolderDrag && !isFeedDrag) return;
 
       clearFolderHeaderDropClasses();
@@ -1396,6 +1407,17 @@ export class Sidebar {
       clearFolderHeaderDropClasses();
 
       if (!e.dataTransfer) return;
+
+      const { feedUrls, folderPaths } = this.extractDragPayload(e.dataTransfer);
+      if (feedUrls.length > 0) {
+        this.batchMoveFeedsAndFoldersToFolder(fullPath, feedUrls, folderPaths);
+        return;
+      }
+
+      if (folderPaths.length > 1) {
+        this.batchMoveFeedsAndFoldersToFolder(fullPath, [], folderPaths);
+        return;
+      }
 
       const draggedFolderPath = e.dataTransfer.getData("folder-path");
       if (draggedFolderPath) {
@@ -1442,31 +1464,6 @@ export class Sidebar {
         void this.plugin.saveSettings().then(() => this.render());
         return;
       }
-
-      const feedUrl = e.dataTransfer.getData("feed-url");
-      if (!feedUrl) return;
-
-      const feed = this.settings.feeds.find((f) => f.url === feedUrl);
-      if (!feed || (feed.folder || "") === fullPath) return;
-
-      const oldFolderPath = feed.folder || "";
-      const op = moveFeedToFolderAppend(this.settings, {
-        draggedUrl: feedUrl,
-        destinationFolderPath: fullPath,
-      });
-      if (!op.ok) {
-        new Notice(op.error || "Unable to move feed.");
-        return;
-      }
-
-      if (oldFolderPath) {
-        const oldFolder = this.findFolderByPath(oldFolderPath);
-        if (oldFolder) oldFolder.modifiedAt = Date.now();
-      }
-      const newFolder = this.findFolderByPath(fullPath);
-      if (newFolder) newFolder.modifiedAt = Date.now();
-
-      void this.plugin.saveSettings().then(() => this.render());
     });
 
     // Create the container for both subfolders and feeds
@@ -1491,29 +1488,9 @@ export class Sidebar {
       e.stopPropagation();
       folderFeedsList.classList.remove("drag-over");
       if (e.dataTransfer) {
-        const feedUrl = e.dataTransfer.getData("feed-url");
-        if (feedUrl) {
-          const feed = this.settings.feeds.find((f) => f.url === feedUrl);
-          if (!feed || (feed.folder || "") === fullPath) return;
-
-          const oldFolderPath = feed.folder || "";
-          const result = moveFeedToFolderAppend(this.settings, {
-            draggedUrl: feedUrl,
-            destinationFolderPath: fullPath,
-          });
-          if (!result.ok) {
-            new Notice(result.error || "Unable to move feed.");
-            return;
-          }
-
-          if (oldFolderPath) {
-            const oldFolder = this.findFolderByPath(oldFolderPath);
-            if (oldFolder) oldFolder.modifiedAt = Date.now();
-          }
-          const newFolder = this.findFolderByPath(fullPath);
-          if (newFolder) newFolder.modifiedAt = Date.now();
-
-          void this.plugin.saveSettings().then(() => this.render());
+        const { feedUrls, folderPaths } = this.extractDragPayload(e.dataTransfer);
+        if (feedUrls.length > 0 || folderPaths.length > 0) {
+          this.batchMoveFeedsAndFoldersToFolder(fullPath, feedUrls, folderPaths);
         }
       }
     });
@@ -1763,7 +1740,24 @@ export class Sidebar {
 
     feedEl.addEventListener("dragstart", (e) => {
       if (!e.dataTransfer) return;
+      let feedUrls: string[] = [];
+      const selectedFeeds = this.options.selectedFeeds || [];
+      if (selectedFeeds.length > 0) {
+        if (!selectedFeeds.includes(feed.url)) {
+          selectedFeeds.push(feed.url);
+        }
+        feedUrls = [...selectedFeeds];
+      } else {
+        feedUrls = [feed.url];
+      }
+
       e.dataTransfer.setData("feed-url", feed.url);
+      e.dataTransfer.setData("feed-urls", JSON.stringify(feedUrls));
+
+      const selectedFolders = this.options.selectedFolders || [];
+      if (selectedFolders.length > 0) {
+        e.dataTransfer.setData("folder-paths", JSON.stringify(selectedFolders));
+      }
       e.dataTransfer.effectAllowed = "move";
     });
 
@@ -1775,10 +1769,17 @@ export class Sidebar {
     feedEl.addEventListener("dragover", (e) => {
       if (!e.dataTransfer) return;
       // Ignore folder drags; those are handled on folder headers/root.
-      if (e.dataTransfer.types.includes("folder-path")) return;
+      if (
+        e.dataTransfer.types.includes("folder-path") ||
+        e.dataTransfer.types.includes("folder-paths")
+      ) {
+        return;
+      }
 
-      const draggedUrl = e.dataTransfer.getData("feed-url");
-      if (!draggedUrl) return;
+      const hasFeedDrag =
+        e.dataTransfer.types.includes("feed-url") ||
+        e.dataTransfer.types.includes("feed-urls");
+      if (!hasFeedDrag) return;
 
       e.preventDefault();
       e.stopPropagation();
@@ -1796,25 +1797,34 @@ export class Sidebar {
 
     feedEl.addEventListener("drop", (e) => {
       if (!e.dataTransfer) return;
-      if (e.dataTransfer.types.includes("folder-path")) return;
+      if (
+        e.dataTransfer.types.includes("folder-path") ||
+        e.dataTransfer.types.includes("folder-paths")
+      ) {
+        return;
+      }
 
-      const draggedUrl = e.dataTransfer.getData("feed-url");
-      if (!draggedUrl || draggedUrl === feed.url) return;
+      const { feedUrls } = this.extractDragPayload(e.dataTransfer);
+      if (feedUrls.length === 0) return;
+      if (feedUrls.includes(feed.url)) return; // No-op drop if target is one of the dragged feeds
 
       e.preventDefault();
       e.stopPropagation();
       clearFeedDropClasses();
 
-      const dragged = this.settings.feeds.find((f) => f.url === draggedUrl);
-      const oldFolderPath = dragged?.folder ?? "";
+      const oldFolderPaths = new Set<string>();
+      for (const u of feedUrls) {
+        const f = this.settings.feeds.find((item) => item.url === u);
+        if (f?.folder) oldFolderPaths.add(f.folder);
+      }
       const destinationFolderPath = feed.folder ?? "";
 
       const rect = feedEl.getBoundingClientRect();
       const before = e.clientY < rect.top + rect.height / 2;
       const placement = before ? "before" : "after";
 
-      const result = moveFeedAndInsert(this.settings, {
-        draggedUrl,
+      const result = moveFeedsAndInsert(this.settings, {
+        draggedUrls: feedUrls,
         targetUrl: feed.url,
         placement,
       });
@@ -1824,14 +1834,19 @@ export class Sidebar {
         return;
       }
 
-      if (oldFolderPath && oldFolderPath !== destinationFolderPath) {
-        const oldFolder = this.findFolderByPath(oldFolderPath);
-        if (oldFolder) oldFolder.modifiedAt = Date.now();
+      for (const oldPath of oldFolderPaths) {
+        if (oldPath !== destinationFolderPath) {
+          const oldFolder = this.findFolderByPath(oldPath);
+          if (oldFolder) oldFolder.modifiedAt = Date.now();
+        }
       }
-      if (destinationFolderPath && oldFolderPath !== destinationFolderPath) {
+      if (destinationFolderPath) {
         const newFolder = this.findFolderByPath(destinationFolderPath);
         if (newFolder) newFolder.modifiedAt = Date.now();
       }
+
+      this.options.selectedFeeds = [];
+      this.options.selectedFolders = [];
 
       void this.plugin.saveSettings().then(() => this.render());
     });
@@ -1914,6 +1929,16 @@ export class Sidebar {
         .setIcon("circle")
         .onClick(() => {
           this.markSelectionReadStatus(false);
+        });
+    });
+    menu.addItem((item: MenuItem) => {
+      item
+        .setTitle("Move selection to folder")
+        .setIcon("folder-open")
+        .onClick((evt) => {
+          if (evt instanceof MouseEvent) {
+            this.showMoveSelectionToFolderMenu(evt);
+          }
         });
     });
     menu.addSeparator();
@@ -2002,6 +2027,220 @@ export class Sidebar {
       this.options.selectedFeeds = [];
       this.render();
     });
+  }
+
+  private extractDragPayload(dataTransfer: DataTransfer | null): {
+    feedUrls: string[];
+    folderPaths: string[];
+  } {
+    if (!dataTransfer) return { feedUrls: [], folderPaths: [] };
+
+    let feedUrls: string[] = [];
+    const feedUrlsRaw = dataTransfer.getData("feed-urls");
+    if (feedUrlsRaw) {
+      try {
+        const parsed: unknown = JSON.parse(feedUrlsRaw);
+        if (
+          Array.isArray(parsed) &&
+          parsed.every((item): item is string => typeof item === "string")
+        ) {
+          feedUrls = parsed;
+        }
+      } catch {}
+    }
+    if (feedUrls.length === 0) {
+      const singleFeed = dataTransfer.getData("feed-url");
+      if (singleFeed) feedUrls = [singleFeed];
+    }
+
+    let folderPaths: string[] = [];
+    const folderPathsRaw = dataTransfer.getData("folder-paths");
+    if (folderPathsRaw) {
+      try {
+        const parsed: unknown = JSON.parse(folderPathsRaw);
+        if (
+          Array.isArray(parsed) &&
+          parsed.every((item): item is string => typeof item === "string")
+        ) {
+          folderPaths = parsed;
+        }
+      } catch {}
+    }
+    if (folderPaths.length === 0) {
+      const singleFolder = dataTransfer.getData("folder-path");
+      if (singleFolder) folderPaths = [singleFolder];
+    }
+
+    return { feedUrls, folderPaths };
+  }
+
+  private batchMoveFeedsAndFoldersToFolder(
+    destinationFolderPath: string,
+    feedUrls: string[],
+    folderPaths: string[] = [],
+  ): void {
+    let movedFeedsCount = 0;
+    let movedFoldersCount = 0;
+    let skippedFoldersCount = 0;
+
+    // 1. Move folders first (if any)
+    for (const folderPath of folderPaths) {
+      if (
+        destinationFolderPath === folderPath ||
+        destinationFolderPath.startsWith(`${folderPath}/`)
+      ) {
+        skippedFoldersCount++;
+        continue;
+      }
+
+      const placement = destinationFolderPath ? "nest" : "rootAppend";
+      const result = moveFolder(this.settings, {
+        draggedPath: folderPath,
+        targetPath: destinationFolderPath,
+        placement,
+      });
+
+      if (result.ok) {
+        movedFoldersCount++;
+      } else {
+        skippedFoldersCount++;
+      }
+    }
+
+    // 2. Move feeds
+    const feedsToMove = feedUrls.filter((url) => {
+      const feed = this.settings.feeds.find((f) => f.url === url);
+      return feed && (feed.folder || "") !== destinationFolderPath;
+    });
+
+    if (feedsToMove.length > 0) {
+      const oldFolderPaths = new Set<string>();
+      for (const url of feedsToMove) {
+        const f = this.settings.feeds.find((item) => item.url === url);
+        if (f?.folder) oldFolderPaths.add(f.folder);
+      }
+
+      const result = moveFeedsToFolderAppend(this.settings, {
+        draggedUrls: feedsToMove,
+        destinationFolderPath,
+      });
+
+      if (result.ok) {
+        movedFeedsCount = feedsToMove.length;
+        for (const oldPath of oldFolderPaths) {
+          const oldFolder = this.findFolderByPath(oldPath);
+          if (oldFolder) oldFolder.modifiedAt = Date.now();
+        }
+      } else {
+        new Notice(result.error || "Unable to move feeds.");
+      }
+    }
+
+    if (destinationFolderPath) {
+      const destFolder = this.findFolderByPath(destinationFolderPath);
+      if (destFolder) destFolder.modifiedAt = Date.now();
+    }
+
+    this.clearFolderPathCache();
+
+    if (skippedFoldersCount > 0) {
+      new Notice("Skipped moving folder into itself or its subfolder.");
+    }
+
+    const totalMoved = movedFeedsCount + movedFoldersCount;
+    if (totalMoved > 0) {
+      const destLabel = destinationFolderPath
+        ? `"${destinationFolderPath}"`
+        : "root";
+      const parts: string[] = [];
+      if (movedFeedsCount > 0) {
+        parts.push(`${movedFeedsCount} feed${movedFeedsCount === 1 ? "" : "s"}`);
+      }
+      if (movedFoldersCount > 0) {
+        parts.push(
+          `${movedFoldersCount} folder${movedFoldersCount === 1 ? "" : "s"}`,
+        );
+      }
+      new Notice(`Moved ${parts.join(" and ")} to ${destLabel}`);
+    }
+
+    this.options.selectedFeeds = [];
+    this.options.selectedFolders = [];
+
+    void this.plugin.saveSettings().then(() => this.render());
+  }
+
+  private showMoveSelectionToFolderMenu(event: MouseEvent): void {
+    const menu = new Menu();
+
+    const selectedFeeds = [...(this.options.selectedFeeds || [])];
+    const selectedFolders = [...(this.options.selectedFolders || [])];
+
+    // Add option to move to root (no folder)
+    menu.addItem((item: MenuItem) => {
+      item
+        .setTitle("Root (no folder)")
+        .setIcon("folder")
+        .onClick(() => {
+          this.batchMoveFeedsAndFoldersToFolder(
+            "",
+            selectedFeeds,
+            selectedFolders,
+          );
+        });
+    });
+
+    menu.addSeparator();
+
+    // Add all available folders
+    const allFolders = this.getCachedFolderPaths();
+    if (allFolders.length > 0) {
+      allFolders.sort((a, b) => a.localeCompare(b));
+
+      allFolders.forEach((folderPath) => {
+        menu.addItem((item: MenuItem) => {
+          item
+            .setTitle(folderPath)
+            .setIcon("folder")
+            .onClick(() => {
+              this.batchMoveFeedsAndFoldersToFolder(
+                folderPath,
+                selectedFeeds,
+                selectedFolders,
+              );
+            });
+        });
+      });
+    }
+
+    menu.addSeparator();
+    menu.addItem((item: MenuItem) => {
+      item
+        .setTitle("Create new folder...")
+        .setIcon("folder-plus")
+        .onClick(() => {
+          this.showFolderNameModal({
+            title: "Create new folder",
+            existingNames: this.settings.folders.map((f) => f.name),
+            onSubmit: (folderName) => {
+              void (async () => {
+                await this.addTopLevelFolder(folderName);
+                this.batchMoveFeedsAndFoldersToFolder(
+                  folderName,
+                  selectedFeeds,
+                  selectedFolders,
+                );
+              })();
+            },
+          });
+        });
+    });
+
+    if (typeof menu.showAtMouseEvent === "function") {
+      menu.showAtMouseEvent(event);
+    } else {
+      menu.showAtPosition({ x: event.clientX, y: event.clientY });
+    }
   }
 
   private showFolderContextMenu(

--- a/src/services/sidebar-ordering-controller.ts
+++ b/src/services/sidebar-ordering-controller.ts
@@ -30,6 +30,52 @@ export function setFolderSortCustom(settings: RssDashboardSettings): void {
   settings.folderSortOrder = { by: "custom", ascending: prev?.ascending ?? true };
 }
 
+export function moveFeedsAndInsert(
+  settings: RssDashboardSettings,
+  opts: {
+    draggedUrls: string[];
+    targetUrl: string;
+    placement: FeedInsertPlacement;
+  },
+): OperationResult {
+  const { draggedUrls, targetUrl, placement } = opts;
+  if (!draggedUrls || draggedUrls.length === 0 || !targetUrl) {
+    return { ok: false, error: "Missing feed urls." };
+  }
+  if (draggedUrls.includes(targetUrl)) {
+    return { ok: false, error: "No-op drop." };
+  }
+
+  const target = settings.feeds.find((f) => f.url === targetUrl);
+  if (!target) return { ok: false, error: "Target feed not found." };
+
+  const destinationFolderPath = normalizeFolderPath(target.folder);
+  const draggedUrlSet = new Set(draggedUrls);
+  const draggedFeeds = settings.feeds.filter((f) => draggedUrlSet.has(f.url));
+  if (draggedFeeds.length === 0) {
+    return { ok: false, error: "Dragged feeds not found." };
+  }
+
+  for (const feed of draggedFeeds) {
+    feed.folder = destinationFolderPath;
+  }
+
+  const withoutDragged = settings.feeds.filter((f) => !draggedUrlSet.has(f.url));
+  const targetIndex = withoutDragged.findIndex((f) => f.url === targetUrl);
+  if (targetIndex === -1) {
+    return { ok: false, error: "Target feed not found after removal." };
+  }
+
+  const insertIndex = placement === "before" ? targetIndex : targetIndex + 1;
+  const next = [...withoutDragged];
+  next.splice(insertIndex, 0, ...draggedFeeds);
+  settings.feeds = next;
+
+  setFolderFeedSortCustom(settings, destinationFolderPath);
+
+  return { ok: true };
+}
+
 export function moveFeedAndInsert(
   settings: RssDashboardSettings,
   opts: {
@@ -38,30 +84,52 @@ export function moveFeedAndInsert(
     placement: FeedInsertPlacement;
   },
 ): OperationResult {
-  const draggedUrl = opts.draggedUrl;
-  const targetUrl = opts.targetUrl;
-  if (!draggedUrl || !targetUrl) return { ok: false, error: "Missing feed urls." };
-  if (draggedUrl === targetUrl) return { ok: false, error: "No-op drop." };
-
-  const dragged = settings.feeds.find((f) => f.url === draggedUrl);
-  const target = settings.feeds.find((f) => f.url === targetUrl);
+  if (!opts.draggedUrl) return { ok: false, error: "Missing feed urls." };
+  const dragged = settings.feeds.find((f) => f.url === opts.draggedUrl);
   if (!dragged) return { ok: false, error: "Dragged feed not found." };
-  if (!target) return { ok: false, error: "Target feed not found." };
+  return moveFeedsAndInsert(settings, {
+    draggedUrls: [opts.draggedUrl],
+    targetUrl: opts.targetUrl,
+    placement: opts.placement,
+  });
+}
 
-  const destinationFolderPath = normalizeFolderPath(target.folder);
-  dragged.folder = destinationFolderPath;
+export function moveFeedsToFolderAppend(
+  settings: RssDashboardSettings,
+  opts: {
+    draggedUrls: string[];
+    destinationFolderPath: string;
+  },
+): OperationResult {
+  const { draggedUrls } = opts;
+  if (!draggedUrls || draggedUrls.length === 0) {
+    return { ok: false, error: "Dragged feeds not found." };
+  }
 
-  const withoutDragged = settings.feeds.filter((f) => f.url !== draggedUrl);
-  const targetIndex = withoutDragged.findIndex((f) => f.url === targetUrl);
-  if (targetIndex === -1) return { ok: false, error: "Target feed not found after removal." };
+  const destinationFolderPath = normalizeFolderPath(opts.destinationFolderPath);
+  const draggedUrlSet = new Set(draggedUrls);
+  const draggedFeeds = settings.feeds.filter((f) => draggedUrlSet.has(f.url));
+  if (draggedFeeds.length === 0) {
+    return { ok: false, error: "Dragged feeds not found." };
+  }
 
-  const insertIndex = opts.placement === "before" ? targetIndex : targetIndex + 1;
+  for (const feed of draggedFeeds) {
+    feed.folder = destinationFolderPath;
+  }
+
+  const withoutDragged = settings.feeds.filter((f) => !draggedUrlSet.has(f.url));
+  let lastIndexInDestination = -1;
+  for (let i = 0; i < withoutDragged.length; i++) {
+    const folderPath = normalizeFolderPath(withoutDragged[i].folder);
+    if (folderPath === destinationFolderPath) lastIndexInDestination = i;
+  }
+
+  const insertIndex = lastIndexInDestination + 1;
   const next = [...withoutDragged];
-  next.splice(insertIndex, 0, dragged);
+  next.splice(insertIndex, 0, ...draggedFeeds);
   settings.feeds = next;
 
   setFolderFeedSortCustom(settings, destinationFolderPath);
-
   return { ok: true };
 }
 
@@ -72,29 +140,13 @@ export function moveFeedToFolderAppend(
     destinationFolderPath: string;
   },
 ): OperationResult {
-  const draggedUrl = opts.draggedUrl;
-  const destinationFolderPath = normalizeFolderPath(opts.destinationFolderPath);
-  if (!draggedUrl) return { ok: false, error: "Missing dragged feed url." };
-
-  const dragged = settings.feeds.find((f) => f.url === draggedUrl);
+  if (!opts.draggedUrl) return { ok: false, error: "Missing dragged feed url." };
+  const dragged = settings.feeds.find((f) => f.url === opts.draggedUrl);
   if (!dragged) return { ok: false, error: "Dragged feed not found." };
-
-  dragged.folder = destinationFolderPath;
-
-  const withoutDragged = settings.feeds.filter((f) => f.url !== draggedUrl);
-  let lastIndexInDestination = -1;
-  for (let i = 0; i < withoutDragged.length; i++) {
-    const folderPath = normalizeFolderPath(withoutDragged[i].folder);
-    if (folderPath === destinationFolderPath) lastIndexInDestination = i;
-  }
-
-  const insertIndex = lastIndexInDestination + 1;
-  const next = [...withoutDragged];
-  next.splice(insertIndex, 0, dragged);
-  settings.feeds = next;
-
-  setFolderFeedSortCustom(settings, destinationFolderPath);
-  return { ok: true };
+  return moveFeedsToFolderAppend(settings, {
+    draggedUrls: [opts.draggedUrl],
+    destinationFolderPath: opts.destinationFolderPath,
+  });
 }
 
 function splitPath(path: string): string[] {

--- a/test_files/unit/components/sidebar-batch-move.test.ts
+++ b/test_files/unit/components/sidebar-batch-move.test.ts
@@ -1,0 +1,390 @@
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  type Mock,
+} from "vitest";
+import {
+  Sidebar,
+  SidebarOptions,
+  SidebarCallbacks,
+} from "../../../src/components/sidebar";
+import * as ObsidianStubs from "../../stubs/obsidian";
+import type { App } from "../../stubs/obsidian";
+import {
+  Folder,
+  type Feed,
+  type RssDashboardSettings,
+} from "../../../src/types/types";
+import { installObsidianDomPolyfills } from "../test-dom-polyfills";
+import type RssDashboardPlugin from "../../../main";
+
+installObsidianDomPolyfills();
+
+interface TestPlugin extends Partial<RssDashboardPlugin> {
+  settings: RssDashboardSettings;
+  saveSettings: Mock<() => Promise<void>>;
+}
+
+function makeFeed(title: string, url: string, folder = ""): Feed {
+  return {
+    title,
+    url,
+    folder,
+    items: [],
+    lastUpdated: 0,
+  };
+}
+
+describe("Sidebar Batch Move (TDD)", () => {
+  let app: App;
+  let container: HTMLElement;
+  let plugin: TestPlugin;
+  let settings: RssDashboardSettings;
+  let options: SidebarOptions;
+  let callbacks: SidebarCallbacks;
+  let sidebar: Sidebar;
+
+  beforeEach(() => {
+    app = ObsidianStubs.App.createMock();
+    container = createDiv();
+
+    const feeds: Feed[] = [
+      makeFeed("Feed 1", "https://feed1.com", "FolderA"),
+      makeFeed("Feed 2", "https://feed2.com", "FolderA"),
+      makeFeed("Feed 3", "https://feed3.com", "FolderB"),
+      makeFeed("Feed 4", "https://feed4.com", ""),
+    ];
+
+    const folders: Folder[] = [
+      { name: "FolderA", subfolders: [] },
+      { name: "FolderB", subfolders: [] },
+      { name: "FolderC", subfolders: [] },
+    ];
+
+    settings = {
+      feeds,
+      folders,
+      display: {
+        sidebarRowSpacing: 10,
+        sidebarRowIndentation: 20,
+        sidebarItemPaddingLeft: 2,
+        sidebarItemPaddingRight: 2,
+      },
+    } as unknown as RssDashboardSettings;
+
+    plugin = {
+      settings,
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+    };
+
+    options = {
+      currentFolder: null,
+      currentFeed: null,
+      selectedTags: [],
+      tagsCollapsed: true,
+      collapsedFolders: [],
+      selectedFolders: [],
+      selectedFeeds: ["https://feed1.com", "https://feed2.com"],
+    };
+
+    callbacks = {
+      onFolderClick: vi.fn(),
+      onFeedClick: vi.fn(),
+      onTagToggle: vi.fn(),
+      onClearTags: vi.fn(),
+      onTagFilterModeChange: vi.fn(),
+      onToggleTagsCollapse: vi.fn(),
+      onToggleFolderCollapse: vi.fn(),
+      onBatchToggleFolders: vi.fn(),
+      onAddFolder: vi.fn(),
+      onAddSubfolder: vi.fn(),
+      onAddFeed: vi.fn(),
+      onEditFeed: vi.fn(),
+      onDeleteFeed: vi.fn(),
+      onDeleteFolder: vi.fn(),
+      onRefreshFeeds: vi.fn(),
+      onRetryFailedFeeds: vi.fn(),
+      onUpdateFeed: vi.fn(),
+    };
+
+    sidebar = new Sidebar(app, container, plugin as unknown as RssDashboardPlugin, settings, options, callbacks);
+    sidebar.render();
+  });
+
+  it("dragstart on a selected feed populates feed-urls with all selected feeds", () => {
+    const feed1El = container.querySelector('[data-feed-url="https://feed1.com"]') as HTMLElement;
+    expect(feed1El).toBeTruthy();
+
+    const dataStore: Record<string, string> = {};
+    const dataTransfer = {
+      setData: vi.fn((key: string, val: string) => {
+        dataStore[key] = val;
+      }),
+      getData: vi.fn((key: string) => dataStore[key] || ""),
+      types: [] as string[],
+      effectAllowed: "none",
+    };
+
+    const dragEvent = new Event("dragstart", { bubbles: true }) as DragEvent;
+    Object.defineProperty(dragEvent, "dataTransfer", { value: dataTransfer });
+
+    feed1El.dispatchEvent(dragEvent);
+
+    expect(dataTransfer.setData).toHaveBeenCalledWith("feed-url", "https://feed1.com");
+    expect(dataTransfer.setData).toHaveBeenCalledWith(
+      "feed-urls",
+      JSON.stringify(["https://feed1.com", "https://feed2.com"]),
+    );
+  });
+
+  it("dragstart on an unselected feed with active multi-selection auto-includes that feed", () => {
+    // feed3 is not in options.selectedFeeds initially
+    const feed3El = container.querySelector('[data-feed-url="https://feed3.com"]') as HTMLElement;
+    expect(feed3El).toBeTruthy();
+
+    const dataStore: Record<string, string> = {};
+    const dataTransfer = {
+      setData: vi.fn((key: string, val: string) => {
+        dataStore[key] = val;
+      }),
+      getData: vi.fn((key: string) => dataStore[key] || ""),
+      types: [] as string[],
+      effectAllowed: "none",
+    };
+
+    const dragEvent = new Event("dragstart", { bubbles: true }) as DragEvent;
+    Object.defineProperty(dragEvent, "dataTransfer", { value: dataTransfer });
+
+    feed3El.dispatchEvent(dragEvent);
+
+    expect(dataTransfer.setData).toHaveBeenCalledWith(
+      "feed-urls",
+      JSON.stringify(["https://feed1.com", "https://feed2.com", "https://feed3.com"]),
+    );
+  });
+
+  it("dropping multiple feeds onto a folder header moves all of them into that folder", () => {
+    const folderCEl = container.querySelector('[data-folder-path="FolderC"]') as HTMLElement;
+    expect(folderCEl).toBeTruthy();
+
+    const dataTransfer = {
+      getData: vi.fn((key: string) => {
+        if (key === "feed-urls") {
+          return JSON.stringify(["https://feed1.com", "https://feed2.com"]);
+        }
+        if (key === "feed-url") return "https://feed1.com";
+        return "";
+      }),
+      types: ["feed-urls", "feed-url"],
+    };
+
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(dropEvent, "dataTransfer", { value: dataTransfer });
+    Object.defineProperty(dropEvent, "clientY", { value: 100 });
+
+    folderCEl.dispatchEvent(dropEvent);
+
+    expect(settings.feeds.find((f) => f.url === "https://feed1.com")?.folder).toBe("FolderC");
+    expect(settings.feeds.find((f) => f.url === "https://feed2.com")?.folder).toBe("FolderC");
+    expect(plugin.saveSettings).toHaveBeenCalled();
+  });
+
+  it("dropping multiple feeds onto root moves all of them to root", () => {
+    const rootSection = container.querySelector(".rss-dashboard-feed-folders-section") as HTMLElement;
+    expect(rootSection).toBeTruthy();
+
+    const dataTransfer = {
+      getData: vi.fn((key: string) => {
+        if (key === "feed-urls") {
+          return JSON.stringify(["https://feed1.com", "https://feed2.com"]);
+        }
+        if (key === "feed-url") return "https://feed1.com";
+        return "";
+      }),
+      types: ["feed-urls", "feed-url"],
+    };
+
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(dropEvent, "dataTransfer", { value: dataTransfer });
+
+    rootSection.dispatchEvent(dropEvent);
+
+    expect(settings.feeds.find((f) => f.url === "https://feed1.com")?.folder).toBe("");
+    expect(settings.feeds.find((f) => f.url === "https://feed2.com")?.folder).toBe("");
+    expect(plugin.saveSettings).toHaveBeenCalled();
+  });
+
+  it("dropping multiple feeds onto another feed reorders them adjacent to that feed", () => {
+    const feed3El = container.querySelector('[data-feed-url="https://feed3.com"]') as HTMLElement;
+    expect(feed3El).toBeTruthy();
+    // feed3 is in FolderB
+
+    const dataTransfer = {
+      getData: vi.fn((key: string) => {
+        if (key === "feed-urls") {
+          return JSON.stringify(["https://feed1.com", "https://feed2.com"]);
+        }
+        if (key === "feed-url") return "https://feed1.com";
+        return "";
+      }),
+      types: ["feed-urls", "feed-url"],
+    };
+
+    // Mock getBoundingClientRect
+    feed3El.getBoundingClientRect = () => ({
+      top: 100,
+      bottom: 150,
+      height: 50,
+      left: 0,
+      right: 200,
+      width: 200,
+      x: 0,
+      y: 100,
+      toJSON: () => {},
+    });
+
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(dropEvent, "dataTransfer", { value: dataTransfer });
+    // clientY = 110 (< 125, so 'before')
+    Object.defineProperty(dropEvent, "clientY", { value: 110 });
+
+    feed3El.dispatchEvent(dropEvent);
+
+    expect(settings.feeds.find((f) => f.url === "https://feed1.com")?.folder).toBe("FolderB");
+    expect(settings.feeds.find((f) => f.url === "https://feed2.com")?.folder).toBe("FolderB");
+    const urls = settings.feeds.map((f) => f.url);
+    const idx1 = urls.indexOf("https://feed1.com");
+    const idx2 = urls.indexOf("https://feed2.com");
+    const idx3 = urls.indexOf("https://feed3.com");
+    expect(idx1).toBeLessThan(idx3);
+    expect(idx2).toBeLessThan(idx3);
+    expect(idx1 + 1).toBe(idx2);
+  });
+
+  it("dropping multiple feeds onto one of the dragged feeds is a no-op", () => {
+    const feed1El = container.querySelector('[data-feed-url="https://feed1.com"]') as HTMLElement;
+    expect(feed1El).toBeTruthy();
+
+    const dataTransfer = {
+      getData: vi.fn((key: string) => {
+        if (key === "feed-urls") {
+          return JSON.stringify(["https://feed1.com", "https://feed2.com"]);
+        }
+        if (key === "feed-url") return "https://feed1.com";
+        return "";
+      }),
+      types: ["feed-urls", "feed-url"],
+    };
+
+    const initialOrder = settings.feeds.map((f) => f.url);
+
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(dropEvent, "dataTransfer", { value: dataTransfer });
+    Object.defineProperty(dropEvent, "clientY", { value: 110 });
+
+    feed1El.dispatchEvent(dropEvent);
+
+    // Order and folders must be untouched
+    expect(settings.feeds.map((f) => f.url)).toEqual(initialOrder);
+  });
+
+  it("context menu on multi-selected feed includes 'Move selection to folder'", () => {
+    const feed1El = container.querySelector('[data-feed-url="https://feed1.com"]') as HTMLElement;
+    expect(feed1El).toBeTruthy();
+
+    const contextMenuEvent = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 50,
+      clientY: 50,
+    });
+
+    feed1El.dispatchEvent(contextMenuEvent);
+
+    const moveItem = ObsidianStubs.Menu.lastItems.find((item) =>
+      item.title.toLowerCase().includes("move selection to folder"),
+    );
+    expect(moveItem).toBeTruthy();
+  });
+
+  it("clicking 'Move selection to folder' submenu item moves selection to chosen folder", () => {
+    const feed1El = container.querySelector('[data-feed-url="https://feed1.com"]') as HTMLElement;
+    expect(feed1El).toBeTruthy();
+
+    const contextMenuEvent = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 50,
+      clientY: 50,
+    });
+
+    feed1El.dispatchEvent(contextMenuEvent);
+
+    const moveItem = ObsidianStubs.Menu.lastItems.find((item) =>
+      item.title.toLowerCase().includes("move selection to folder"),
+    );
+    expect(moveItem).toBeTruthy();
+
+    // Trigger opening the submenu
+    moveItem?.trigger();
+
+    // Now Menu.lastItems has the submenu items: Root, FolderA, FolderB, FolderC, Create new folder
+    const folderCItem = ObsidianStubs.Menu.lastItems.find((item) => item.title === "FolderC");
+    expect(folderCItem).toBeTruthy();
+
+    // Trigger moving to FolderC
+    folderCItem?.trigger();
+
+    expect(settings.feeds.find((f) => f.url === "https://feed1.com")?.folder).toBe("FolderC");
+    expect(settings.feeds.find((f) => f.url === "https://feed2.com")?.folder).toBe("FolderC");
+    expect(plugin.saveSettings).toHaveBeenCalled();
+  });
+
+  it("handles mixed move of folders and feeds, reparenting folders into target", () => {
+    // Select feed1 and FolderA, drop onto FolderC
+    const folderCEl = container.querySelector('[data-folder-path="FolderC"]') as HTMLElement;
+    expect(folderCEl).toBeTruthy();
+
+    const dataTransfer = {
+      getData: vi.fn((key: string) => {
+        if (key === "feed-urls") {
+          return JSON.stringify(["https://feed1.com"]);
+        }
+        if (key === "folder-paths") {
+          return JSON.stringify(["FolderB"]);
+        }
+        return "";
+      }),
+      types: ["feed-urls", "folder-paths"],
+    };
+
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(dropEvent, "dataTransfer", { value: dataTransfer });
+    Object.defineProperty(dropEvent, "clientY", { value: 100 });
+
+    folderCEl.dispatchEvent(dropEvent);
+
+    expect(settings.feeds.find((f) => f.url === "https://feed1.com")?.folder).toBe("FolderC");
+    const folderC = settings.folders.find((f) => f.name === "FolderC");
+    expect(folderC?.subfolders.some((sub) => sub.name === "FolderB")).toBe(true);
+  });
+
+  it("skips circular folder nesting on mixed move but still moves feeds", () => {
+    // Add subfolder to FolderA
+    const folderA = settings.folders.find((f) => f.name === "FolderA");
+    folderA?.subfolders.push({ name: "SubA", subfolders: [] });
+
+    // Call batchMoveFeedsAndFoldersToFolder directly to test circular nesting protection
+    (sidebar as unknown as {
+      batchMoveFeedsAndFoldersToFolder: (dest: string, feeds: string[], folders: string[]) => void;
+    }).batchMoveFeedsAndFoldersToFolder("FolderA/SubA", ["https://feed1.com"], ["FolderA"]);
+
+    // feed1 moved to FolderA/SubA
+    expect(settings.feeds.find((f) => f.url === "https://feed1.com")?.folder).toBe("FolderA/SubA");
+    // FolderA was NOT nested into itself/descendant
+    expect(settings.folders.some((f) => f.name === "FolderA")).toBe(true);
+  });
+});

--- a/test_files/unit/services/sidebar-ordering-controller.test.ts
+++ b/test_files/unit/services/sidebar-ordering-controller.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   moveFeedAndInsert,
+  moveFeedsAndInsert,
   moveFeedToFolderAppend,
+  moveFeedsToFolderAppend,
   moveFolder,
   setFolderFeedSortCustom,
   setFolderSortCustom,
@@ -157,6 +159,148 @@ describe("moveFeedToFolderAppend", () => {
     expect(settings.folderFeedSortOrders?.["Home"]?.by).toBe("custom");
   });
 });
+
+describe("moveFeedsToFolderAppend", () => {
+  it("rejects when no dragged urls match existing feeds", () => {
+    const settings = cloneSettings();
+    settings.feeds = [makeFeed("A", "a", "Work")];
+
+    expect(
+      moveFeedsToFolderAppend(settings, {
+        draggedUrls: ["nonexistent1", "nonexistent2"],
+        destinationFolderPath: "Work",
+      }),
+    ).toEqual({ ok: false, error: "Dragged feeds not found." });
+
+    expect(
+      moveFeedsToFolderAppend(settings, {
+        draggedUrls: [],
+        destinationFolderPath: "Work",
+      }),
+    ).toEqual({ ok: false, error: "Dragged feeds not found." });
+  });
+
+  it("moves multiple feeds to destination folder preserving their relative order and appends to existing feeds", () => {
+    const settings = cloneSettings();
+    settings.feeds = [
+      makeFeed("A", "a", "Source1"),
+      makeFeed("Target1", "t1", "Dest"),
+      makeFeed("B", "b", "Source2"),
+      makeFeed("Target2", "t2", "Dest"),
+      makeFeed("C", "c", "Source1"),
+      makeFeed("Other", "o", "Other"),
+    ];
+
+    // Move 'a', 'b', 'c' to 'Dest'
+    const result = moveFeedsToFolderAppend(settings, {
+      draggedUrls: ["a", "b", "c"],
+      destinationFolderPath: "Dest",
+    });
+
+    expect(result.ok).toBe(true);
+    // Relative order of a, b, c is preserved, appended after target feeds in Dest
+    expect(settings.feeds.map((f) => f.url)).toEqual(["t1", "t2", "a", "b", "c", "o"]);
+    expect(settings.feeds.filter((f) => ["a", "b", "c"].includes(f.url)).map((f) => f.folder)).toEqual([
+      "Dest",
+      "Dest",
+      "Dest",
+    ]);
+    expect(settings.folderFeedSortOrders?.["Dest"]?.by).toBe("custom");
+  });
+
+  it("moves multiple feeds to root preserving relative order", () => {
+    const settings = cloneSettings();
+    settings.feeds = [
+      makeFeed("Root1", "r1", ""),
+      makeFeed("A", "a", "Work"),
+      makeFeed("B", "b", "Personal"),
+    ];
+
+    const result = moveFeedsToFolderAppend(settings, {
+      draggedUrls: ["a", "b"],
+      destinationFolderPath: "",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(settings.feeds.map((f) => f.url)).toEqual(["r1", "a", "b"]);
+    expect(settings.feeds.find((f) => f.url === "a")?.folder).toBe("");
+    expect(settings.feeds.find((f) => f.url === "b")?.folder).toBe("");
+    expect(settings.folderFeedSortOrders?.[""]?.by).toBe("custom");
+  });
+});
+
+describe("moveFeedsAndInsert", () => {
+  it("rejects when target feed is in dragged feeds (no-op drop)", () => {
+    const settings = cloneSettings();
+    settings.feeds = [makeFeed("A", "a", "Work"), makeFeed("B", "b", "Work")];
+
+    expect(
+      moveFeedsAndInsert(settings, {
+        draggedUrls: ["a", "b"],
+        targetUrl: "a",
+        placement: "before",
+      }),
+    ).toEqual({ ok: false, error: "No-op drop." });
+  });
+
+  it("rejects when target feed is not found", () => {
+    const settings = cloneSettings();
+    settings.feeds = [makeFeed("A", "a", "Work")];
+
+    expect(
+      moveFeedsAndInsert(settings, {
+        draggedUrls: ["a"],
+        targetUrl: "nonexistent",
+        placement: "before",
+      }),
+    ).toEqual({ ok: false, error: "Target feed not found." });
+  });
+
+  it("moves multiple feeds and inserts before target in relative order", () => {
+    const settings = cloneSettings();
+    settings.feeds = [
+      makeFeed("Feed1", "f1", "Work"),
+      makeFeed("Feed2", "f2", "Personal"),
+      makeFeed("Target", "t", "Dest"),
+      makeFeed("AfterTarget", "at", "Dest"),
+    ];
+
+    const result = moveFeedsAndInsert(settings, {
+      draggedUrls: ["f1", "f2"],
+      targetUrl: "t",
+      placement: "before",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(settings.feeds.map((f) => f.url)).toEqual(["f1", "f2", "t", "at"]);
+    expect(settings.feeds.find((f) => f.url === "f1")?.folder).toBe("Dest");
+    expect(settings.feeds.find((f) => f.url === "f2")?.folder).toBe("Dest");
+    expect(settings.folderFeedSortOrders?.["Dest"]?.by).toBe("custom");
+  });
+
+  it("moves multiple feeds and inserts after target in relative order", () => {
+    const settings = cloneSettings();
+    settings.feeds = [
+      makeFeed("Feed1", "f1", "Work"),
+      makeFeed("Target", "t", "Dest"),
+      makeFeed("AfterTarget", "at", "Dest"),
+      makeFeed("Feed2", "f2", "Personal"),
+    ];
+
+    const result = moveFeedsAndInsert(settings, {
+      draggedUrls: ["f1", "f2"],
+      targetUrl: "t",
+      placement: "after",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(settings.feeds.map((f) => f.url)).toEqual(["t", "f1", "f2", "at"]);
+    expect(settings.feeds.find((f) => f.url === "f1")?.folder).toBe("Dest");
+    expect(settings.feeds.find((f) => f.url === "f2")?.folder).toBe("Dest");
+    expect(settings.folderFeedSortOrders?.["Dest"]?.by).toBe("custom");
+  });
+});
+
 
 describe("moveFolder", () => {
   it("rejects missing required inputs and invalid nesting", () => {


### PR DESCRIPTION
## Summary

Fixes batch move for multi-selected feeds in the sidebar, covering both drag-and-drop and context menu paths.

### Changes
- **src/components/sidebar.ts**: Implemented batch move logic for multi-selected feeds during drag-and-drop; context menu 'Move to folder' action now moves all selected feeds in one operation.
- **src/services/sidebar-ordering-controller.ts**: Extended ordering controller to support batch move operations across multiple feeds atomically.

### Tests
- 	est_files/unit/components/sidebar-batch-move.test.ts (new): Full coverage of the batch drag-and-drop and context menu move flows.
- 	est_files/unit/services/sidebar-ordering-controller.test.ts: Extended with batch move scenarios.

### Validation
- Build gate passed (CSS scoping, platform compatibility, ESLint).
- Unit tests pass.