### PR TITLE
chore: align tooling configuration with sample baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 - Fixed unnecessary type assertion in `src/utils/settings-loader.ts` by updating `migrateDefaultFilterToDashboardMultiFilters` to accept typed `DisplaySettings`.
 - Fixed the global-refresh Stop button not appearing on mobile/tablet: the sidebar modal's polling loop now applies the `stop` class and swaps the icon to `square-stop` when the refresh is cancellable, matching the desktop sidebar behaviour.
 
+### Development and compliance
+
+- Aligned repository tooling with the current Obsidian sample-plugin baseline: TypeScript now targets ES2021, Node-only maintenance scripts are linted under a scoped tooling policy, and repeat version bumps preserve an existing `versions.json` compatibility mapping. Added regression coverage for both version-bump paths. [GH Issue #240](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/240)
+
 ## 2.6.0 - August 24, 2026
 
 ### Features

--- a/docs/plans/240-sample-plugin-tooling-alignment.md
+++ b/docs/plans/240-sample-plugin-tooling-alignment.md
@@ -1,0 +1,37 @@
+---
+status: proposed
+created: 2026-09-10
+issue: "https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/240"
+milestone: ""
+owner: unassigned
+workstream: configuration-alignment
+sequence: null
+depends_on: []
+release_requirement: ""
+implementation: ""
+---
+
+# Align repository tooling with the Obsidian sample-plugin baseline
+
+## Problem and value
+
+The repository's TypeScript and ESLint configuration differs from the current Obsidian sample plugin. Review each material variance as adopted, intentional, or deferred; do not copy the sample wholesale.
+
+## Current evidence
+
+- `strictNullChecks` was already effective through `strict: true` and explicitly present in `HEAD`.
+- Adding `noUncheckedIndexedAccess` yields 260 TypeScript errors in 43 files; the same compiler command with that option disabled has zero errors.
+- Including `scripts/**/*.mjs` in lint yields 5 errors and 13 warnings because mobile-runtime rules are applied to Node-only tooling.
+- `version-bump.mjs` should preserve an existing compatibility floor for a target already in `versions.json`.
+
+## Planned work
+
+- Adopt `noUncheckedIndexedAccess` only through green remediation slices.
+- Lint Node-only tools with a scoped policy while keeping runtime rules intact.
+- Validate idempotent version-bump behavior.
+
+## Acceptance criteria
+
+- Each material upstream configuration difference is recorded as adopted, intentional, or deferred.
+- Any adopted configuration change passes its full relevant validation gate.
+- `npm run build` passes before the parent work is complete.

--- a/docs/plans/draft-20260910-adopt-no-unchecked-indexed-access.md
+++ b/docs/plans/draft-20260910-adopt-no-unchecked-indexed-access.md
@@ -1,0 +1,25 @@
+---
+status: idea
+created: 2026-09-10
+issue: ""
+milestone: ""
+owner: unassigned
+workstream: configuration-alignment
+sequence: 1
+depends_on:
+  - https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/240
+release_requirement: ""
+implementation: ""
+---
+
+# Adopt noUncheckedIndexedAccess and remediate undefined-index access errors
+
+## Scope
+
+Keep `strict: true` and adopt `noUncheckedIndexedAccess: true`. This is not a strict-null migration. Remediate the 260 errors in coherent, tested slices by guarding genuinely optional values, proving presence, or strengthening source contracts; do not use blanket assertions or casts.
+
+## Acceptance criteria
+
+- `npx tsc --noEmit --skipLibCheck --pretty false` passes with strict indexing enabled.
+- Representative missing-value behavior has focused regression coverage where an observable seam exists.
+- No compiler-policy weakening or broad suppression is introduced.

--- a/docs/plans/draft-20260910-lint-node-tooling-scripts.md
+++ b/docs/plans/draft-20260910-lint-node-tooling-scripts.md
@@ -1,0 +1,25 @@
+---
+status: idea
+created: 2026-09-10
+issue: ""
+milestone: ""
+owner: unassigned
+workstream: configuration-alignment
+sequence: 2
+depends_on:
+  - https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/240
+release_requirement: ""
+implementation: ""
+---
+
+# Lint Node-only repository tooling with a scoped ESLint policy
+
+## Scope
+
+Keep `scripts/**/*.mjs` included in linting. Add a tooling-only Node policy that exempts only rules based on mobile-runtime assumptions, retain ordinary correctness checks, use `process` rather than `globalThis.process`, and permit command-line console output only for tooling scripts.
+
+## Acceptance criteria
+
+- The five named Node tooling scripts lint with zero errors and warnings.
+- Runtime plugin files retain the existing Obsidian mobile and popout policy.
+- `npm run lint` and `npm run build` pass.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,6 @@ export default defineConfig([
       "main.js",
       "*.mjs",
       "scripts/**/*.js",
-      "scripts/**/*.mjs",
       ".kilo/**",
       ".tmp-*",
     ],
@@ -26,13 +25,19 @@ export default defineConfig([
     },
   },
   {
-    files: ["scripts/check-platform-compat.mjs", "scripts/check-css-important.mjs"],
+    // These scripts run only in Node during repository maintenance and are
+    // never bundled into the mobile plugin runtime.
+    files: ["scripts/**/*.mjs"],
     languageOptions: {
       globals: {
         ...globals.node,
         console: "readonly",
         process: "readonly",
       },
+    },
+    rules: {
+      "obsidianmd/no-nodejs-modules": "off",
+      "obsidianmd/rule-custom-message": "off",
     },
   },
   {

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 
-const proc = globalThis.process;
+const proc = process;
 
 function run(command, args, options = {}) {
   return spawnSync(command, args, {

--- a/test_files/unit/version-bump.test.ts
+++ b/test_files/unit/version-bump.test.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { cwd, env, execPath } from "node:process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const scriptPath = resolve(env.INIT_CWD ?? cwd(), "version-bump.mjs");
+const temporaryDirectories: string[] = [];
+
+function createVersionBumpFixture(
+  targetVersion: string,
+  minAppVersion: string,
+  versions: Record<string, string>,
+) {
+  const directory = mkdtempSync(join(tmpdir(), "rss-dashboard-version-bump-"));
+  temporaryDirectories.push(directory);
+
+  writeFileSync(
+    join(directory, "manifest.json"),
+    JSON.stringify({ version: "0.0.0", minAppVersion }),
+  );
+  writeFileSync(join(directory, "versions.json"), JSON.stringify(versions));
+
+  const environment = Object.fromEntries(
+    Object.entries(env).filter(
+      ([key]) => key.toLowerCase() !== "npm_package_version",
+    ),
+  );
+  environment.npm_package_version = targetVersion;
+
+  execFileSync(execPath, [scriptPath], {
+    cwd: directory,
+    env: environment,
+  });
+
+  return {
+    manifest: JSON.parse(readFileSync(join(directory, "manifest.json"), "utf8")) as {
+      version: string;
+      minAppVersion: string;
+    },
+    versions: JSON.parse(readFileSync(join(directory, "versions.json"), "utf8")) as Record<
+      string,
+      string
+    >,
+  };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("version-bump", () => {
+  it("preserves the recorded compatibility floor for an existing target version", () => {
+    const result = createVersionBumpFixture("2.7.0", "1.12.0", {
+      "2.7.0": "1.8.7",
+    });
+
+    expect(result.manifest.version).toBe("2.7.0");
+    expect(result.versions).toEqual({ "2.7.0": "1.8.7" });
+  });
+
+  it("adds the manifest compatibility floor for a missing target version", () => {
+    const result = createVersionBumpFixture("2.8.0", "1.12.0", {
+      "2.7.0": "1.8.7",
+    });
+
+    expect(result.manifest.version).toBe("2.8.0");
+    expect(result.versions).toEqual({ "2.7.0": "1.8.7", "2.8.0": "1.12.0" });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,19 +3,20 @@
     "inlineSourceMap": false,
     // "inlineSources": true,
     "module": "ESNext",
-    "target": "ES6",
-    "allowJs": true,
+    "target": "ES2021",
+    "strict": true,
     "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
     "moduleResolution": "bundler",
     "importHelpers": true,
     "isolatedModules": true,
-    "strictNullChecks": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "lib": ["DOM", "ES2020"],
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true
+    "lib": ["DOM", "ES2021"]
   },
   "include": ["main.ts", "src/**/*.ts"],
   "exclude": ["test_files/**", "coverage/**", "node_modules/**"]

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -3,12 +3,15 @@ import { readFileSync, writeFileSync } from "fs";
 const targetVersion = process.env.npm_package_version;
 
 // read minAppVersion from manifest.json and bump version to target version
-let manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
+const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
 const { minAppVersion } = manifest;
 manifest.version = targetVersion;
 writeFileSync("manifest.json", JSON.stringify(manifest, null, "\t"));
 
 // update versions.json with target version and minAppVersion from manifest.json
-let versions = JSON.parse(readFileSync("versions.json", "utf8"));
-versions[targetVersion] = minAppVersion;
-writeFileSync("versions.json", JSON.stringify(versions, null, "\t"));
+// but only if the target version is not already in versions.json
+const versions = JSON.parse(readFileSync("versions.json", "utf8"));
+if (!(targetVersion in versions)) {
+  versions[targetVersion] = minAppVersion;
+  writeFileSync("versions.json", JSON.stringify(versions, null, "\t"));
+}


### PR DESCRIPTION
## Summary

- Align safe TypeScript tooling settings with the current Obsidian sample-plugin baseline while leaving the broad `noUncheckedIndexedAccess` migration deferred under #240.
- Lint Node-only maintenance scripts with a scoped Node policy instead of excluding them, and replace `globalThis.process` in the git-hook setup script.
- Preserve existing `versions.json` compatibility mappings during repeat version bumps, with regression coverage for existing and missing versions.
- Add the #240 planning documents and Unreleased changelog entry.

Part of #240.

## Type

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [x] Docs
- [x] Chore

## Areas

- `area: build`

## User Impact

- No direct user impact.

## Release Notes Candidate

- Aligned repository tooling with the current Obsidian sample-plugin baseline: TypeScript now targets ES2021, Node-only maintenance scripts are linted under a scoped tooling policy, and repeat version bumps preserve an existing `versions.json` compatibility mapping. Added regression coverage for both version-bump paths. [GH Issue #240](https://github.com/amatya-aditya/obsidian-rss-dashboard/issues/240)

## Testing

- [x] Unit tests added/updated
- [ ] Existing tests pass locally
- [ ] Manual smoke test completed

### Test Evidence

- Passed `npx vitest run --config vitest.config.mjs test_files/unit/version-bump.test.ts` (2 tests).
- Passed `npx tsc --noEmit --skipLibCheck --pretty false` with `noUncheckedIndexedAccess` deferred.
- Passed focused ESLint for all five Node maintenance scripts and `test_files/unit/version-bump.test.ts` with `--max-warnings=0`.
- The normal pre-push full build gate completed before the branch was pushed.
- An earlier direct full lint invocation and full unit-suite attempt were blocked by an inherited dependency/runtime stall in the nested worktree.

## Risk and Rollback

Risk level:

- [x] Low
- [ ] Medium
- [ ] High

Rollback plan:

- Revert `6aeaaf5` and `3af543f`; the strict-indexing migration is not part of this PR.

## Checklist

- [x] Base branch is dev
- [x] Branch is scoped to one concern
- [x] No unrelated files included
- [x] If validation logic changed, tests updated
- [x] User-facing changes are recorded under `CHANGELOG.md` > `Unreleased`, or marked N/A
