### PR TITLE
Refactor OPML importer into reusable shell (v1.8.7)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,7 +43,7 @@ _Avoid_: Modal dialog, photo popup, preview card, photo gallery
 **Full-resolution image source**:
 The unconstrained original media URL extracted by resolving direct image links, selecting the highest-resolution candidate in a srcset, or stripping CDN resize transformations.
 _Avoid_: Thumbnail, cached preview, compressed version
-## Data retention and article lifecycle
+## Data retention and article lifecycle
 
 **Auto-delete cutoff**:
 The calculated timestamp before which unprotected articles are deleted from local storage, based on publication date and the configured retention duration.
@@ -52,3 +52,10 @@ _Avoid_: Expiration date, purge limit
 **Retention protection**:
 The user-selected set of article states (such as starred, saved to vault, or tagged) that shield an article from automatic deletion and feed capacity trimming.
 _Avoid_: Pinned articles, whitelisted items, lock state
+
+## Import preview
+
+**Existing feed**:
+A feed from an import file whose URL is already configured. In Update mode it
+is informationally unavailable and is not selectable for import.
+_Avoid_: Error feed, invalid feed, rejected feed

--- a/docs/plans/233-opml-importer-shell-refactor.md
+++ b/docs/plans/233-opml-importer-shell-refactor.md
@@ -1,0 +1,37 @@
+---
+status: proposed
+created: 2026-09-09
+issue: "https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/233"
+milestone: ""
+owner: unassigned
+workstream: importers
+sequence: 1
+depends_on: []
+release_requirement: ""
+implementation: ""
+---
+
+# Refactor OPML importer into reusable import shell
+
+Parent issue: [#233](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/233).
+
+## What to build
+
+Extract a minimal, format-agnostic "importer shell" from the existing OPML importer (`ImportOpmlModal`, `OpmlManager`, `OpmlImportPreviewModel`) that owns the shared modal lifecycle (file pick → validate → preview → execute) and shared UI chrome (stat badges, toolbar scaffolding), while OPML-specific behavior (file-type validation messages, the XML-cleaner-tool link, the Update/Overwrite mode selector and its confirmation warning) stays inside an OPML-specific plug-in to that shell.
+
+This is a structural refactor, not a feature change: the OPML import flow must remain behaviorally identical to a user — same file picker, same error messages, same preview tree with per-item checkboxes and inline rename, same Select all/none and Expand/Collapse all, same Auto-fix invalid names, same Update vs. Overwrite modes, same background ingestion via `plugin.ingestFeedsForBackgroundImport(...)`.
+
+`OpmlImportPreviewModel` is reused unchanged (still feed/folder-shaped) via the shell's pluggable preview-model/renderer slot — it is not itself generalized in this ticket. A future importer (starred.json) will supply its own, differently-shaped preview-selection model against whatever minimal interface the shell requires.
+
+## Blocked by
+
+None (can start immediately)
+
+## Acceptance criteria
+
+- [ ] A shared importer shell exists that owns lifecycle state (idle → validating → preview → executing → done/error), accepting a pluggable `validate(content)`, `parse(content)`, and preview-list renderer/selection-model.
+- [ ] The OPML importer is refactored to be a plug-in to this shell; `OpmlManager` parsing/generation logic and `BackgroundImportService` are untouched.
+- [ ] `OpmlImportPreviewModel`'s existing behavior (toggle, rename, folder-merge-on-collision, `getStats()`, `getSelectedImportableFeeds()`, `getDerivedFoldersForSelectedFeeds()`) is unchanged and still exercised by the refactored modal.
+- [ ] All existing OPML-related tests pass unchanged (`test_files/unit/modals/opml-import-preview-model.test.ts`, `test_files/unit/modals/import-opml-modal.test.ts`, `test_files/unit/services/opml-manager.test.ts`).
+- [ ] A new test exercises the shell's lifecycle in isolation using a fake validator/parser/renderer (no OPML-specific code in the shell).
+- [ ] **Manual gate:** the repository owner has run a stress-test pass against the refactored OPML importer (file picker; valid and malformed OPML files; per-feed/folder selection; inline rename; folder-merge-on-collision; Auto-fix invalid names; Select/Expand all-none; both Update and Overwrite modes including the overwrite confirmation warning; background ingestion still populates feeds and fetches content) and confirmed sign-off on issue #233. No downstream ticket (234-*) may start before this is confirmed.

--- a/docs/plans/234-01-import-starred-items-for-existing-feeds.md
+++ b/docs/plans/234-01-import-starred-items-for-existing-feeds.md
@@ -1,0 +1,34 @@
+---
+status: proposed
+created: 2026-09-09
+issue: "https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234"
+milestone: ""
+owner: unassigned
+workstream: importers
+sequence: 2
+depends_on: ["233-opml-importer-shell-refactor"]
+release_requirement: ""
+implementation: ""
+---
+
+# Import starred.json for feeds you already subscribe to
+
+Parent issue: [#234](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234).
+
+## What to build
+
+The base "Import Starred Articles" flow, built on the shared importer shell from [233-opml-importer-shell-refactor](233-opml-importer-shell-refactor.md), living as a sibling entry point next to "Import OPML". A user picks an exported `starred.json` (Inoreader/Google-Reader-API "Read later"/starred format); a pure mapper reads `items[]` and, for this ticket, keeps only starred items whose source feed (`origin.streamId`, matched by URL) already exists locally. The preview groups these by source feed with per-article checkboxes. On execute, each selected item is inserted as a `FeedItem` built directly from the export's own fields (title, `canonical`/`alternate` href as link, `summary.content` as content, author, published date, `id` as guid) — never from a live feed re-fetch, since feeds churn and won't contain older items — with `starred: true` set (and `read: true` if the export marked it read).
+
+Items whose feed does not yet exist locally are excluded from this ticket's import (deferred to [234-02](234-02-auto-create-missing-source-feeds.md)); no tag mapping (deferred to [234-04](234-04-map-labels-to-tags.md)) and no full-content fetch (deferred to [234-06](234-06-opt-in-full-content-fetch.md)) happen yet.
+
+## Blocked by
+
+- 233-opml-importer-shell-refactor (must be merged and manually confirmed)
+
+## Acceptance criteria
+
+- [ ] "Import Starred Articles" is discoverable next to "Import OPML" and opens a modal built on the shared importer shell.
+- [ ] A pure mapper function/class turns a parsed `starred.json` into candidate `FeedItem`s (for feeds already present, matched by URL) with no network or Obsidian API dependency, tested against the real exported fixture file.
+- [ ] The preview groups candidate items by source feed under collapsible headers with per-article selection.
+- [ ] Executing the import inserts selected items into their feed's `items`, with `starred` (and `read`, when applicable) set from the export's category state.
+- [ ] Items whose source feed doesn't exist locally are simply not shown/selectable in this ticket (no error needed yet — that's handled by later tickets).

--- a/docs/plans/234-02-auto-create-missing-source-feeds.md
+++ b/docs/plans/234-02-auto-create-missing-source-feeds.md
@@ -1,0 +1,31 @@
+---
+status: proposed
+created: 2026-09-09
+issue: "https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234"
+milestone: ""
+owner: unassigned
+workstream: importers
+sequence: 3
+depends_on: ["234-01-import-starred-items-for-existing-feeds"]
+release_requirement: ""
+implementation: ""
+---
+
+# Auto-create missing source feeds during import
+
+Parent issue: [#234](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234).
+
+## What to build
+
+Extend [234-01](234-01-import-starred-items-for-existing-feeds.md) so starred items whose source feed (`origin.streamId`/`origin.title`/`origin.htmlUrl`) is not already in the user's feed list are no longer excluded. The mapper produces candidate `Feed` records for these new sources; the preview lets the user assign/edit each new feed's folder placement (same editable-folder UX pattern as OPML import's preview tree, not a fixed "Imported" folder). On execute, any selected new feed is created and then fetched/refreshed once via the existing feed-fetch pipeline — purely to populate feed metadata (title, siteUrl, icon) and current items — independently of, and not blocking, insertion of the historical starred item itself (which still comes from the export's own data, per 234-01).
+
+## Blocked by
+
+- 234-01-import-starred-items-for-existing-feeds
+
+## Acceptance criteria
+
+- [ ] The mapper also emits candidate `Feed` records for source feeds not already present locally (matched by URL).
+- [ ] The preview shows these new feeds grouped with their starred items and lets the user edit the target folder per new feed before import.
+- [ ] Executing the import creates the new feed(s), triggers one feed-fetch/refresh for metadata/current items, and inserts the historical starred item(s) regardless of what that live fetch returns.
+- [ ] A starred item for a brand-new feed is starred (and read, if applicable) immediately after import, without waiting on the feed-fetch to complete.

--- a/docs/plans/234-03-surface-unimportable-entries.md
+++ b/docs/plans/234-03-surface-unimportable-entries.md
@@ -1,0 +1,30 @@
+---
+status: proposed
+created: 2026-09-09
+issue: "https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234"
+milestone: ""
+owner: unassigned
+workstream: importers
+sequence: 3
+depends_on: ["234-01-import-starred-items-for-existing-feeds"]
+release_requirement: ""
+implementation: ""
+---
+
+# Surface unimportable entries with reasons
+
+Parent issue: [#234](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234).
+
+## What to build
+
+Some `starred.json` entries can't be imported at all: missing `origin.streamId` (no identifiable source feed) or missing both `canonical` and `alternate` href (no article URL). Rather than silently dropping these, the mapper from [234-01](234-01-import-starred-items-for-existing-feeds.md) classifies them into an `unimportable` list with a specific reason per entry, and the import UI shows an "unable to import" section listing each one with its title (if available) and reason.
+
+## Blocked by
+
+- 234-01-import-starred-items-for-existing-feeds
+
+## Acceptance criteria
+
+- [ ] The mapper returns an `unimportable` list alongside its candidates, each entry carrying enough identifying info (title if present, raw id) and a specific reason (`no_source_feed` / `no_article_url`).
+- [ ] The import preview/results UI renders an "unable to import" section listing these with their reasons — never a silent drop.
+- [ ] Mapper tests cover both cases against synthetic entries derived from the real exported fixture's shape.

--- a/docs/plans/234-04-map-labels-to-tags.md
+++ b/docs/plans/234-04-map-labels-to-tags.md
@@ -1,0 +1,31 @@
+---
+status: proposed
+created: 2026-09-09
+issue: "https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234"
+milestone: ""
+owner: unassigned
+workstream: importers
+sequence: 3
+depends_on: ["234-01-import-starred-items-for-existing-feeds"]
+release_requirement: ""
+implementation: ""
+---
+
+# Map Inoreader labels to tags
+
+Parent issue: [#234](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234).
+
+## What to build
+
+Extend the mapper from [234-01](234-01-import-starred-items-for-existing-feeds.md) to translate each starred item's `categories[]` into plugin tags: entries matching `.../label/X` become a `{name, color}` tag on the imported `FeedItem`; `.../state/com.google/starred` and `.../state/com.google/read` continue to only set the `starred`/`read` booleans (already handled in 234-01) and are never turned into tags; `.../state/com.google/reading-list` is ignored entirely. Any label name not already present in `settings.availableTags` is added there, using the same default-color assignment logic already used when a user creates a tag manually, so it appears immediately in the normal tag-filter UI.
+
+## Blocked by
+
+- 234-01-import-starred-items-for-existing-feeds
+
+## Acceptance criteria
+
+- [ ] `label/X` categories on a starred item become `Tag` entries on the resulting `FeedItem`.
+- [ ] System-state categories (`starred`, `read`, `reading-list`) never produce tags.
+- [ ] A label not already in `settings.availableTags` is added there with a color chosen via the plugin's existing default-tag-color logic (same as manual tag creation), not a hardcoded fixed color.
+- [ ] Mapper tests cover: an item with multiple labels, an item with no labels, and a label that already exists in `availableTags` (no duplicate palette entry created).

--- a/docs/plans/234-05-idempotent-reimport-dedup-merge.md
+++ b/docs/plans/234-05-idempotent-reimport-dedup-merge.md
@@ -1,0 +1,32 @@
+---
+status: proposed
+created: 2026-09-09
+issue: "https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234"
+milestone: ""
+owner: unassigned
+workstream: importers
+sequence: 4
+depends_on: ["234-01-import-starred-items-for-existing-feeds", "234-04-map-labels-to-tags"]
+release_requirement: ""
+implementation: ""
+---
+
+# Idempotent re-import (dedup + merge)
+
+Parent issue: [#234](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234).
+
+## What to build
+
+Make re-running the starred.json importer against the same or an updated export safe. Candidate items are matched against a target feed's existing `items` using the same canonicalized guid-or-link identity logic already used by feed-refresh merging (`canonicalizeItemIdentityUrl`). A match is treated as an update, not a new insert: any newly-present labels (from [234-04](234-04-map-labels-to-tags.md)) are merged into the article's existing tags, and `starred` is forced to `true` — but `read`, `saved`, `savedFilePath`, and any other locally-edited fields are left untouched.
+
+## Blocked by
+
+- 234-01-import-starred-items-for-existing-feeds
+- 234-04-map-labels-to-tags
+
+## Acceptance criteria
+
+- [ ] Re-importing an unchanged export produces zero duplicate articles.
+- [ ] Re-importing an export where a previously-imported item gained a new label results in that label being merged into the existing article's tags, without removing tags the user added locally.
+- [ ] Re-importing never overwrites `read`, `saved`, `savedFilePath`, or other locally-edited fields on an already-imported article.
+- [ ] Merge-function tests cover: brand-new item insertion, unchanged re-import (no-op), and re-import with an additional label/newly-starred state.

--- a/docs/plans/234-06-opt-in-full-content-fetch.md
+++ b/docs/plans/234-06-opt-in-full-content-fetch.md
@@ -1,0 +1,31 @@
+---
+status: proposed
+created: 2026-09-09
+issue: "https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234"
+milestone: ""
+owner: unassigned
+workstream: importers
+sequence: 3
+depends_on: ["234-01-import-starred-items-for-existing-feeds"]
+release_requirement: ""
+implementation: ""
+---
+
+# Opt-in full article content fetch
+
+Parent issue: [#234](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/234).
+
+## What to build
+
+Add a checkbox to the import review UI ("Fetch full article content"), off by default. When enabled, after the base import from [234-01](234-01-import-starred-items-for-existing-feeds.md) completes, run the existing `fetchFullArticleContentWithOutcome`/Readability/Turndown pipeline (the same one `ArticleSaver.saveArticleWithFullContent` uses) once per selected imported article. A per-article failure (removed page, paywall, network error) does not fail the whole import — it's recorded and shown in a results summary naming the article, linking to its original URL, and recommending the Obsidian Web Clipper browser extension as a manual fallback.
+
+## Blocked by
+
+- 234-01-import-starred-items-for-existing-feeds
+
+## Acceptance criteria
+
+- [ ] The review UI has an off-by-default "Fetch full article content" toggle.
+- [ ] When enabled, each selected imported article gets a full-content-fetch attempt via the existing pipeline, without duplicating its fetch/Readability/Turndown internals.
+- [ ] A per-article fetch failure is non-blocking and appears in a results summary with the article's URL and a note recommending the Obsidian Web Clipper extension.
+- [ ] When the toggle is off, no full-content fetch requests are made at all.

--- a/src/modals/import-opml-modal.ts
+++ b/src/modals/import-opml-modal.ts
@@ -284,12 +284,14 @@ export class ImportOpmlModal extends Modal {
     const list = this.previewContainer.createDiv({
       cls: "import-preview-list import-preview-tree",
     });
-    list.scrollTop = previousScrollTop;
 
     const tree = model.getFolderTree();
     for (const node of tree) {
       this.renderFolderNode(list, node, 0);
     }
+    // Browsers clamp scrollTop on an empty scroll container to zero. Restore it
+    // only after the rows are present so selection re-renders keep their place.
+    list.scrollTop = previousScrollTop;
   }
 
   private updateImportButtonFromModel(): void {

--- a/src/modals/import-opml-modal.ts
+++ b/src/modals/import-opml-modal.ts
@@ -599,6 +599,13 @@ export class ImportOpmlModal extends Modal {
     });
     checkbox.checked = selected;
     checkbox.disabled = duplicate;
+    if (duplicate) {
+      row.setAttr("title", "Already exists — unavailable in Update mode.");
+      checkbox.setAttr(
+        "aria-label",
+        `${feed.title}: already exists, unavailable in Update mode`,
+      );
+    }
     checkbox.addEventListener("change", () => {
       model.toggleFeed(url, checkbox.checked);
       this.updateSelectionPresentation();

--- a/src/modals/import-opml-modal.ts
+++ b/src/modals/import-opml-modal.ts
@@ -6,6 +6,7 @@ import { shouldUseMobileSidebarLayout } from "../utils/platform-utils";
 import type { OpmlImportPreviewFolderSnapshot } from "../services/opml-import-preview-model";
 import { OpmlImportPreviewModel } from "../services/opml-import-preview-model";
 import { isValidFeedTitle, isValidFolderName } from "../utils/validation";
+import { ImporterShell } from "./importer-shell";
 
 /**
  * Import OPML Modal - Provides a preview-based import experience
@@ -23,7 +24,6 @@ export class ImportOpmlModal extends Modal {
   private opmlContent: string | null = null;
   private parsedFeeds: Feed[] = [];
   private parsedFolders: Folder[] = [];
-  private validationError: string | null = null;
   private importMode: "update" | "overwrite" = "update";
   private validationErrorKind:
     | "invalid_extension"
@@ -35,12 +35,13 @@ export class ImportOpmlModal extends Modal {
     | null = null;
   private previewModel: OpmlImportPreviewModel | null = null;
   private collapsedFolderPaths = new Set<string>();
+  private readonly importerShell: ImporterShell<
+    { feeds: Feed[]; folders: Folder[] },
+    OpmlImportPreviewModel
+  >;
 
   // UI References
-  private filePathInput!: HTMLInputElement;
   private previewContainer!: HTMLDivElement;
-  private errorContainer!: HTMLDivElement;
-  private importButton!: HTMLButtonElement;
   private modeSelectorContainer!: HTMLDivElement;
 
   constructor(
@@ -51,6 +52,37 @@ export class ImportOpmlModal extends Modal {
     super(app);
     this.plugin = plugin;
     this.onImportStarted = onImportStarted;
+    this.importerShell = new ImporterShell({
+      acceptedFileTypes: ".opml,.xml,.backup",
+      validate: (content, file) => this.validateOpml(content, file),
+      parse: (content) => this.parseOpml(content),
+      createPreviewModel: (parsed) => {
+        if (parsed.feeds.length === 0) {
+          this.validationErrorKind = "no_feeds";
+          return null;
+        }
+        this.previewModel = new OpmlImportPreviewModel({
+          feeds: parsed.feeds,
+          folders: parsed.folders,
+          importMode: this.importMode,
+          existingUrls: new Set(this.plugin.settings.feeds.map((feed) => feed.url)),
+        });
+        return this.previewModel;
+      },
+      renderer: { render: () => this.renderPreview() },
+      execute: async () => this.performImport(),
+      onAction: () => {
+        if (this.importMode === "overwrite") {
+          this.showOverwriteWarning();
+        } else {
+          void this.importerShell.execute();
+        }
+      },
+      noItemsError: "No feeds found in the OPML file.",
+      renderError: (container, error) => this.renderOpmlError(container, error),
+      onPreviewVisibilityChange: (visible) => this.setModeSelectorVisibility(visible),
+      getActionState: (model) => this.getImportActionState(model),
+    });
   }
 
   onOpen() {
@@ -74,25 +106,6 @@ export class ImportOpmlModal extends Modal {
     subtitle.textContent =
       "Import feeds from an OPML file with preview and validation";
 
-    // File selector row
-    this.createFileSelector(contentEl);
-
-    // Error container (hidden by default)
-    this.errorContainer = contentEl.createDiv({
-      cls: "import-error-container import-hidden",
-    });
-
-    // Preview container (hidden by default)
-    this.previewContainer = contentEl.createDiv({
-      cls: "import-preview-container import-hidden",
-    });
-
-    // Import mode selector (hidden by default)
-    this.modeSelectorContainer = contentEl.createDiv({
-      cls: "import-mode-selector import-hidden",
-    });
-    this.createModeSelector(this.modeSelectorContainer);
-
     // Button container
     const buttonContainer = contentEl.createDiv({
       cls: "rss-dashboard-modal-buttons",
@@ -103,78 +116,32 @@ export class ImportOpmlModal extends Modal {
     });
     cancelButton.onclick = () => this.close();
 
-    this.importButton = buttonContainer.createEl("button", {
-      text: "Import feeds",
-      cls: "rss-dashboard-primary-button",
+    this.importerShell.mount(contentEl, buttonContainer);
+    this.previewContainer = contentEl.querySelector<HTMLDivElement>(
+      ".import-preview-container",
+    )!;
+    this.modeSelectorContainer = contentEl.createDiv({
+      cls: "import-mode-selector import-hidden",
     });
-    this.importButton.disabled = true;
-    this.importButton.onclick = () => {
-      if (this.importMode === "overwrite") {
-        this.showOverwriteWarning();
-      } else {
-        void this.executeImport();
-      }
-    };
+    buttonContainer.parentElement?.insertBefore(
+      this.modeSelectorContainer,
+      buttonContainer,
+    );
+    this.createModeSelector(this.modeSelectorContainer);
   }
 
-  private createFileSelector(contentEl: HTMLElement) {
-    const fileSelector = contentEl.createDiv({
-      cls: "import-file-selector",
-    });
-
-    // File path input (disabled, shows selected file path)
-    this.filePathInput = fileSelector.createEl("input", {
-      type: "text",
-      cls: "import-file-path-input",
-      attr: {
-        placeholder: "No file selected...",
-        disabled: "true",
-      },
-    });
-
-    // Import file button
-    const fileButton = fileSelector.createEl("button", {
-      cls: "import-file-button",
-    });
-    setIcon(fileButton, "folder-open");
-    fileButton.createSpan({ text: " Import file..." });
-    fileButton.onclick = () => this.openFilePicker();
-  }
-
-  private openFilePicker() {
-    const input = activeDocument.body.createEl("input", {
-      attr: { type: "file", accept: ".opml,.xml,.backup" },
-    });
-    input.onchange = async () => {
-      const file = input.files?.[0];
-      if (file) {
-        await this.handleFileSelection(file);
-      }
-      input.remove();
-    };
-    input.click();
-  }
   private async handleFileSelection(file: File) {
     this.selectedFile = file;
-    this.filePathInput.value = file.name;
-
-    // Clear previous state
-    this.validationError = null;
     this.validationErrorKind = null;
     this.parsedFeeds = [];
     this.parsedFolders = [];
     this.opmlContent = null;
     this.previewModel = null;
     this.collapsedFolderPaths.clear();
-
-    // Validate and parse
-    await this.validateAndParseFile(file);
-
-    // Update UI
-    this.updateUI();
+    await this.importerShell.handleFileSelection(file);
   }
 
-  private async validateAndParseFile(file: File): Promise<void> {
+  private validateOpml(content: string, file: File) {
     // Check file extension
     const fileName = file.name.toLowerCase();
     if (
@@ -182,14 +149,12 @@ export class ImportOpmlModal extends Modal {
       !fileName.endsWith(".xml") &&
       !fileName.endsWith(".backup")
     ) {
-      this.validationError =
-        "Please select a valid OPML or XML file (.opml, .xml, or .backup extension required)";
       this.validationErrorKind = "invalid_extension";
-      return;
+      return {
+        valid: false as const,
+        error: "Please select a valid OPML or XML file (.opml, .xml, or .backup extension required)",
+      };
     }
-
-    try {
-      const content = await file.text();
 
       // Basic XML validation
       const parser = new DOMParser();
@@ -198,112 +163,36 @@ export class ImportOpmlModal extends Modal {
       // Check for parsing errors
       const parseError = xmlDoc.querySelector("parsererror");
       if (parseError) {
-        this.validationError =
-          "This is not a valid OPML file. The file contains invalid XML.";
         this.validationErrorKind = "invalid_xml";
-        return;
+        return { valid: false as const, error: "This is not a valid OPML file. The file contains invalid XML." };
       }
 
       // Check for OPML structure
       const opmlRoot = xmlDoc.querySelector("opml");
       if (!opmlRoot) {
-        this.validationError =
-          "This is not a valid OPML file. Missing OPML root element.";
         this.validationErrorKind = "missing_opml";
-        return;
+        return { valid: false as const, error: "This is not a valid OPML file. Missing OPML root element." };
       }
 
       const body = xmlDoc.querySelector("body");
       if (!body) {
-        this.validationError =
-          "This is not a valid OPML file. Missing body element.";
         this.validationErrorKind = "missing_body";
-        return;
+        return { valid: false as const, error: "This is not a valid OPML file. Missing body element." };
       }
 
-      // Parse the valid OPML
-      try {
-        const result = OpmlManager.parseOpml(content);
-        this.parsedFeeds = result.feeds;
-        this.parsedFolders = result.folders;
-        this.opmlContent = content;
-        this.validationError = null;
-        this.validationErrorKind = null;
-
-        const existingUrls = new Set(
-          this.plugin.settings.feeds.map((f) => f.url),
-        );
-        this.previewModel = new OpmlImportPreviewModel({
-          feeds: this.parsedFeeds,
-          folders: this.parsedFolders,
-          importMode: this.importMode,
-          existingUrls,
-        });
-      } catch (error) {
-        this.validationError = `Failed to parse OPML: ${error instanceof Error ? error.message : "Unknown error"}`;
-        this.validationErrorKind = "parse_failed";
-        return;
-      }
-    } catch (error) {
-      this.validationError = `Error reading file: ${error instanceof Error ? error.message : "Unknown error"}`;
-      this.validationErrorKind = "parse_failed";
-    }
+    return { valid: true as const };
   }
 
-  private updateUI() {
-    // Update error container
-    if (this.validationError) {
-      this.errorContainer.removeClass("import-hidden");
-      this.errorContainer.addClass("import-visible");
-      this.errorContainer.empty();
-      const errorDiv = this.errorContainer.createDiv({
-        cls: "import-error-message",
-      });
-      errorDiv.textContent = this.validationError;
-
-      if (
-        this.validationErrorKind === "invalid_xml" ||
-        this.validationErrorKind === "missing_opml" ||
-        this.validationErrorKind === "missing_body" ||
-        this.validationErrorKind === "parse_failed"
-      ) {
-        this.renderOpmlCleanerSuggestion(this.errorContainer);
-      }
-
-      // Hide preview and mode selector
-      this.previewContainer.removeClass("import-visible");
-      this.previewContainer.addClass("import-hidden");
-      this.modeSelectorContainer.removeClass("import-visible");
-      this.modeSelectorContainer.addClass("import-hidden");
-      this.importButton.disabled = true;
-    } else if (this.parsedFeeds.length > 0 && this.previewModel) {
-      // Hide error
-      this.errorContainer.removeClass("import-visible");
-      this.errorContainer.addClass("import-hidden");
-
-      // Show preview
-      this.renderPreview();
-
-      // Show mode selector
-      this.modeSelectorContainer.removeClass("import-hidden");
-      this.modeSelectorContainer.addClass("import-visible");
-
-      this.updateImportButtonFromModel();
-    } else {
-      // No feeds found
-      this.errorContainer.removeClass("import-hidden");
-      this.errorContainer.addClass("import-visible");
-      this.errorContainer.empty();
-      const errorDiv = this.errorContainer.createDiv({
-        cls: "import-error-message",
-      });
-      errorDiv.textContent = "No feeds found in the OPML file.";
-      this.validationErrorKind = "no_feeds";
-      this.previewContainer.removeClass("import-visible");
-      this.previewContainer.addClass("import-hidden");
-      this.modeSelectorContainer.removeClass("import-visible");
-      this.modeSelectorContainer.addClass("import-hidden");
-      this.importButton.disabled = true;
+  private parseOpml(content: string): { feeds: Feed[]; folders: Folder[] } {
+    try {
+      const result = OpmlManager.parseOpml(content);
+      this.parsedFeeds = result.feeds;
+      this.parsedFolders = result.folders;
+      this.opmlContent = content;
+      return result;
+    } catch (error) {
+      this.validationErrorKind = "parse_failed";
+      throw new Error(`Failed to parse OPML: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }
 
@@ -404,30 +293,46 @@ export class ImportOpmlModal extends Modal {
   }
 
   private updateImportButtonFromModel(): void {
-    if (!this.previewModel) {
-      this.importButton.disabled = true;
-      this.importButton.textContent = "Import feeds";
-      return;
-    }
+    this.importerShell.updateAction();
+  }
 
-    const stats = this.previewModel.getStats();
+  private getImportActionState(model: OpmlImportPreviewModel | null): {
+    text: string;
+    disabled: boolean;
+    title?: string;
+  } {
+    if (!model) return { text: "Import feeds", disabled: true };
+
+    const stats = model.getStats();
     const count = stats.selectedImportableFeeds;
-
-    this.importButton.textContent =
-      count === 1 ? "Import 1 feed" : `Import ${count} feeds`;
-    this.importButton.disabled = count === 0 || stats.hasBlockingErrors;
-    this.importButton.classList.toggle(
-      "is-disabled",
-      this.importButton.disabled,
-    );
-
     if (stats.hasBlockingErrors) {
-      this.importButton.title =
-        "Fix invalid names (or unselect them) to import.";
-    } else if (count === 0) {
-      this.importButton.title = "Select at least one feed to import.";
-    } else {
-      this.importButton.title = "";
+      return {
+        text: count === 1 ? "Import 1 feed" : `Import ${count} feeds`,
+        disabled: true,
+        title: "Fix invalid names (or unselect them) to import.",
+      };
+    }
+    return {
+      text: count === 1 ? "Import 1 feed" : `Import ${count} feeds`,
+      disabled: count === 0,
+      title: count === 0 ? "Select at least one feed to import." : "",
+    };
+  }
+
+  private setModeSelectorVisibility(visible: boolean): void {
+    this.modeSelectorContainer.toggleClass("import-hidden", !visible);
+    this.modeSelectorContainer.toggleClass("import-visible", visible);
+  }
+
+  private renderOpmlError(container: HTMLElement, error: string): void {
+    container.createDiv({ cls: "import-error-message", text: error });
+    if (
+      this.validationErrorKind === "invalid_xml" ||
+      this.validationErrorKind === "missing_opml" ||
+      this.validationErrorKind === "missing_body" ||
+      this.validationErrorKind === "parse_failed"
+    ) {
+      this.renderOpmlCleanerSuggestion(container);
     }
   }
 
@@ -917,6 +822,10 @@ export class ImportOpmlModal extends Modal {
   }
 
   private async executeImport() {
+    await this.importerShell.execute();
+  }
+
+  private async performImport() {
     if (!this.previewModel) {
       return;
     }

--- a/src/modals/import-opml-modal.ts
+++ b/src/modals/import-opml-modal.ts
@@ -430,6 +430,7 @@ export class ImportOpmlModal extends Modal {
     const folderRow = listEl.createDiv({
       cls: "import-preview-row import-preview-row--folder",
     });
+    folderRow.dataset.folderPath = node.path;
     folderRow.style.setProperty("--import-indent", `${depth * 14}px`);
 
     const checkbox = folderRow.createEl("input", {
@@ -446,8 +447,7 @@ export class ImportOpmlModal extends Modal {
 
     checkbox.addEventListener("change", () => {
       model.toggleFolder(node.path, checkbox.checked);
-      this.renderPreview();
-      this.updateImportButtonFromModel();
+      this.updateSelectionPresentation();
     });
 
     const icon = folderRow.createDiv({ cls: "import-preview-icon" });
@@ -590,6 +590,7 @@ export class ImportOpmlModal extends Modal {
     const row = listEl.createDiv({
       cls: "import-preview-row import-preview-row--feed",
     });
+    row.dataset.feedUrl = url;
     row.style.setProperty("--import-indent", `${depth * 14}px`);
 
     const checkbox = row.createEl("input", {
@@ -600,8 +601,7 @@ export class ImportOpmlModal extends Modal {
     checkbox.disabled = duplicate;
     checkbox.addEventListener("change", () => {
       model.toggleFeed(url, checkbox.checked);
-      this.renderPreview();
-      this.updateImportButtonFromModel();
+      this.updateSelectionPresentation();
     });
 
     const icon = row.createDiv({ cls: "import-preview-icon" });
@@ -687,6 +687,85 @@ export class ImportOpmlModal extends Modal {
 
     // Keep grid alignment: empty toggle cell
     row.createDiv({ cls: "import-preview-toggle-spacer" });
+  }
+
+  private updateSelectionPresentation(): void {
+    const model = this.previewModel;
+    if (!model) return;
+
+    const primaryBadge = this.previewContainer.querySelector<HTMLElement>(
+      ".import-preview-count--primary",
+    );
+    if (primaryBadge) {
+      primaryBadge.textContent = `${model.getStats().selectedImportableFeeds} to import`;
+    }
+
+    const folderUrls = new Map<string, string[]>();
+    const collectFolderUrls = (
+      nodes: OpmlImportPreviewFolderSnapshot[],
+    ): string[] => {
+      const collected: string[] = [];
+      for (const node of nodes) {
+        const urls = [
+          ...node.feedUrls,
+          ...collectFolderUrls(node.children ?? []),
+        ];
+        folderUrls.set(node.path, urls);
+        collected.push(...urls);
+      }
+      return collected;
+    };
+    collectFolderUrls(model.getFolderTree());
+
+    this.previewContainer
+      .querySelectorAll<HTMLElement>(".import-preview-row--folder")
+      .forEach((row) => {
+        const path = row.dataset.folderPath;
+        if (!path) return;
+        const checkbox = row.querySelector<HTMLInputElement>(
+          ".import-preview-checkbox",
+        );
+        const meta = row.querySelector<HTMLElement>(".import-preview-meta");
+        const selection = model.getFolderSelectionState(path);
+        if (checkbox) {
+          checkbox.checked = selection.checked;
+          checkbox.indeterminate = selection.indeterminate;
+        }
+        const urls = folderUrls.get(path) ?? [];
+        if (meta) {
+          const selectedCount = urls.filter(
+            (url) => model.getFeedState(url).selected,
+          ).length;
+          meta.textContent = `${selectedCount}/${urls.length}`;
+        }
+      });
+
+    this.previewContainer
+      .querySelectorAll<HTMLElement>(".import-preview-row--feed")
+      .forEach((row) => {
+        const url = row.dataset.feedUrl;
+        if (!url) return;
+        const { feed, selected, duplicate } = model.getFeedState(url);
+        const checkbox = row.querySelector<HTMLInputElement>(
+          ".import-preview-checkbox",
+        );
+        if (checkbox) checkbox.checked = selected;
+        const titleValidation = isValidFeedTitle(feed.title);
+        row.classList.toggle(
+          "is-invalid",
+          !titleValidation.valid && selected && !duplicate,
+        );
+        const meta = row.querySelector<HTMLElement>(".import-preview-meta");
+        if (meta) {
+          meta.textContent = duplicate
+            ? "Already exists"
+            : !titleValidation.valid && selected
+              ? "Needs fix"
+              : "";
+        }
+      });
+
+    this.updateImportButtonFromModel();
   }
 
   private createModeSelector(container: HTMLElement) {

--- a/src/modals/importer-shell.ts
+++ b/src/modals/importer-shell.ts
@@ -1,0 +1,195 @@
+import { setIcon } from "obsidian";
+
+export type ImporterShellState =
+  | "idle"
+  | "validating"
+  | "preview"
+  | "executing"
+  | "done"
+  | "error";
+
+export type ImporterShellValidation =
+  | { valid: true }
+  | { valid: false; error: string };
+
+export interface ImporterPreviewModel {
+  getStats(): unknown;
+}
+
+export interface ImporterPreviewRenderer<TModel extends ImporterPreviewModel> {
+  render(container: HTMLElement, model: TModel, controls: {
+    rerender: () => void;
+    updateAction: () => void;
+  }): void;
+}
+
+export interface ImporterShellOptions<TParsed, TModel extends ImporterPreviewModel> {
+  acceptedFileTypes: string;
+  validate: (content: string, file: File) => ImporterShellValidation;
+  parse: (content: string) => TParsed;
+  createPreviewModel: (parsed: TParsed) => TModel | null;
+  renderer: ImporterPreviewRenderer<TModel>;
+  execute: (model: TModel) => Promise<void>;
+  onAction?: () => void;
+  noItemsError?: string;
+  renderError?: (container: HTMLElement, error: string) => void;
+  onPreviewVisibilityChange?: (visible: boolean) => void;
+  getActionState: (model: TModel | null) => {
+    text: string;
+    disabled: boolean;
+    title?: string;
+  };
+}
+
+/**
+ * Format-agnostic file import lifecycle and shared preview chrome.
+ * Format-specific validation, parsing, preview behavior, and execution are
+ * supplied by the importer that composes this shell.
+ */
+export class ImporterShell<TParsed, TModel extends ImporterPreviewModel> {
+  private readonly options: ImporterShellOptions<TParsed, TModel>;
+  private filePathInput!: HTMLInputElement;
+  private errorContainer!: HTMLDivElement;
+  private previewContainer!: HTMLDivElement;
+  private actionButton!: HTMLButtonElement;
+  private model: TModel | null = null;
+
+  state: ImporterShellState = "idle";
+  selectedFile: File | null = null;
+
+  constructor(options: ImporterShellOptions<TParsed, TModel>) {
+    this.options = options;
+  }
+
+  mount(contentEl: HTMLElement, buttonContainer: HTMLElement): void {
+    const fileSelector = contentEl.createDiv({ cls: "import-file-selector" });
+    this.filePathInput = fileSelector.createEl("input", {
+      type: "text",
+      cls: "import-file-path-input",
+      attr: { placeholder: "No file selected...", disabled: "true" },
+    });
+
+    const fileButton = fileSelector.createEl("button", { cls: "import-file-button" });
+    setIcon(fileButton, "folder-open");
+    fileButton.createSpan({ text: " Import file..." });
+    fileButton.onclick = () => this.openFilePicker();
+
+    this.errorContainer = contentEl.createDiv({
+      cls: "import-error-container import-hidden",
+    });
+    this.previewContainer = contentEl.createDiv({
+      cls: "import-preview-container import-hidden",
+    });
+    this.actionButton = buttonContainer.createEl("button", {
+      text: "Import feeds",
+      cls: "rss-dashboard-primary-button",
+    });
+    this.actionButton.disabled = true;
+    this.actionButton.onclick = () => {
+      if (this.options.onAction) {
+        this.options.onAction();
+        return;
+      }
+      void this.execute();
+    };
+  }
+
+  async handleFileSelection(file: File): Promise<void> {
+    this.selectedFile = file;
+    this.filePathInput.value = file.name;
+    this.model = null;
+    this.state = "validating";
+
+    try {
+      const content = await file.text();
+      const validation = this.options.validate(content, file);
+      if (!validation.valid) {
+        this.showError(validation.error);
+        return;
+      }
+      this.model = this.options.createPreviewModel(this.options.parse(content));
+      if (!this.model) {
+        this.showError(this.options.noItemsError ?? "No items found in the import file.");
+        return;
+      }
+      this.state = "preview";
+      this.renderPreview();
+    } catch (error) {
+      this.showError(error instanceof Error ? error.message : "Unable to import file.");
+    }
+  }
+
+  async execute(): Promise<void> {
+    if (!this.model || this.state !== "preview") return;
+    this.state = "executing";
+    this.updateAction();
+    try {
+      await this.options.execute(this.model);
+      this.state = "done";
+    } catch (error) {
+      this.state = "preview";
+      this.updateAction();
+      throw error;
+    }
+  }
+
+  getPreviewModel(): TModel | null {
+    return this.model;
+  }
+
+  refreshPreview(): void {
+    if (this.model) this.renderPreview();
+  }
+
+  updateAction(): void {
+    const action = this.options.getActionState(this.model);
+    this.actionButton.textContent = action.text;
+    this.actionButton.disabled = action.disabled || this.state === "executing";
+    this.actionButton.classList.toggle("is-disabled", this.actionButton.disabled);
+    this.actionButton.title = action.title ?? "";
+  }
+
+  private openFilePicker(): void {
+    const input = activeDocument.body.createEl("input", {
+      attr: { type: "file", accept: this.options.acceptedFileTypes },
+    });
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (file) await this.handleFileSelection(file);
+      input.remove();
+    };
+    input.click();
+  }
+
+  private renderPreview(): void {
+    const model = this.model;
+    if (!model) return;
+    this.errorContainer.removeClass("import-visible");
+    this.errorContainer.addClass("import-hidden");
+    this.previewContainer.removeClass("import-hidden");
+    this.previewContainer.addClass("import-visible");
+    this.previewContainer.empty();
+    this.options.onPreviewVisibilityChange?.(true);
+    this.options.renderer.render(this.previewContainer, model, {
+      rerender: () => this.refreshPreview(),
+      updateAction: () => this.updateAction(),
+    });
+    this.updateAction();
+  }
+
+  private showError(error: string): void {
+    this.state = "error";
+    this.errorContainer.removeClass("import-hidden");
+    this.errorContainer.addClass("import-visible");
+    this.errorContainer.empty();
+    if (this.options.renderError) {
+      this.options.renderError(this.errorContainer, error);
+    } else {
+      this.errorContainer.createDiv({ cls: "import-error-message", text: error });
+    }
+    this.previewContainer.removeClass("import-visible");
+    this.previewContainer.addClass("import-hidden");
+    this.options.onPreviewVisibilityChange?.(false);
+    this.updateAction();
+  }
+}

--- a/src/modals/importer-shell.ts
+++ b/src/modals/importer-shell.ts
@@ -80,6 +80,10 @@ export class ImporterShell<TParsed, TModel extends ImporterPreviewModel> {
     this.previewContainer = contentEl.createDiv({
       cls: "import-preview-container import-hidden",
     });
+    // The modal creates its action row first so it can add format-specific
+    // controls. Move it after the shell content to preserve the established
+    // file selector -> preview -> format controls -> actions reading order.
+    contentEl.appendChild(buttonContainer);
     this.actionButton = buttonContainer.createEl("button", {
       text: "Import feeds",
       cls: "rss-dashboard-primary-button",

--- a/src/services/opml-import-preview-model.ts
+++ b/src/services/opml-import-preview-model.ts
@@ -95,7 +95,11 @@ export class OpmlImportPreviewModel {
       const normalizedFolder = feed.folder?.trim() ? feed.folder.trim() : UNCATEGORIZED_FOLDER;
       const duplicate = this.importMode === "update" && args.existingUrls.has(feed.url);
       const normalizedFeed: Feed = { ...feed, folder: normalizedFolder };
-      this.feedByUrl.set(feed.url, { feed: normalizedFeed, selected: true, duplicate });
+      this.feedByUrl.set(feed.url, {
+        feed: normalizedFeed,
+        selected: !duplicate,
+        duplicate,
+      });
     }
 
     this.ensureFolderNodesForFeeds();
@@ -105,7 +109,13 @@ export class OpmlImportPreviewModel {
   setImportMode(importMode: ImportMode, existingUrls: Set<string>): void {
     this.importMode = importMode;
     for (const state of this.feedByUrl.values()) {
+      const wasDuplicate = state.duplicate;
       state.duplicate = this.importMode === "update" && existingUrls.has(state.feed.url);
+      if (state.duplicate) {
+        state.selected = false;
+      } else if (wasDuplicate) {
+        state.selected = true;
+      }
     }
   }
 
@@ -178,7 +188,7 @@ export class OpmlImportPreviewModel {
 
   toggleFeed(url: string, selected: boolean): void {
     const state = this.feedByUrl.get(url);
-    if (!state) return;
+    if (!state || state.duplicate) return;
     state.selected = selected;
   }
 
@@ -206,7 +216,7 @@ export class OpmlImportPreviewModel {
     const urls = this.collectDescendantFeedUrls(node);
     for (const url of urls) {
       const state = this.feedByUrl.get(url);
-      if (state) state.selected = selected;
+      if (state && !state.duplicate) state.selected = selected;
     }
   }
 

--- a/src/styles/import-opml-modal.css
+++ b/src/styles/import-opml-modal.css
@@ -425,6 +425,10 @@
   margin: 0;
 }
 
+.rss-dashboard-modal .import-preview-checkbox:checked::after {
+  translate: 1px 0;
+}
+
 .import-preview-icon {
   display: flex;
   align-items: center;

--- a/src/styles/import-opml-modal.css
+++ b/src/styles/import-opml-modal.css
@@ -421,6 +421,7 @@
    ============================================ */
 
 .import-preview-checkbox {
+  justify-self: center;
   margin: 0;
 }
 

--- a/src/styles/import-opml-modal.css
+++ b/src/styles/import-opml-modal.css
@@ -429,6 +429,15 @@
   translate: 1px 0;
 }
 
+.rss-dashboard-modal .import-preview-row.is-duplicate,
+.rss-dashboard-modal .import-preview-row.is-duplicate .import-preview-checkbox {
+  cursor: not-allowed;
+}
+
+.rss-dashboard-modal .import-preview-row.is-duplicate .import-preview-checkbox {
+  pointer-events: none;
+}
+
 .import-preview-icon {
   display: flex;
   align-items: center;

--- a/test_files/unit/modals/import-opml-modal.test.ts
+++ b/test_files/unit/modals/import-opml-modal.test.ts
@@ -354,41 +354,25 @@ expect(plugin.ingestFeedsForBackgroundImport).toHaveBeenCalledWith(
       }),
     );
 
-    // Browsers clamp an empty scroll container's scrollTop to zero; jsdom does not.
-    const originalScrollTop = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      "scrollTop",
-    );
-    const positions = new WeakMap<HTMLElement, number>();
-    Object.defineProperty(HTMLElement.prototype, "scrollTop", {
-      configurable: true,
-      get(this: HTMLElement) {
-        return positions.get(this) ?? 0;
-      },
-      set(this: HTMLElement, value: number) {
-        positions.set(
-          this,
-          this.querySelectorAll(".import-preview-row").length === 0 ? 0 : value,
-        );
-      },
-    });
+    const before = document.querySelector<HTMLDivElement>(".import-preview-list")!;
+    before.scrollTop = 72;
+    const checkbox = document.querySelector<HTMLInputElement>(
+      ".import-preview-row--feed .import-preview-checkbox",
+    )!;
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event("change"));
 
-    try {
-      const before = document.querySelector<HTMLDivElement>(".import-preview-list")!;
-      before.scrollTop = 72;
-      const checkbox = document.querySelector<HTMLInputElement>(
-        ".import-preview-row--feed .import-preview-checkbox",
-      )!;
-      checkbox.checked = false;
-      checkbox.dispatchEvent(new Event("change"));
+    const after = document.querySelector<HTMLDivElement>(".import-preview-list")!;
+    expect(after).toBe(before);
+    expect(after.scrollTop).toBe(72);
 
-      expect(document.querySelector<HTMLDivElement>(".import-preview-list")?.scrollTop).toBe(72);
-    } finally {
-      if (originalScrollTop) {
-        Object.defineProperty(HTMLElement.prototype, "scrollTop", originalScrollTop);
-      } else {
-        delete (HTMLElement.prototype as { scrollTop?: number }).scrollTop;
-      }
-    }
+    const folderCheckbox = document.querySelector<HTMLInputElement>(
+      ".import-preview-row--folder .import-preview-checkbox",
+    )!;
+    folderCheckbox.checked = false;
+    folderCheckbox.dispatchEvent(new Event("change"));
+
+    expect(document.querySelector(".import-preview-list")).toBe(before);
+    expect(before.scrollTop).toBe(72);
   });
 });

--- a/test_files/unit/modals/import-opml-modal.test.ts
+++ b/test_files/unit/modals/import-opml-modal.test.ts
@@ -151,6 +151,46 @@ describe("ImportOpmlModal", () => {
     expect(plugin.saveSettings).toHaveBeenCalledTimes(0);
   });
 
+  it("presents an existing feed as unavailable in update mode", async () => {
+    const app = createMockApp();
+    const settings = cloneSettings();
+    settings.feeds = [
+      {
+        title: "Existing",
+        url: "https://example.com/feed.xml",
+        folder: "Tech",
+        items: [],
+        lastUpdated: 0,
+      },
+    ];
+    const plugin: TestPlugin = {
+      settings,
+      saveSettings: vi.fn(async () => {}),
+      getActiveDashboardView: vi.fn(async () => null),
+      startBackgroundImport: vi.fn(),
+    } as unknown as TestPlugin;
+    const modal = new ImportOpmlModal(
+      app,
+      plugin as unknown as ConstructorParameters<typeof ImportOpmlModal>[1],
+    );
+    (modal as unknown as TestModal).open();
+    await (modal as unknown as TestModal).handleFileSelection(
+      new File([readFixture("single-feed.opml")], "single-feed.opml", {
+        type: "text/xml",
+      }),
+    );
+
+    const row = modal.contentEl.querySelector<HTMLElement>(
+      ".import-preview-row--feed.is-duplicate",
+    )!;
+    const checkbox = row.querySelector<HTMLInputElement>(
+      ".import-preview-checkbox",
+    )!;
+    expect(checkbox.disabled).toBe(true);
+    expect(checkbox.checked).toBe(false);
+    expect(row.title).toBe("Already exists — unavailable in Update mode.");
+  });
+
   it("imports a valid OPML file in update mode and persists once", async () => {
     const app = createMockApp();
     const settings = cloneSettings();

--- a/test_files/unit/modals/import-opml-modal.test.ts
+++ b/test_files/unit/modals/import-opml-modal.test.ts
@@ -329,4 +329,66 @@ expect(plugin.ingestFeedsForBackgroundImport).toHaveBeenCalledWith(
       expect.objectContaining({ mode: "overwrite" }),
     );
   });
+
+  it("preserves preview scroll position when changing a feed selection", async () => {
+    const app = createMockApp();
+    const plugin: TestPlugin = {
+      settings: cloneSettings(),
+      saveSettings: vi.fn(async () => {}),
+      getActiveDashboardView: vi.fn(async () => null),
+      startBackgroundImport: vi.fn(),
+      ingestFeedsForBackgroundImport: vi.fn(async () => ({
+        addedCount: 1,
+        skippedCount: 0,
+        queuedFeeds: [],
+      })),
+    } as unknown as TestPlugin;
+    const modal = new ImportOpmlModal(
+      app,
+      plugin as unknown as ConstructorParameters<typeof ImportOpmlModal>[1],
+    );
+    (modal as unknown as TestModal).open();
+    await (modal as unknown as TestModal).handleFileSelection(
+      new File([readFixture("nested-folders.opml")], "nested-folders.opml", {
+        type: "text/xml",
+      }),
+    );
+
+    // Browsers clamp an empty scroll container's scrollTop to zero; jsdom does not.
+    const originalScrollTop = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollTop",
+    );
+    const positions = new WeakMap<HTMLElement, number>();
+    Object.defineProperty(HTMLElement.prototype, "scrollTop", {
+      configurable: true,
+      get(this: HTMLElement) {
+        return positions.get(this) ?? 0;
+      },
+      set(this: HTMLElement, value: number) {
+        positions.set(
+          this,
+          this.querySelectorAll(".import-preview-row").length === 0 ? 0 : value,
+        );
+      },
+    });
+
+    try {
+      const before = document.querySelector<HTMLDivElement>(".import-preview-list")!;
+      before.scrollTop = 72;
+      const checkbox = document.querySelector<HTMLInputElement>(
+        ".import-preview-row--feed .import-preview-checkbox",
+      )!;
+      checkbox.checked = false;
+      checkbox.dispatchEvent(new Event("change"));
+
+      expect(document.querySelector<HTMLDivElement>(".import-preview-list")?.scrollTop).toBe(72);
+    } finally {
+      if (originalScrollTop) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTop", originalScrollTop);
+      } else {
+        delete (HTMLElement.prototype as { scrollTop?: number }).scrollTop;
+      }
+    }
+  });
 });

--- a/test_files/unit/modals/import-opml-modal.test.ts
+++ b/test_files/unit/modals/import-opml-modal.test.ts
@@ -33,6 +33,10 @@ interface TestModal {
   executeImport: () => Promise<void>;
 }
 
+interface ModalElements {
+  containerEl: HTMLElement;
+}
+
 function readFixture(name: string): string {
   const fixturePath = path.resolve(__dirname, "../../fixtures/opml", name);
   return readFileSync(fixturePath, "utf-8");
@@ -62,6 +66,34 @@ beforeEach(() => {
 });
 
 describe("ImportOpmlModal", () => {
+  it("keeps the original file, preview, mode, and action reading order", () => {
+    const app = createMockApp();
+    const plugin: TestPlugin = {
+      settings: cloneSettings(),
+      saveSettings: vi.fn(async () => {}),
+      getActiveDashboardView: vi.fn(async () => null),
+      startBackgroundImport: vi.fn(),
+    } as unknown as TestPlugin;
+    const modal = new ImportOpmlModal(
+      app,
+      plugin as unknown as ConstructorParameters<typeof ImportOpmlModal>[1],
+    );
+    (modal as unknown as TestModal).open();
+
+    const content = (modal as unknown as TestModal).contentEl;
+    const children = Array.from(content.children);
+    const file = content.querySelector(".import-file-selector")!;
+    const error = content.querySelector(".import-error-container")!;
+    const preview = content.querySelector(".import-preview-container")!;
+    const mode = content.querySelector(".import-mode-selector")!;
+    const actions = content.querySelector(".rss-dashboard-modal-buttons")!;
+
+    expect(children.indexOf(file)).toBeLessThan(children.indexOf(error));
+    expect(children.indexOf(error)).toBeLessThan(children.indexOf(preview));
+    expect(children.indexOf(preview)).toBeLessThan(children.indexOf(mode));
+    expect(children.indexOf(mode)).toBeLessThan(children.indexOf(actions));
+  });
+
   it("shows a validation error for invalid XML and keeps import disabled", async () => {
     const app = createMockApp();
     const plugin: TestPlugin = {
@@ -164,10 +196,11 @@ describe("ImportOpmlModal", () => {
     ) as HTMLButtonElement;
     expect(importBtn.disabled).toBe(false);
 
-    await (modal as unknown as TestModal).executeImport();
-    await flushPromises();
+    importBtn.click();
+    await vi.waitFor(() => {
+      expect(plugin.ingestFeedsForBackgroundImport).toHaveBeenCalledTimes(1);
+    });
 
-    expect(plugin.ingestFeedsForBackgroundImport).toHaveBeenCalledTimes(1);
     expect(plugin.ingestFeedsForBackgroundImport).toHaveBeenCalledWith(
       [
         expect.objectContaining({
@@ -177,6 +210,48 @@ describe("ImportOpmlModal", () => {
       expect.objectContaining({ mode: "update", globalOperation: true }),
     );
     expect(logSpy.mock.calls.some((c) => c[0] === "[Stub Notice]")).toBe(true);
+    expect((modal as unknown as ModalElements).containerEl.isConnected).toBe(false);
+  });
+
+  it("dismisses the overwrite warning and importer after confirming", async () => {
+    const app = createMockApp();
+    const plugin: TestPlugin = {
+      settings: cloneSettings(),
+      saveSettings: vi.fn(async () => {}),
+      getActiveDashboardView: vi.fn(async () => null),
+      startBackgroundImport: vi.fn(),
+      ingestFeedsForBackgroundImport: vi.fn(async () => ({
+        addedCount: 1,
+        skippedCount: 0,
+        queuedFeeds: [],
+      })),
+    } as unknown as TestPlugin;
+    const modal = new ImportOpmlModal(
+      app,
+      plugin as unknown as ConstructorParameters<typeof ImportOpmlModal>[1],
+    );
+    (modal as unknown as TestModal).open();
+    await (modal as unknown as TestModal).handleFileSelection(
+      new File([readFixture("single-feed.opml")], "single-feed.opml", {
+        type: "text/xml",
+      }),
+    );
+
+    const modeOptions = modal.contentEl.querySelectorAll<HTMLElement>(
+      ".import-mode-option",
+    );
+    modeOptions[1].click();
+    modal.contentEl
+      .querySelector<HTMLButtonElement>("button.rss-dashboard-primary-button")!
+      .click();
+    document
+      .querySelector<HTMLButtonElement>(".rss-dashboard-danger-button")!
+      .click();
+
+    await vi.waitFor(() => {
+      expect((modal as unknown as ModalElements).containerEl.isConnected).toBe(false);
+      expect(document.querySelector(".rss-dashboard-modal-overlay")).toBeNull();
+    });
   });
 
   it("calls the optional callback after a successful import starts", async () => {

--- a/test_files/unit/modals/importer-shell.test.ts
+++ b/test_files/unit/modals/importer-shell.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ImporterShell } from "../../../src/modals/importer-shell";
+import { installObsidianDomPolyfills } from "../test-dom-polyfills";
+
+type FakePreviewModel = { value: string; getStats: () => { selected: number } };
+
+beforeEach(() => {
+  installObsidianDomPolyfills();
+  document.body.empty();
+});
+
+describe("ImporterShell", () => {
+  it("runs a format-agnostic validation, preview, and execution lifecycle", async () => {
+    const validate = vi.fn((content: string) =>
+      content === "valid" ? { valid: true as const } : { valid: false as const, error: "Invalid file" },
+    );
+    const parse = vi.fn((content: string) => ({ value: content }));
+    const execute = vi.fn(async () => {});
+    const render = vi.fn();
+    const shell = new ImporterShell<{ value: string }, FakePreviewModel>({
+      acceptedFileTypes: ".fake",
+      validate,
+      parse,
+      createPreviewModel: (parsed) => ({
+        ...parsed,
+        getStats: () => ({ selected: 1 }),
+      }),
+      renderer: { render },
+      execute,
+      getActionState: (model) => ({
+        text: model ? "Import item" : "Import items",
+        disabled: !model,
+      }),
+    });
+    const buttons = document.body.createDiv();
+    shell.mount(document.body, buttons);
+
+    await shell.handleFileSelection(new File(["invalid"], "bad.fake"));
+
+    expect(shell.state).toBe("error");
+    expect(parse).not.toHaveBeenCalled();
+    expect(document.querySelector(".import-error-message")?.textContent).toBe("Invalid file");
+
+    await shell.handleFileSelection(new File(["valid"], "good.fake"));
+
+    expect(shell.state).toBe("preview");
+    expect(parse).toHaveBeenCalledWith("valid");
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(buttons.querySelector("button")?.textContent).toBe("Import item");
+
+    await shell.execute();
+
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ value: "valid" }));
+    expect(shell.state).toBe("done");
+  });
+});

--- a/test_files/unit/modals/opml-import-preview-model.test.ts
+++ b/test_files/unit/modals/opml-import-preview-model.test.ts
@@ -13,7 +13,7 @@ function makeFeed(args: { title: string; url: string; folder: string }): Feed {
 }
 
 describe("OpmlImportPreviewModel", () => {
-  it("builds a folder tree, defaults selection to all feeds, and tracks duplicates in update mode", () => {
+  it("builds a folder tree, selects importable feeds, and unselects duplicates in update mode", () => {
     const feeds: Feed[] = [
       makeFeed({ title: "AI", url: "u1", folder: "Tech/AI" }),
       makeFeed({ title: "Tech News", url: "u2", folder: "Tech" }),
@@ -34,13 +34,14 @@ describe("OpmlImportPreviewModel", () => {
     const stats = model.getStats();
     expect(stats.totalFeeds).toBe(3);
     expect(stats.duplicateFeeds).toBe(1);
-    expect(stats.selectedFeeds).toBe(3);
+    expect(stats.selectedFeeds).toBe(2);
     expect(stats.selectedImportableFeeds).toBe(2);
     expect(stats.hasBlockingErrors).toBe(false);
+    expect(model.getFeedState("u2").selected).toBe(false);
 
     const techState = model.getFolderSelectionState("Tech");
-    expect(techState.checked).toBe(true);
-    expect(techState.indeterminate).toBe(false);
+    expect(techState.checked).toBe(false);
+    expect(techState.indeterminate).toBe(true);
 
     model.toggleFolder("Tech", false);
     const afterToggle = model.getStats();


### PR DESCRIPTION
## Summary

- extract a format-agnostic importer shell for file selection, validation, parsing, preview, and execution lifecycle state
- refactor the OPML modal to provide its existing validation, preview model, mode controls, cleaner guidance, and ingestion behavior as OPML-specific hooks
- add an isolated shell lifecycle test using fake validation, parsing, preview rendering, and execution behavior

## Validation

- `npm run build`
- focused OPML and importer-shell unit tests

## Manual gate

Refs #233. The repository owner must still complete and sign off on #233's manual OPML stress-test checklist before any `234-*` starred.json importer work begins. This PR does not mark #233 done.
