### PR TITLE
fix: - Fixed Discover view pagination rendering pages vertically stac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 
+- Fixed Discover view pagination rendering pages vertically stacked by structuring pagination into horizontal page navigation buttons (`.rss-dashboard-pagination-pages`), utility controls (`.rss-dashboard-pagination-controls`) with a styled page-size wrapper, and results count, matching the Dashboard view layout.
 - Fixed an issue where dragging and dropping multiple selected feeds in the sidebar only moved a single feed; dragging now moves all selected feeds together, preserving their relative order across folder headers, folder lists, root, and feed reordering drops.
 - Fixed Feed View grouping so **Grouping: Disabled** renders a flat article sequence and **Grouping: Feed** displays one collapsible header per feed. [GH Issue #195](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/195)
 - Removed Nitter integration, automatic X/Twitter-to-Nitter RSS feed conversion, and obsolete Twitter/X settings and fallbacks following the permanent shutdown of Nitter instances and the project repository on August 24, 2026 due to cease and desist demands from X Corp. (https://github.com/zedeus/nitter). Attempting to add an `x.com`, `twitter.com`, or any `nitter.*` URL now shows a clear error message explaining the situation and suggesting third-party RSS bridges (e.g. RSSHub) as an alternative.

--- a/src/styles/pagination.css
+++ b/src/styles/pagination.css
@@ -22,6 +22,7 @@
   gap: 0.5rem;
   padding-top: 16px;
   margin: 0;
+  margin-bottom: 40px;
   width: 100%;
 }
 

--- a/src/views/discover-view.ts
+++ b/src/views/discover-view.ts
@@ -2042,16 +2042,31 @@ export class DiscoverView extends ItemView {
       cls: "rss-dashboard-pagination",
     });
 
-    const prevButton = paginationContainer.createEl("button", {
+    const pagesRow = paginationContainer.createDiv({
+      cls: "rss-dashboard-pagination-pages",
+    });
+
+    const prevButton = pagesRow.createEl("button", {
       cls: "rss-dashboard-pagination-btn prev",
       text: "<",
     });
     prevButton.disabled = currentPage === 1;
-    prevButton.onclick = () => this.handlePageChange(currentPage - 1);
+    prevButton.onclick = () => {
+      if (currentPage > 1) {
+        this.handlePageChange(currentPage - 1);
+      }
+    };
 
-    const maxPagesToShow = 7;
-    let startPage = Math.max(1, currentPage - 3);
-    let endPage = Math.min(totalPages, currentPage + 3);
+    const isMobile =
+      typeof activeWindow !== "undefined" &&
+      typeof activeWindow.matchMedia === "function"
+        ? activeWindow.matchMedia("(max-width: 768px)").matches
+        : false;
+    const maxPagesToShow = isMobile ? 3 : 5;
+    const padding = isMobile ? 1 : 2;
+
+    let startPage = Math.max(1, currentPage - padding);
+    let endPage = Math.min(totalPages, currentPage + padding);
     if (endPage - startPage < maxPagesToShow - 1) {
       if (startPage === 1) {
         endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
@@ -2060,35 +2075,46 @@ export class DiscoverView extends ItemView {
       }
     }
     if (startPage > 1) {
-      this.createPageButton(paginationContainer, 1, currentPage);
+      this.createPageButton(pagesRow, 1, currentPage);
       if (startPage > 2) {
-        paginationContainer.createSpan({
+        pagesRow.createSpan({
           text: "...",
           cls: "rss-dashboard-pagination-ellipsis",
         });
       }
     }
     for (let i = startPage; i <= endPage; i++) {
-      this.createPageButton(paginationContainer, i, currentPage);
+      this.createPageButton(pagesRow, i, currentPage);
     }
     if (endPage < totalPages) {
       if (endPage < totalPages - 1) {
-        paginationContainer.createSpan({
+        pagesRow.createSpan({
           text: "...",
           cls: "rss-dashboard-pagination-ellipsis",
         });
       }
-      this.createPageButton(paginationContainer, totalPages, currentPage);
+      this.createPageButton(pagesRow, totalPages, currentPage);
     }
 
-    const nextButton = paginationContainer.createEl("button", {
+    const nextButton = pagesRow.createEl("button", {
       cls: "rss-dashboard-pagination-btn next",
       text: ">",
     });
     nextButton.disabled = currentPage === totalPages;
-    nextButton.onclick = () => this.handlePageChange(currentPage + 1);
+    nextButton.onclick = () => {
+      if (currentPage < totalPages) {
+        this.handlePageChange(currentPage + 1);
+      }
+    };
 
-    const pageSizeDropdown = paginationContainer.createEl("select", {
+    const controlsRow = paginationContainer.createDiv({
+      cls: "rss-dashboard-pagination-controls",
+    });
+
+    const pageSizeWrapper = controlsRow.createDiv({
+      cls: "rss-dashboard-page-size-wrapper",
+    });
+    const pageSizeDropdown = pageSizeWrapper.createEl("select", {
       cls: "rss-dashboard-page-size-dropdown",
     });
     for (const size of getPageSizeOptions(pageSize)) {
@@ -2117,7 +2143,10 @@ export class DiscoverView extends ItemView {
       pageSize,
       currentPage,
     });
-    paginationContainer.createSpan({
+    const resultsRow = paginationContainer.createDiv({
+      cls: "rss-dashboard-pagination-results",
+    });
+    resultsRow.createSpan({
       cls: "rss-dashboard-pagination-results",
       text: `Results: ${startIdx} - ${endIdx} of ${totalFeeds}`,
     });
@@ -2156,6 +2185,10 @@ export class DiscoverView extends ItemView {
       text: String(page),
     });
     btn.disabled = page === currentPage;
-    btn.onclick = () => this.handlePageChange(page);
+    btn.onclick = () => {
+      if (page !== currentPage) {
+        this.handlePageChange(page);
+      }
+    };
   }
 }

--- a/test_files/unit/views/discover-view.test.ts
+++ b/test_files/unit/views/discover-view.test.ts
@@ -601,4 +601,102 @@ describe("DiscoverView (P1-3)", () => {
       "Added 2 feeds. Articles will be fetched in the background. Skipped 1 already-followed feeds.",
     );
   });
+
+  it("renders pagination with structured pages row, controls row, and wrapped dropdown", async () => {
+    const { view } = await createView();
+    view.pageSize = 1;
+    view.loadData();
+    view.render();
+
+    const pagination = view.containerEl.querySelector(
+      ".rss-dashboard-pagination",
+    );
+    expect(pagination).not.toBeNull();
+
+    const pagesRow = pagination?.querySelector(
+      ".rss-dashboard-pagination-pages",
+    );
+    expect(pagesRow).not.toBeNull();
+
+    const prevButton = pagination?.querySelector(
+      ".rss-dashboard-pagination-btn.prev",
+    );
+    const nextButton = pagination?.querySelector(
+      ".rss-dashboard-pagination-btn.next",
+    );
+    expect(prevButton?.parentElement).toBe(pagesRow);
+    expect(nextButton?.parentElement).toBe(pagesRow);
+
+    const pageButtons = Array.from(
+      pagesRow?.querySelectorAll<HTMLButtonElement>(
+        ".rss-dashboard-pagination-btn:not(.prev):not(.next)",
+      ) ?? [],
+    );
+    expect(pageButtons.length).toBeGreaterThan(0);
+    for (const btn of pageButtons) {
+      expect(btn.parentElement).toBe(pagesRow);
+    }
+
+    const controlsRow = pagination?.querySelector(
+      ".rss-dashboard-pagination-controls",
+    );
+    expect(controlsRow).not.toBeNull();
+
+    const pageSizeDropdown = pagination?.querySelector(
+      ".rss-dashboard-page-size-dropdown",
+    );
+    expect(pageSizeDropdown).not.toBeNull();
+    expect(
+      pageSizeDropdown?.parentElement?.classList.contains(
+        "rss-dashboard-page-size-wrapper",
+      ),
+    ).toBe(true);
+    expect(pageSizeDropdown?.parentElement?.parentElement).toBe(controlsRow);
+
+    const resultsRow = pagination?.querySelector(
+      ".rss-dashboard-pagination-results",
+    );
+    expect(resultsRow).not.toBeNull();
+    expect(resultsRow?.textContent).toContain("Results: 1 - 1 of 4");
+    expect((prevButton as HTMLButtonElement).disabled).toBe(true);
+    expect((nextButton as HTMLButtonElement).disabled).toBe(false);
+
+    // Clicking next button advances page
+    (nextButton as HTMLButtonElement).click();
+    expect(view.currentPage).toBe(2);
+
+    const updatedNext = view.containerEl.querySelector(
+      ".rss-dashboard-pagination-btn.next",
+    );
+    const updatedPrev = view.containerEl.querySelector(
+      ".rss-dashboard-pagination-btn.prev",
+    );
+    expect((updatedPrev as HTMLButtonElement).disabled).toBe(false);
+    expect((updatedNext as HTMLButtonElement).disabled).toBe(false);
+
+
+    // Clicking page button directly
+    const page3Btn = Array.from(
+      view.containerEl.querySelectorAll<HTMLButtonElement>(
+        ".rss-dashboard-pagination-pages .rss-dashboard-pagination-btn:not(.prev):not(.next)",
+      ),
+    ).find((b) => b.textContent?.trim() === "3");
+    expect(page3Btn).not.toBeUndefined();
+    page3Btn?.click();
+    expect(view.currentPage).toBe(3);
+
+    // Changing page size updates page size and resets current page to 1
+    const dropdown = view.containerEl.querySelector<HTMLSelectElement>(
+      ".rss-dashboard-page-size-dropdown",
+    );
+    expect(dropdown).not.toBeNull();
+    if (dropdown) {
+      dropdown.value = "10";
+      dropdown.dispatchEvent(new Event("change"));
+    }
+    expect(view.pageSize).toBe(10);
+    expect(view.currentPage).toBe(1);
+  });
 });
+
+


### PR DESCRIPTION
Fixed Discover view pagination rendering pages vertically stacked by structuring pagination into horizontal page navigation buttons (`.rss-dashboard-pagination-pages`), utility controls (`.rss-dashboard-pagination-controls`) with a styled page-size wrapper, and results count, matching the Dashboard view layout.