### PR TITLE
feat(reader): add full-resolution image lightbox (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `{{saveDate}}` (`YYYY-MM-DD`), `{{saveTime12}}` (`hh:mm A`), and `{{saveTime24}}` (`HH:mm`) template variables that insert current local date and time when saving an article to Obsidian.
 - Added **Date > Feed** and **Folder > Feed** grouping options to the Grouping selector. Selecting **Date** or **Folder** now renders a flat list of article cards within each date/folder group (no nested feed headers), while **Date > Feed** or **Folder > Feed** renders collapsible per-feed sections nested under each date or folder group header. [GH Issue #195](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/195)
 - Added **Move selection to folder** to the sidebar multi-selection context menu, allowing users to relocate multiple selected feeds and folders directly to a chosen folder or root without drag-and-drop.
+- Added tap-to-expand image viewing in the article Reader view, opening an interactive full-resolution Lightbox with progressive loading, 1:1 zoom toggling, pan gestures, mobile swipe-to-dismiss, and smart resolution that retrieves original unconstrained media rather than cached or downscaled thumbnails. [GH Issue #202](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/202)
 
 ### Fixes
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,3 +34,14 @@ _Avoid_: Active feeds, multi-selection target, highlighted list
 Relocating multiple selected feeds or folders together into a target destination folder or root in a single operation.
 _Avoid_: Bulk drag, mass reorder, multi-drop
 
+## Reader view
+
+**Reader lightbox**:
+The modal overlay presented over the reader view to display an article or hero image in its full resolution with pan and zoom capabilities.
+_Avoid_: Modal dialog, photo popup, preview card, photo gallery
+
+**Full-resolution image source**:
+The unconstrained original media URL extracted by resolving direct image links, selecting the highest-resolution candidate in a srcset, or stripping CDN resize transformations.
+_Avoid_: Thumbnail, cached preview, compressed version
+
+

--- a/docs/adr/0001-reader-full-resolution-lightbox.md
+++ b/docs/adr/0001-reader-full-resolution-lightbox.md
@@ -1,0 +1,18 @@
+# Full-Resolution Reader Lightbox
+
+In the article reader, users previously had no way to view unconstrained full-size images without saving the article as a markdown note. We decided to implement a custom full-window Reader Lightbox mounted to the owning document body, using tiered resolution to extract the unconstrained full-size image source rather than a downscaled thumbnail or cached asset, with instant low-res preview and smooth progressive upgrade.
+
+## Status
+
+accepted
+
+## Considered Options
+
+- **Obsidian Modal Subclass**: Standard modal window with title header and frame borders. Rejected because standard modal frames feel heavy and obstruct wide-aspect or tall photo inspection.
+- **Direct External Browser Navigation**: Opening image URLs directly in the default OS browser. Rejected because it breaks reading continuity and requires leaving Obsidian.
+- **Custom Full-Window Lightbox Overlay**: Selected for zero-friction inspection, gesture support (pinch/zoom/pan/swipe-down dismiss), and popout window compatibility.
+
+## Consequences
+
+- Reader images gain click/tap listeners that intercept image clicks while preserving access to external hyperlinks via an in-lightbox action pill.
+- Math/LaTeX formulas, UI icons, and avatars must be carefully filtered out to avoid unintended activations.

--- a/src/components/reader-lightbox.ts
+++ b/src/components/reader-lightbox.ts
@@ -1,0 +1,456 @@
+import { Notice, setIcon } from "obsidian";
+import type { ResolvedImageSource } from "../utils/full-size-image-resolver";
+
+export interface ReaderLightboxOptions {
+  source: ResolvedImageSource;
+  doc?: Document;
+}
+
+export class ReaderLightbox {
+  private readonly source: ResolvedImageSource;
+  private readonly doc: Document;
+  private readonly win: Window;
+
+  private backdropEl: HTMLElement | null = null;
+  private viewportEl: HTMLElement | null = null;
+  private stageEl: HTMLElement | null = null;
+  private fullImgEl: HTMLImageElement | null = null;
+  private previewImgEl: HTMLImageElement | null = null;
+  private spinnerEl: HTMLElement | null = null;
+
+  private scale = 1;
+  private panX = 0;
+  private panY = 0;
+  private isDragging = false;
+  private dragStartX = 0;
+  private dragStartY = 0;
+  private dragInitialPanX = 0;
+  private dragInitialPanY = 0;
+
+  // Touch tracking
+  private touchStartY = 0;
+  private touchStartX = 0;
+  private initialPinchDistance = 0;
+  private initialPinchScale = 1;
+  private isSwipingToDismiss = false;
+
+  private isClosed = false;
+  private readonly cleanups: Array<() => void> = [];
+
+  constructor(options: ReaderLightboxOptions) {
+    this.source = options.source;
+    this.doc = options.doc ?? activeDocument;
+    this.win = this.doc.defaultView ?? window;
+  }
+
+  open(): void {
+    if (this.isClosed) return;
+
+    // Create backdrop
+    this.backdropEl = this.doc.body.createDiv({
+      cls: "rss-reader-lightbox-backdrop",
+    });
+
+    this.renderToolbar();
+    this.renderViewport();
+    this.attachEventListeners();
+
+    // Trigger opening animation
+    this.win.setTimeout(() => {
+      if (!this.isClosed && this.backdropEl) {
+        this.backdropEl.addClass("is-open");
+      }
+    }, 10);
+  }
+
+  close(): void {
+    if (this.isClosed) return;
+    this.isClosed = true;
+
+    // Clean up event listeners
+    while (this.cleanups.length > 0) {
+      const cleanup = this.cleanups.pop();
+      cleanup?.();
+    }
+
+    if (this.backdropEl) {
+      this.backdropEl.removeClass("is-open");
+      const elToRemove = this.backdropEl;
+      this.win.setTimeout(() => {
+        elToRemove.remove();
+      }, 200);
+      this.backdropEl = null;
+    }
+  }
+
+  private renderToolbar(): void {
+    if (!this.backdropEl) return;
+
+    const toolbar = this.backdropEl.createDiv({
+      cls: "rss-reader-lightbox-toolbar",
+    });
+
+    // Start of toolbar (External link pill if image is a link to an article)
+    const startSection = toolbar.createDiv({
+      cls: "rss-reader-lightbox-toolbar-start",
+    });
+
+    if (this.source.externalHref) {
+      let hostname = "";
+      try {
+        hostname = new URL(this.source.externalHref).hostname.replace(/^www\./, "");
+      } catch {
+        hostname = "External link";
+      }
+
+      const linkBtn = startSection.createEl("button", {
+        cls: "rss-reader-lightbox-btn rss-reader-lightbox-external-link",
+        attr: {
+          "aria-label": `Open link to ${hostname}`,
+          type: "button",
+        },
+      });
+      setIcon(linkBtn, "external-link");
+      linkBtn.createSpan({ text: `Visit ${hostname}` });
+
+      const onLinkClick = (e: MouseEvent): void => {
+        e.stopPropagation();
+        if (this.source.externalHref) {
+          this.win.open(this.source.externalHref, "_blank", "noopener,noreferrer");
+        }
+      };
+      linkBtn.addEventListener("click", onLinkClick);
+      this.cleanups.push(() => linkBtn.removeEventListener("click", onLinkClick));
+    }
+
+    // End of toolbar (actions: Zoom Reset, Open image in browser, Close)
+    const endSection = toolbar.createDiv({
+      cls: "rss-reader-lightbox-toolbar-end",
+    });
+
+    // Zoom reset / fit button
+    const zoomFitBtn = endSection.createEl("button", {
+      cls: "rss-reader-lightbox-btn rss-reader-lightbox-btn-zoom-fit",
+      attr: {
+        "aria-label": "Reset zoom",
+        type: "button",
+      },
+    });
+    setIcon(zoomFitBtn, "expand");
+    const onZoomFitClick = (e: MouseEvent): void => {
+      e.stopPropagation();
+      this.resetZoom();
+    };
+    zoomFitBtn.addEventListener("click", onZoomFitClick);
+    this.cleanups.push(() => zoomFitBtn.removeEventListener("click", onZoomFitClick));
+
+    // Open image in browser button
+    const openImgBtn = endSection.createEl("button", {
+      cls: "rss-reader-lightbox-btn rss-reader-lightbox-btn-open-external",
+      attr: {
+        "aria-label": "Open original image in browser",
+        type: "button",
+      },
+    });
+    setIcon(openImgBtn, "globe");
+    const onOpenImgClick = (e: MouseEvent): void => {
+      e.stopPropagation();
+      this.win.open(this.source.fullUrl, "_blank", "noopener,noreferrer");
+    };
+    openImgBtn.addEventListener("click", onOpenImgClick);
+    this.cleanups.push(() => openImgBtn.removeEventListener("click", onOpenImgClick));
+
+    // Close button
+    const closeBtn = endSection.createEl("button", {
+      cls: "rss-reader-lightbox-btn rss-reader-lightbox-btn-close",
+      attr: {
+        "aria-label": "Close lightbox",
+        type: "button",
+      },
+    });
+    setIcon(closeBtn, "x");
+    const onCloseClick = (e: MouseEvent): void => {
+      e.stopPropagation();
+      this.close();
+    };
+    closeBtn.addEventListener("click", onCloseClick);
+    this.cleanups.push(() => closeBtn.removeEventListener("click", onCloseClick));
+  }
+
+  private renderViewport(): void {
+    if (!this.backdropEl) return;
+
+    this.viewportEl = this.backdropEl.createDiv({
+      cls: "rss-reader-lightbox-viewport",
+    });
+
+    this.stageEl = this.viewportEl.createDiv({
+      cls: "rss-reader-lightbox-stage",
+    });
+
+    // 1. Preview image (instant low-res placeholder)
+    if (this.source.previewUrl) {
+      this.previewImgEl = this.stageEl.createEl("img", {
+        cls: "rss-reader-lightbox-img rss-reader-lightbox-preview-img",
+        attr: {
+          src: this.source.previewUrl,
+          alt: this.source.altText,
+          draggable: "false",
+        },
+      });
+    }
+
+    // 2. Full-resolution image (loaded asynchronously)
+    this.fullImgEl = this.stageEl.createEl("img", {
+      cls: "rss-reader-lightbox-img rss-reader-lightbox-full-img",
+      attr: {
+        src: this.source.fullUrl,
+        alt: this.source.altText,
+        draggable: "false",
+      },
+    });
+
+    // 3. Loading spinner
+    this.spinnerEl = this.stageEl.createDiv({
+      cls: "rss-reader-lightbox-spinner",
+    });
+
+    const onFullImageLoad = (): void => {
+      if (this.isClosed) return;
+      this.spinnerEl?.addClass("is-hidden");
+      this.fullImgEl?.addClass("is-loaded");
+      this.previewImgEl?.addClass("is-hidden");
+    };
+
+    const onFullImageError = (): void => {
+      if (this.isClosed) return;
+      this.spinnerEl?.addClass("is-hidden");
+      new Notice("Could not load full-size image. Displaying preview.");
+      if (this.previewImgEl) {
+        this.previewImgEl.removeClass("is-hidden");
+      }
+    };
+
+    this.fullImgEl.addEventListener("load", onFullImageLoad);
+    this.fullImgEl.addEventListener("error", onFullImageError);
+    this.cleanups.push(() => {
+      this.fullImgEl?.removeEventListener("load", onFullImageLoad);
+      this.fullImgEl?.removeEventListener("error", onFullImageError);
+    });
+
+    // 4. Caption if altText is present
+    if (this.source.altText.trim()) {
+      this.viewportEl.createDiv({
+        cls: "rss-reader-lightbox-caption",
+        text: this.source.altText.trim(),
+      });
+    }
+  }
+
+  private attachEventListeners(): void {
+    if (!this.viewportEl || !this.stageEl) return;
+
+    // Click on viewport background to close
+    const onViewportClick = (e: MouseEvent): void => {
+      if (e.target === this.viewportEl && !this.isDragging) {
+        this.close();
+      }
+    };
+    this.viewportEl.addEventListener("click", onViewportClick);
+    this.cleanups.push(() =>
+      this.viewportEl?.removeEventListener("click", onViewportClick),
+    );
+
+    // Double-click to toggle zoom between fit (1x) and 2.5x
+    const onStageDoubleClick = (e: MouseEvent): void => {
+      e.stopPropagation();
+      if (this.scale === 1) {
+        this.zoomTo(2.5, e.clientX, e.clientY);
+      } else {
+        this.resetZoom();
+      }
+    };
+    this.stageEl.addEventListener("dblclick", onStageDoubleClick);
+    this.cleanups.push(() =>
+      this.stageEl?.removeEventListener("dblclick", onStageDoubleClick),
+    );
+
+    // Mouse wheel zoom
+    const onWheel = (e: WheelEvent): void => {
+      e.preventDefault();
+      const zoomFactor = e.deltaY < 0 ? 1.15 : 0.87;
+      const newScale = Math.min(Math.max(this.scale * zoomFactor, 1), 4);
+      if (newScale === 1) {
+        this.resetZoom();
+      } else {
+        this.zoomTo(newScale, e.clientX, e.clientY);
+      }
+    };
+    this.viewportEl.addEventListener("wheel", onWheel, { passive: false });
+    this.cleanups.push(() =>
+      this.viewportEl?.removeEventListener("wheel", onWheel),
+    );
+
+    // Mouse drag pan when zoomed
+    const onMouseDown = (e: MouseEvent): void => {
+      if (e.button !== 0 || this.scale <= 1) return;
+      this.isDragging = true;
+      this.dragStartX = e.clientX;
+      this.dragStartY = e.clientY;
+      this.dragInitialPanX = this.panX;
+      this.dragInitialPanY = this.panY;
+      this.viewportEl?.addClass("is-dragging");
+      this.stageEl?.addClass("is-panning");
+      e.preventDefault();
+    };
+
+    const onMouseMove = (e: MouseEvent): void => {
+      if (!this.isDragging) return;
+      const deltaX = e.clientX - this.dragStartX;
+      const deltaY = e.clientY - this.dragStartY;
+      this.panX = this.dragInitialPanX + deltaX;
+      this.panY = this.dragInitialPanY + deltaY;
+      this.updateTransform();
+    };
+
+    const onMouseUp = (): void => {
+      if (this.isDragging) {
+        this.isDragging = false;
+        this.viewportEl?.removeClass("is-dragging");
+        this.stageEl?.removeClass("is-panning");
+      }
+    };
+
+    this.viewportEl.addEventListener("mousedown", onMouseDown);
+    this.win.addEventListener("mousemove", onMouseMove);
+    this.win.addEventListener("mouseup", onMouseUp);
+    this.cleanups.push(() => {
+      this.viewportEl?.removeEventListener("mousedown", onMouseDown);
+      this.win.removeEventListener("mousemove", onMouseMove);
+      this.win.removeEventListener("mouseup", onMouseUp);
+    });
+
+    // Touch events for mobile
+    const onTouchStart = (e: TouchEvent): void => {
+      if (e.touches.length === 1) {
+        this.touchStartX = e.touches[0].clientX;
+        this.touchStartY = e.touches[0].clientY;
+        this.isSwipingToDismiss = this.scale === 1;
+
+        if (this.scale > 1) {
+          this.isDragging = true;
+          this.dragStartX = e.touches[0].clientX;
+          this.dragStartY = e.touches[0].clientY;
+          this.dragInitialPanX = this.panX;
+          this.dragInitialPanY = this.panY;
+          this.stageEl?.addClass("is-panning");
+        }
+      } else if (e.touches.length === 2) {
+        this.isSwipingToDismiss = false;
+        this.isDragging = false;
+        this.initialPinchDistance = this.getTouchDistance(e.touches);
+        this.initialPinchScale = this.scale;
+      }
+    };
+
+    const onTouchMove = (e: TouchEvent): void => {
+      if (e.touches.length === 1) {
+        if (this.isDragging && this.scale > 1) {
+          const deltaX = e.touches[0].clientX - this.dragStartX;
+          const deltaY = e.touches[0].clientY - this.dragStartY;
+          this.panX = this.dragInitialPanX + deltaX;
+          this.panY = this.dragInitialPanY + deltaY;
+          this.updateTransform();
+        } else if (this.isSwipingToDismiss && this.scale === 1) {
+          const deltaY = e.touches[0].clientY - this.touchStartY;
+          if (deltaY > 0) {
+            this.panY = deltaY * 0.7;
+            this.updateTransform();
+          }
+        }
+      } else if (e.touches.length === 2 && this.initialPinchDistance > 0) {
+        const currentDistance = this.getTouchDistance(e.touches);
+        const ratio = currentDistance / this.initialPinchDistance;
+        this.scale = Math.min(Math.max(this.initialPinchScale * ratio, 1), 4);
+        this.updateTransform();
+      }
+    };
+
+    const onTouchEnd = (_e: TouchEvent): void => {
+      if (this.isSwipingToDismiss && this.scale === 1) {
+        const deltaY = this.panY;
+        if (deltaY > 75) {
+          this.close();
+          return;
+        }
+        this.resetZoom();
+      }
+
+      if (this.scale <= 1) {
+        this.resetZoom();
+      }
+
+      this.isDragging = false;
+      this.isSwipingToDismiss = false;
+      this.stageEl?.removeClass("is-panning");
+    };
+
+    this.viewportEl.addEventListener("touchstart", onTouchStart, { passive: true });
+    this.viewportEl.addEventListener("touchmove", onTouchMove, { passive: true });
+    this.viewportEl.addEventListener("touchend", onTouchEnd, { passive: true });
+    this.cleanups.push(() => {
+      this.viewportEl?.removeEventListener("touchstart", onTouchStart);
+      this.viewportEl?.removeEventListener("touchmove", onTouchMove);
+      this.viewportEl?.removeEventListener("touchend", onTouchEnd);
+    });
+
+    // Keyboard navigation (Escape key to dismiss)
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        this.close();
+      }
+    };
+    this.win.addEventListener("keydown", onKeyDown);
+    this.cleanups.push(() => this.win.removeEventListener("keydown", onKeyDown));
+  }
+
+  private zoomTo(targetScale: number, clientX?: number, clientY?: number): void {
+    this.scale = targetScale;
+    if (this.scale <= 1) {
+      this.panX = 0;
+      this.panY = 0;
+      this.viewportEl?.removeClass("is-zoomed");
+    } else {
+      this.viewportEl?.addClass("is-zoomed");
+      if (clientX !== undefined && clientY !== undefined && this.viewportEl) {
+        const rect = this.viewportEl.getBoundingClientRect();
+        const offsetX = clientX - (rect.left + rect.width / 2);
+        const offsetY = clientY - (rect.top + rect.height / 2);
+        this.panX = -offsetX * 0.5;
+        this.panY = -offsetY * 0.5;
+      }
+    }
+    this.updateTransform();
+  }
+
+  private resetZoom(): void {
+    this.scale = 1;
+    this.panX = 0;
+    this.panY = 0;
+    this.viewportEl?.removeClass("is-zoomed");
+    this.updateTransform();
+  }
+
+  private updateTransform(): void {
+    if (!this.stageEl) return;
+    this.stageEl.style.transform = `translate(${this.panX}px, ${this.panY}px) scale(${this.scale})`;
+  }
+
+  private getTouchDistance(touches: TouchList): number {
+    if (touches.length < 2) return 0;
+    const dx = touches[0].clientX - touches[1].clientX;
+    const dy = touches[0].clientY - touches[1].clientY;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -5,6 +5,7 @@
 @import "./card-view.css";
 @import "./list-view.css";
 @import "./reader.css";
+@import "./reader-lightbox.css";
 @import "./video.css";
 @import "./controls.css";
 @import "./controls-dropdown.css";

--- a/src/styles/reader-lightbox.css
+++ b/src/styles/reader-lightbox.css
@@ -1,0 +1,200 @@
+/* Full-Resolution Reader Lightbox */
+
+.rss-reader-lightbox-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background-color: rgba(0, 0, 0, 0.88);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
+}
+
+.rss-reader-lightbox-backdrop.is-open {
+  opacity: 1;
+}
+
+.rss-reader-lightbox-toolbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 10;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0) 100%);
+  pointer-events: none;
+}
+
+.rss-reader-lightbox-toolbar-start,
+.rss-reader-lightbox-toolbar-end {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  pointer-events: auto;
+}
+
+.rss-reader-lightbox-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 36px;
+  min-width: 36px;
+  padding: 0 10px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease, transform 0.1s ease;
+}
+
+.rss-reader-lightbox-btn:hover {
+  background: rgba(255, 255, 255, 0.22);
+  transform: translateY(-1px);
+}
+
+.rss-reader-lightbox-btn:active {
+  transform: translateY(0);
+}
+
+.rss-reader-lightbox-btn.rss-reader-lightbox-external-link {
+  max-width: 280px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rss-reader-lightbox-viewport {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  cursor: default;
+}
+
+.rss-reader-lightbox-viewport.is-zoomed {
+  cursor: grab;
+}
+
+.rss-reader-lightbox-viewport.is-dragging {
+  cursor: grabbing;
+}
+
+.rss-reader-lightbox-stage {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 90vw;
+  max-height: 90vh;
+  transform-origin: center center;
+  transition: transform 0.15s cubic-bezier(0.2, 0, 0, 1);
+  will-change: transform;
+}
+
+.rss-reader-lightbox-stage.is-panning {
+  transition: none;
+}
+
+.rss-reader-lightbox-img {
+  max-width: 90vw;
+  max-height: 85vh;
+  object-fit: contain;
+  border-radius: 4px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+  pointer-events: auto;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.rss-reader-lightbox-preview-img {
+  position: absolute;
+  filter: blur(4px);
+  transform: scale(0.99);
+  transition: opacity 0.3s ease;
+}
+
+.rss-reader-lightbox-preview-img.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rss-reader-lightbox-full-img {
+  opacity: 0;
+  transition: opacity 0.25s ease-in-out;
+}
+
+.rss-reader-lightbox-full-img.is-loaded {
+  opacity: 1;
+}
+
+.rss-reader-lightbox-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 36px;
+  height: 36px;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: rss-lightbox-spin 0.8s linear infinite;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.rss-reader-lightbox-spinner.is-hidden {
+  display: none;
+}
+
+@keyframes rss-lightbox-spin {
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+.rss-reader-lightbox-caption {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 80%;
+  padding: 6px 14px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 16px;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 12px;
+  text-align: center;
+  pointer-events: none;
+  z-index: 10;
+  backdrop-filter: blur(4px);
+}
+
+/* Image affordance in reader content */
+.rss-reader-zoomable-img {
+  cursor: zoom-in;
+  transition: opacity 0.15s ease, filter 0.15s ease;
+}
+
+.rss-reader-zoomable-img:hover {
+  filter: brightness(1.03);
+}

--- a/src/utils/full-size-image-resolver.ts
+++ b/src/utils/full-size-image-resolver.ts
@@ -1,0 +1,224 @@
+import { isLatexFormulaImageElement } from "./image-url-utils";
+import { normalizeSubstackImageUrl } from "./substack-image-url";
+
+export interface ResolvedImageSource {
+  previewUrl: string;
+  fullUrl: string;
+  altText: string;
+  externalHref?: string;
+}
+
+const COMMON_IMAGE_EXTENSIONS = /\.(?:jpe?g|png|webp|gif|avif|svg|bmp)(?:[?#]|$)/i;
+
+/**
+ * Checks whether an image element in reader content should trigger the full-resolution lightbox.
+ * Filters out LaTeX formulas, 1x1 tracking pixels, and UI elements.
+ */
+export function isLightboxEligibleImage(img: HTMLImageElement | null | undefined): boolean {
+  if (!img || typeof img.tagName !== "string" || img.tagName.toLowerCase() !== "img") {
+    return false;
+  }
+
+  if (isLatexFormulaImageElement(img)) {
+    return false;
+  }
+
+  // Filter 1x1 transparent tracking pixels or spacer GIFs
+  const src = (img.getAttribute("src") || "").trim();
+  if (
+    src.startsWith("data:image/gif;base64,R0lGODlhAQABA") ||
+    src.startsWith("data:image/svg+xml")
+  ) {
+    return false;
+  }
+
+  // Dimension attributes when explicitly declared tiny (< 5px)
+  const widthAttr = parseInt(img.getAttribute("width") || "", 10);
+  const heightAttr = parseInt(img.getAttribute("height") || "", 10);
+  if (
+    (!Number.isNaN(widthAttr) && widthAttr > 0 && widthAttr < 5) ||
+    (!Number.isNaN(heightAttr) && heightAttr > 0 && heightAttr < 5)
+  ) {
+    return false;
+  }
+
+  // Filter known non-article images
+  const classList = img.classList;
+  if (
+    classList.contains("rss-feed-icon") ||
+    classList.contains("rss-author-avatar") ||
+    classList.contains("rss-reader-ui-icon")
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Parses a srcset attribute and returns the URL corresponding to the highest width or density.
+ */
+export function extractHighestResolutionFromSrcset(srcset: string | null | undefined): string | null {
+  const trimmed = (srcset || "").trim();
+  if (!trimmed) return null;
+
+  const entries = trimmed
+    .split(/,\s+(?=(?:https?:\/\/|data:image\/|\/))/i)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (entries.length === 0) return null;
+
+  let bestUrl: string | null = null;
+  let bestScore = -1;
+
+  for (const entry of entries) {
+    const parts = entry.split(/\s+/);
+    const url = parts[0];
+    const descriptor = parts[1] || "";
+
+    let score = 1;
+    if (descriptor.endsWith("w")) {
+      const width = parseInt(descriptor.slice(0, -1), 10);
+      if (!Number.isNaN(width)) {
+        score = width;
+      }
+    } else if (descriptor.endsWith("x")) {
+      const density = parseFloat(descriptor.slice(0, -1));
+      if (!Number.isNaN(density)) {
+        score = density * 1000;
+      }
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestUrl = url;
+    }
+  }
+
+  return bestUrl;
+}
+
+/**
+ * Strips common CDN image downscaling and resizing query/path parameters to restore the original full size.
+ */
+export function stripCdnResizeParameters(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return "";
+
+  // Substack CDN fetch URLs
+  if (trimmed.includes("substackcdn.com/image/fetch/")) {
+    const normalizedSubstack = normalizeSubstackImageUrl(trimmed);
+    if (normalizedSubstack) {
+      return stripCdnResizeParameters(normalizedSubstack);
+    }
+  }
+
+  try {
+    const url = new URL(trimmed);
+
+    // WordPress Photon (i0.wp.com, i1.wp.com, etc.)
+    if (/^i[0-3]\.wp\.com$/i.test(url.hostname)) {
+      url.searchParams.delete("w");
+      url.searchParams.delete("h");
+      url.searchParams.delete("resize");
+      url.searchParams.delete("fit");
+      url.searchParams.delete("crop");
+      return url.toString();
+    }
+
+    // Cloudinary /upload/w_...,c_scale/
+    if (url.hostname.includes("cloudinary.com") && url.pathname.includes("/upload/")) {
+      url.pathname = url.pathname.replace(/\/upload\/(?:[a-z]_[^/]+,?)+\//i, "/upload/");
+      return url.toString();
+    }
+
+    // Brightspot / NPR CDN resize
+    if (url.hostname.includes("brightspotcdn.com") || url.hostname.includes("media.npr.org")) {
+      url.pathname = url.pathname.replace(/\/resize\/\d+x\d*!?\//g, "/");
+      return url.toString();
+    }
+
+    // Generic resize params like ?width=, ?maxwidth=, ?w=, ?resize=
+    if (
+      url.searchParams.has("w") ||
+      url.searchParams.has("width") ||
+      url.searchParams.has("maxwidth") ||
+      url.searchParams.has("resize")
+    ) {
+      url.searchParams.delete("w");
+      url.searchParams.delete("width");
+      url.searchParams.delete("maxwidth");
+      url.searchParams.delete("resize");
+      url.searchParams.delete("h");
+      url.searchParams.delete("height");
+      return url.toString();
+    }
+
+    return trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * Resolves the full-resolution image source and any enclosing external link for a reader image element.
+ */
+export function resolveFullResolutionImageSource(img: HTMLImageElement): ResolvedImageSource {
+  const previewUrl = img.currentSrc || img.getAttribute("src") || "";
+  const altText = img.getAttribute("alt") || "";
+
+  let candidateUrl = "";
+  let externalHref: string | undefined;
+
+  // 1. Inspect enclosing anchor link
+  const anchor = img.closest("a");
+  if (anchor && anchor.hasAttribute("href")) {
+    const href = (anchor.getAttribute("href") || "").trim();
+    if (
+      COMMON_IMAGE_EXTENSIONS.test(href) ||
+      href.includes("substackcdn.com/image/fetch/") ||
+      /^data:image\//i.test(href)
+    ) {
+      candidateUrl = href;
+    } else if (/^https?:\/\//i.test(href)) {
+      externalHref = href;
+    }
+  }
+
+  // 2. Inspect srcset for highest resolution candidate if no direct image anchor link found
+  if (!candidateUrl) {
+    const srcsetCandidate = extractHighestResolutionFromSrcset(img.getAttribute("srcset"));
+    if (srcsetCandidate) {
+      candidateUrl = srcsetCandidate;
+    }
+  }
+
+  // 3. Inspect common lazy-loading data attributes
+  if (!candidateUrl) {
+    const dataSrc =
+      img.dataset.original ||
+      img.dataset.fullUrl ||
+      img.dataset.origFile ||
+      img.dataset.largeFile ||
+      img.dataset.src;
+    if (dataSrc) {
+      candidateUrl = dataSrc.trim();
+    }
+  }
+
+  // 4. Fallback to image src or currentSrc
+  if (!candidateUrl) {
+    candidateUrl = img.getAttribute("src") || img.currentSrc || "";
+  }
+
+  // 5. Strip CDN resizing transformations to yield original full size
+  const fullUrl = stripCdnResizeParameters(candidateUrl) || candidateUrl;
+
+  return {
+    previewUrl,
+    fullUrl,
+    altText,
+    externalHref,
+  };
+}

--- a/src/views/reader-view.ts
+++ b/src/views/reader-view.ts
@@ -58,6 +58,11 @@ import {
   findFirstNonFormulaImage,
   firstNonFormulaImageUrl,
 } from "../utils/image-url-utils";
+import { ReaderLightbox } from "../components/reader-lightbox";
+import {
+  isLightboxEligibleImage,
+  resolveFullResolutionImageSource,
+} from "../utils/full-size-image-resolver";
 import { PodcastPlayer } from "./podcast-player";
 import { VideoPlayer } from "./video-player";
 import { RSS_DASHBOARD_VIEW_TYPE, RssDashboardView } from "./dashboard-view";
@@ -2026,10 +2031,11 @@ export class ReaderView extends ItemView {
           }
 
           if (heroUrl) {
-            heroSlot.createEl("img", {
+            const heroImg = heroSlot.createEl("img", {
               cls: "rss-reader-fallback-hero",
               attr: { src: heroUrl, alt: title || "Hero image" },
             });
+            this.setupLightboxForImage(heroImg);
 
             // Remove the first image from the body if it's the hero image to avoid duplication
             if (
@@ -2105,6 +2111,7 @@ export class ReaderView extends ItemView {
     // Add classes to images for styling
     container.querySelectorAll("img").forEach((img) => {
       img.addClass("rss-reader-responsive-img");
+      this.setupLightboxForImage(img);
       img.addEventListener("error", () => {
         if (this.recoverFailedSubstackImageElement(img)) {
           console.warn(
@@ -2122,6 +2129,22 @@ export class ReaderView extends ItemView {
     void scheduleProcessMathElements(container, {
       app: this.app,
       component: this,
+    });
+  }
+
+  private setupLightboxForImage(img: HTMLImageElement): void {
+    if (!isLightboxEligibleImage(img)) return;
+
+    img.addClass("rss-reader-zoomable-img");
+    img.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const source = resolveFullResolutionImageSource(img);
+      const lightbox = new ReaderLightbox({
+        source,
+        doc: this.containerEl.ownerDocument,
+      });
+      lightbox.open();
     });
   }
 

--- a/test_files/unit/components/reader-lightbox.test.ts
+++ b/test_files/unit/components/reader-lightbox.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReaderLightbox } from "../../../src/components/reader-lightbox";
+import { installObsidianDomPolyfills } from "../test-dom-polyfills";
+
+describe("ReaderLightbox", () => {
+  beforeEach(() => {
+    installObsidianDomPolyfills();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("mounts to document body when opened and renders toolbar buttons", () => {
+    const lightbox = new ReaderLightbox({
+      source: {
+        previewUrl: "https://example.com/thumb.jpg",
+        fullUrl: "https://example.com/full.jpg",
+        altText: "A majestic mountain",
+        externalHref: "https://nationalgeographic.com/photo-of-the-day",
+      },
+      doc: document,
+    });
+
+    lightbox.open();
+
+    const backdrop = document.body.querySelector(".rss-reader-lightbox-backdrop");
+    expect(backdrop).not.toBeNull();
+
+    // Toolbar buttons
+    const closeBtn = backdrop?.querySelector(".rss-reader-lightbox-btn-close");
+    expect(closeBtn).not.toBeNull();
+
+    const zoomFitBtn = backdrop?.querySelector(".rss-reader-lightbox-btn-zoom-fit");
+    expect(zoomFitBtn).not.toBeNull();
+
+    const openImgBtn = backdrop?.querySelector(".rss-reader-lightbox-btn-open-external");
+    expect(openImgBtn).not.toBeNull();
+
+    // External link button
+    const externalLinkBtn = backdrop?.querySelector(".rss-reader-lightbox-external-link");
+    expect(externalLinkBtn).not.toBeNull();
+    expect(externalLinkBtn?.textContent).toContain("nationalgeographic.com");
+
+    // Caption
+    const caption = backdrop?.querySelector(".rss-reader-lightbox-caption");
+    expect(caption?.textContent).toBe("A majestic mountain");
+
+    lightbox.close();
+  });
+
+  it("handles image load events by hiding spinner and preview", () => {
+    const lightbox = new ReaderLightbox({
+      source: {
+        previewUrl: "https://example.com/thumb.jpg",
+        fullUrl: "https://example.com/full.jpg",
+        altText: "",
+      },
+      doc: document,
+    });
+
+    lightbox.open();
+
+    const fullImg = document.body.querySelector<HTMLImageElement>(
+      ".rss-reader-lightbox-full-img",
+    );
+    const previewImg = document.body.querySelector<HTMLImageElement>(
+      ".rss-reader-lightbox-preview-img",
+    );
+    const spinner = document.body.querySelector(
+      ".rss-reader-lightbox-spinner",
+    );
+
+    expect(fullImg).not.toBeNull();
+    expect(previewImg).not.toBeNull();
+    expect(spinner?.classList.contains("is-hidden")).toBe(false);
+
+    // Simulate image loaded
+    fullImg?.dispatchEvent(new Event("load"));
+
+    expect(fullImg?.classList.contains("is-loaded")).toBe(true);
+    expect(previewImg?.classList.contains("is-hidden")).toBe(true);
+    expect(spinner?.classList.contains("is-hidden")).toBe(true);
+
+    lightbox.close();
+  });
+
+  it("toggles zoom on double-click on stage", () => {
+    const lightbox = new ReaderLightbox({
+      source: {
+        previewUrl: "https://example.com/thumb.jpg",
+        fullUrl: "https://example.com/full.jpg",
+        altText: "",
+      },
+      doc: document,
+    });
+
+    lightbox.open();
+
+    const stage = document.body.querySelector<HTMLElement>(
+      ".rss-reader-lightbox-stage",
+    );
+    const viewport = document.body.querySelector<HTMLElement>(
+      ".rss-reader-lightbox-viewport",
+    );
+
+    expect(stage).not.toBeNull();
+    expect(viewport?.classList.contains("is-zoomed")).toBe(false);
+
+    // Double click to zoom in
+    stage?.dispatchEvent(
+      new MouseEvent("dblclick", { bubbles: true, clientX: 200, clientY: 200 }),
+    );
+    expect(viewport?.classList.contains("is-zoomed")).toBe(true);
+    expect(stage?.style.transform).toContain("scale(2.5)");
+
+    // Double click again to reset zoom
+    stage?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    expect(viewport?.classList.contains("is-zoomed")).toBe(false);
+    expect(stage?.style.transform).toContain("scale(1)");
+
+    lightbox.close();
+  });
+
+  it("closes on Escape key press", () => {
+    const lightbox = new ReaderLightbox({
+      source: {
+        previewUrl: "https://example.com/thumb.jpg",
+        fullUrl: "https://example.com/full.jpg",
+        altText: "",
+      },
+      doc: document,
+    });
+
+    lightbox.open();
+    expect(document.body.querySelector(".rss-reader-lightbox-backdrop")).not.toBeNull();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    // Closes and schedules removal
+    const backdrop = document.body.querySelector(".rss-reader-lightbox-backdrop");
+    expect(backdrop?.classList.contains("is-open")).toBe(false);
+  });
+
+  it("opens external webpage in new window on clicking external link button", () => {
+    const windowOpenMock = vi.fn();
+    window.open = windowOpenMock;
+
+    const lightbox = new ReaderLightbox({
+      source: {
+        previewUrl: "https://example.com/thumb.jpg",
+        fullUrl: "https://example.com/full.jpg",
+        altText: "",
+        externalHref: "https://example.org/article",
+      },
+      doc: document,
+    });
+
+    lightbox.open();
+
+    const linkBtn = document.body.querySelector<HTMLButtonElement>(
+      ".rss-reader-lightbox-external-link",
+    );
+    linkBtn?.click();
+
+    expect(windowOpenMock).toHaveBeenCalledWith(
+      "https://example.org/article",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    lightbox.close();
+  });
+});

--- a/test_files/unit/utils/full-size-image-resolver.test.ts
+++ b/test_files/unit/utils/full-size-image-resolver.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  extractHighestResolutionFromSrcset,
+  isLightboxEligibleImage,
+  resolveFullResolutionImageSource,
+  stripCdnResizeParameters,
+} from "../../../src/utils/full-size-image-resolver";
+import { installObsidianDomPolyfills } from "../test-dom-polyfills";
+
+describe("full-size-image-resolver", () => {
+  beforeEach(() => {
+    installObsidianDomPolyfills();
+    document.body.replaceChildren();
+  });
+
+  describe("isLightboxEligibleImage", () => {
+    it("returns false for null or undefined", () => {
+      expect(isLightboxEligibleImage(null)).toBe(false);
+      expect(isLightboxEligibleImage(undefined)).toBe(false);
+    });
+
+    it("returns false for LaTeX formula images", () => {
+      const img = createEl("img", {
+        cls: "alignnone latex size-full",
+        attr: { src: "https://example.com/formula.png" },
+      });
+      expect(isLightboxEligibleImage(img)).toBe(false);
+    });
+
+    it("returns false for tracking pixels and transparent spacers", () => {
+      const trackingImg = createEl("img", {
+        attr: {
+          src: "data:image/gif;base64,R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
+        },
+      });
+      expect(isLightboxEligibleImage(trackingImg)).toBe(false);
+
+      const tinyImg = createEl("img", {
+        attr: {
+          width: "1",
+          height: "1",
+          src: "https://tracker.example.com/pixel.gif",
+        },
+      });
+      expect(isLightboxEligibleImage(tinyImg)).toBe(false);
+    });
+
+    it("returns false for UI and feed icons", () => {
+      const icon = createEl("img", {
+        cls: "rss-feed-icon",
+        attr: { src: "https://example.com/favicon.ico" },
+      });
+      expect(isLightboxEligibleImage(icon)).toBe(false);
+    });
+
+    it("returns true for standard article images", () => {
+      const img = createEl("img", {
+        attr: {
+          src: "https://example.com/photo.jpg",
+          alt: "Beautiful scenery",
+        },
+      });
+      expect(isLightboxEligibleImage(img)).toBe(true);
+    });
+  });
+
+  describe("extractHighestResolutionFromSrcset", () => {
+    it("returns null for empty or null srcset", () => {
+      expect(extractHighestResolutionFromSrcset(null)).toBe(null);
+      expect(extractHighestResolutionFromSrcset("")).toBe(null);
+    });
+
+    it("extracts the highest width descriptor", () => {
+      const srcset =
+        "https://example.com/img-300.jpg 300w, https://example.com/img-1200.jpg 1200w, https://example.com/img-600.jpg 600w";
+      expect(extractHighestResolutionFromSrcset(srcset)).toBe(
+        "https://example.com/img-1200.jpg",
+      );
+    });
+
+    it("extracts the highest pixel density descriptor", () => {
+      const srcset =
+        "https://example.com/img-1x.jpg 1x, https://example.com/img-3x.jpg 3x, https://example.com/img-2x.jpg 2x";
+      expect(extractHighestResolutionFromSrcset(srcset)).toBe(
+        "https://example.com/img-3x.jpg",
+      );
+    });
+  });
+
+  describe("stripCdnResizeParameters", () => {
+    it("normalizes Substack CDN fetch URLs to original unconstrained asset", () => {
+      const substack =
+        "https://substackcdn.com/image/fetch/w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fexample.com%2Foriginal-photo.jpg";
+      expect(stripCdnResizeParameters(substack)).toBe(
+        "https://example.com/original-photo.jpg",
+      );
+    });
+
+    it("strips WordPress Photon sizing parameters", () => {
+      const photon = "https://i0.wp.com/example.com/photo.jpg?w=600&h=400&crop=1";
+      expect(stripCdnResizeParameters(photon)).toBe(
+        "https://i0.wp.com/example.com/photo.jpg",
+      );
+    });
+
+    it("strips Cloudinary upload resizing path segments", () => {
+      const cloudinary =
+        "https://res.cloudinary.com/demo/image/upload/w_300,c_scale/sample.jpg";
+      expect(stripCdnResizeParameters(cloudinary)).toBe(
+        "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+      );
+    });
+
+    it("strips Brightspot resize paths", () => {
+      const brightspot =
+        "https://media.npr.brightspotcdn.com/dims4/default/resize/600x!/photo.jpg";
+      expect(stripCdnResizeParameters(brightspot)).toBe(
+        "https://media.npr.brightspotcdn.com/dims4/default/photo.jpg",
+      );
+    });
+
+    it("strips generic width/resize query parameters", () => {
+      const generic = "https://example.com/image.png?width=800&maxwidth=1200&resize=800x600";
+      expect(stripCdnResizeParameters(generic)).toBe("https://example.com/image.png");
+    });
+  });
+
+  describe("resolveFullResolutionImageSource", () => {
+    it("prioritizes anchor href when pointing directly to an image asset", () => {
+      const container = createDiv();
+      const anchor = container.createEl("a", {
+        attr: { href: "https://example.com/fullsize-original.jpg" },
+      });
+      const img = anchor.createEl("img", {
+        attr: {
+          src: "https://example.com/thumbnail-300.jpg",
+          alt: "Test image",
+        },
+      });
+      const result = resolveFullResolutionImageSource(img);
+
+      expect(result.previewUrl).toBe("https://example.com/thumbnail-300.jpg");
+      expect(result.fullUrl).toBe("https://example.com/fullsize-original.jpg");
+      expect(result.altText).toBe("Test image");
+      expect(result.externalHref).toBeUndefined();
+    });
+
+    it("captures externalHref when anchor href is a webpage rather than an image", () => {
+      const container = createDiv();
+      const anchor = container.createEl("a", {
+        attr: { href: "https://nytimes.com/article-source" },
+      });
+      const img = anchor.createEl("img", {
+        attr: {
+          src: "https://example.com/scenery.jpg?w=500",
+          alt: "Scenery",
+        },
+      });
+      const result = resolveFullResolutionImageSource(img);
+
+      expect(result.previewUrl).toBe("https://example.com/scenery.jpg?w=500");
+      expect(result.fullUrl).toBe("https://example.com/scenery.jpg");
+      expect(result.externalHref).toBe("https://nytimes.com/article-source");
+    });
+
+    it("resolves from srcset when no image anchor link exists", () => {
+      const img = createEl("img", {
+        attr: {
+          src: "https://example.com/thumb.jpg",
+          srcset: "https://example.com/small.jpg 400w, https://example.com/large.jpg 1600w",
+        },
+      });
+      const result = resolveFullResolutionImageSource(img);
+
+      expect(result.fullUrl).toBe("https://example.com/large.jpg");
+    });
+
+    it("resolves from data-full-url or data-original if present", () => {
+      const img = createEl("img", {
+        attr: {
+          src: "https://example.com/placeholder.jpg",
+          "data-full-url": "https://example.com/hires-version.jpg",
+        },
+      });
+      const result = resolveFullResolutionImageSource(img);
+
+      expect(result.fullUrl).toBe("https://example.com/hires-version.jpg");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #202

Implements tap-to-expand image viewing in the Reader view, introducing an interactive full-resolution Lightbox with progressive loading, gestures, and tiered high-resolution extraction:
- **Tiered Source Resolution**: Extracts original unconstrained media URLs by following direct image links, selecting highest-density srcset candidates, and stripping CDN resize transformations (Substack, WordPress Photon, Cloudinary, Brightspot/NPR, etc.) while excluding math/LaTeX formulas, 1x1 tracking pixels, feed icons, and UI avatars.
- **Reader Lightbox Component & Styles**: Custom full-window overlay mounted to activeDocument.body (compatible with popout windows). Features instant preview thumbnail with smooth progressive upgrade to full-res, fit/1:1 toggle zoom, mouse drag pan, pinch zoom, mobile swipe-down-to-dismiss, and an action toolbar with external link routing.
- **Documentation & Architecture**: Added ADR docs/adr/0001-reader-full-resolution-lightbox.md and updated domain terms in CONTEXT.md.

## Verification
- Unit tests: 192 files, 1755 tests passed
- Platform & compliance: npm run check:platform, check:important, check:css-scope, lint, tsc, and build passed