### PR TITLE
feat: adopt noUncheckedIndexedAccess safely (#240)

### DIFF
--- a/docs/plans/draft-20260910-adopt-no-unchecked-indexed-access.md
+++ b/docs/plans/draft-20260910-adopt-no-unchecked-indexed-access.md
@@ -1,5 +1,5 @@
 ---
-status: idea
+status: in-progress
 created: 2026-09-10
 issue: ""
 milestone: ""

--- a/main.ts
+++ b/main.ts
@@ -1259,7 +1259,7 @@ export default class RssDashboardPlugin extends Plugin {
       const leaves = workspace.getLeavesOfType(RSS_DASHBOARD_VIEW_TYPE);
 
       if (leaves.length > 0) {
-        leaf = leaves[0];
+        leaf = leaves[0] ?? null;
       } else {
         switch (this.settings.viewLocation) {
           case "left-sidebar":
@@ -1294,7 +1294,7 @@ export default class RssDashboardPlugin extends Plugin {
       const leaves = workspace.getLeavesOfType(RSS_DISCOVER_VIEW_TYPE);
 
       if (leaves.length > 0) {
-        leaf = leaves[0];
+        leaf = leaves[0] ?? null;
       } else {
         leaf = workspace.getLeaf("tab");
       }
@@ -1319,7 +1319,7 @@ export default class RssDashboardPlugin extends Plugin {
       const leaves = workspace.getLeavesOfType(RSS_SMALLWEB_VIEW_TYPE);
 
       if (leaves.length > 0) {
-        leaf = leaves[0];
+        leaf = leaves[0] ?? null;
       } else {
         leaf = workspace.getLeaf("tab");
       }
@@ -1496,15 +1496,23 @@ export default class RssDashboardPlugin extends Plugin {
 
       let feedNoticeText = "";
       if (feedsToRefresh.length === 1) {
-        feedNoticeText = feedsToRefresh[0].title;
+        const singleFeed = feedsToRefresh[0];
+        if (!singleFeed) {
+          return;
+        }
+        feedNoticeText = singleFeed.title;
       } else {
         feedNoticeText = `${feedsToRefresh.length} feeds`;
       }
 
       new Notice(`Refreshing ${feedNoticeText}...`);
       if (feedsToRefresh.length === 1 && intent !== "global") {
+        const singleFeed = feedsToRefresh[0];
+        if (!singleFeed) {
+          return;
+        }
         await this.refreshSingleFeed(
-          feedsToRefresh[0],
+          singleFeed,
           feedNoticeText,
           false,
         );
@@ -2959,11 +2967,15 @@ export default class RssDashboardPlugin extends Plugin {
       (f) => f.url === updatedFeed.url,
     );
     if (index >= 0) {
+      const storedFeed = this.settings.feeds[index];
+      if (!storedFeed) {
+        return;
+      }
       this.settings.feeds[index] = {
         ...updatedFeed,
         excludeFromRefresh:
           updatedFeed.excludeFromRefresh ??
-          this.settings.feeds[index].excludeFromRefresh,
+          storedFeed.excludeFromRefresh,
       };
     }
   }
@@ -2991,8 +3003,13 @@ export default class RssDashboardPlugin extends Plugin {
       return;
     }
 
+    const storedFeed = this.settings.feeds[index];
+    if (!storedFeed) {
+      return;
+    }
+
     this.settings.feeds[index] = {
-      ...this.settings.feeds[index],
+      ...storedFeed,
       lastRefreshAttemptCompletedAt: completedAt,
       lastFetchError: error instanceof Error ? error.message : String(error),
     };

--- a/src/components/article-header-menu.ts
+++ b/src/components/article-header-menu.ts
@@ -423,7 +423,7 @@ export class ArticleHeaderMenu {
     const entries: MenuOptionEntries = Array.isArray(options)
       ? options
       : Object.keys(options).map(
-          (label): [string, string] => [label, options[label]],
+          (label): [string, string] => [label, options[label] ?? label],
         );
 
     entries.forEach(([label, value]) => {

--- a/src/components/article-header.ts
+++ b/src/components/article-header.ts
@@ -431,7 +431,7 @@ export class ArticleHeader {
 
     const entries: MenuOptionEntries = Array.isArray(options)
       ? options
-      : Object.keys(options).map((label) => [label, options[label]]);
+      : Object.keys(options).map((label): [string, string] => [label, options[label] ?? label]);
 
     entries.forEach(([label, value]) => {
       const item = portal.createDiv({ cls: "rss-dashboard-filter-menu-item" });

--- a/src/components/article-list.ts
+++ b/src/components/article-list.ts
@@ -682,7 +682,11 @@ export class ArticleList {
   ): number {
     const newTime = new Date(article.pubDate).getTime();
     for (let i = 0; i < this.articles.length; i++) {
-      const existingTime = new Date(this.articles[i].pubDate).getTime();
+      const existingArticle = this.articles[i];
+      if (!existingArticle) {
+        continue;
+      }
+      const existingTime = new Date(existingArticle.pubDate).getTime();
       if (
         sortOrder === "newest" ? newTime > existingTime : newTime < existingTime
       ) {
@@ -822,7 +826,7 @@ export class ArticleList {
       (card) => card.dataset.articleGuid === currentGuid,
     );
     if (currentIndex === -1) {
-      return cards[0].dataset.articleGuid ?? null;
+      return cards[0]?.dataset.articleGuid ?? null;
     }
 
     const rowTolerance = 6;
@@ -838,7 +842,10 @@ export class ArticleList {
     const rows: Array<Array<{ guid: string; rect: DOMRect }>> = [];
     positionedCards.forEach((entry) => {
       const existingRow = rows.find(
-        (row) => Math.abs(row[0].rect.top - entry.rect.top) <= rowTolerance,
+        (row) => {
+          const rowTop = row[0]?.rect.top;
+          return rowTop !== undefined && Math.abs(rowTop - entry.rect.top) <= rowTolerance;
+        },
       );
       if (existingRow) {
         existingRow.push(entry);
@@ -847,7 +854,7 @@ export class ArticleList {
       rows.push([entry]);
     });
     rows.forEach((row) => row.sort((a, b) => a.rect.left - b.rect.left));
-    rows.sort((a, b) => a[0].rect.top - b[0].rect.top);
+    rows.sort((a, b) => (a[0]?.rect.top ?? 0) - (b[0]?.rect.top ?? 0));
 
     const currentRowIndex = rows.findIndex((row) =>
       row.some((entry) => entry.guid === currentGuid),
@@ -857,6 +864,9 @@ export class ArticleList {
     }
 
     const currentRow = rows[currentRowIndex];
+    if (!currentRow) {
+      return null;
+    }
     const currentColumnIndex = currentRow.findIndex(
       (entry) => entry.guid === currentGuid,
     );
@@ -866,13 +876,13 @@ export class ArticleList {
 
     if (direction === "left") {
       return currentColumnIndex > 0
-        ? currentRow[currentColumnIndex - 1].guid
+        ? currentRow[currentColumnIndex - 1]?.guid ?? null
         : null;
     }
 
     if (direction === "right") {
       return currentColumnIndex < currentRow.length - 1
-        ? currentRow[currentColumnIndex + 1].guid
+        ? currentRow[currentColumnIndex + 1]?.guid ?? null
         : null;
     }
 
@@ -883,6 +893,9 @@ export class ArticleList {
     }
 
     const targetRow = rows[targetRowIndex];
+    if (!targetRow) {
+      return null;
+    }
     const targetColumnIndex = Math.min(
       currentColumnIndex,
       targetRow.length - 1,
@@ -1314,7 +1327,7 @@ export class ArticleList {
           cls: `rss-dashboard-article-group-content ${isInitiallyCollapsed ? "collapsed" : ""}`,
         });
 
-        const groupArticles = groupedArticles[groupName];
+        const groupArticles = groupedArticles[groupName] ?? [];
         if (this.settings.viewStyle === "list") {
           this.renderListView(groupContent, groupArticles);
         } else if (this.settings.viewStyle === "feed") {

--- a/src/components/article-list/utils/article-grouping.ts
+++ b/src/components/article-list/utils/article-grouping.ts
@@ -31,7 +31,8 @@ export function groupArticles(
       if (!acc[key]) {
         acc[key] = [];
       }
-      acc[key].push(article);
+      const group = acc[key];
+      if (group) group.push(article);
       return acc;
     },
     {} as Record<string, FeedItem[]>,

--- a/src/components/article-list/utils/article-preview-utils.ts
+++ b/src/components/article-list/utils/article-preview-utils.ts
@@ -27,7 +27,7 @@ export function extractFirstImageSrc(html: string): string | null {
     const srcMatch = imageTag.match(/\bsrc=["']([^"']+)["']/i);
     if (!srcMatch) continue;
 
-    const src = srcMatch[1].trim();
+    const src = srcMatch[1]?.trim() ?? "";
     const className = imageTag.match(/\bclass=["']([^"']*)["']/i)?.[1];
 
     // Reject literal placeholder values that some feeds (e.g. NPR CDATA) emit.

--- a/src/components/article-list/utils/tag-layout-utils.ts
+++ b/src/components/article-list/utils/tag-layout-utils.ts
@@ -72,7 +72,9 @@ export function renderSingleRowCardTagChips(
   let visibleCount = 0;
 
   for (let i = 0; i < tags.length; i += 1) {
-    createTagChip(container, tags[i]);
+    const tag = tags[i];
+    if (!tag) continue;
+    createTagChip(container, tag);
     visibleCount = i + 1;
 
     const remainingTags = tags.slice(visibleCount);

--- a/src/components/article-renderer.ts
+++ b/src/components/article-renderer.ts
@@ -744,9 +744,12 @@ export class ArticleRenderer {
         return this.getNormalizedBlockText(block) === normalizedDescription;
       });
       if (duplicateIndex !== -1) {
-        blocks[duplicateIndex].remove();
+        const duplicateBlock = blocks[duplicateIndex];
+        if (!duplicateBlock) return;
+        duplicateBlock.remove();
         for (let index = duplicateIndex - 1; index >= 0; index--) {
           const block = blocks[index];
+          if (!block) continue;
           if (this.isShortLeadInBlock(block) || this.isLeadMediaBlock(block)) {
             block.remove();
             continue;
@@ -783,6 +786,7 @@ export class ArticleRenderer {
 
     for (let index = 0; index < firstSubstantialIndex; index++) {
       const block = blocks[index];
+      if (!block) continue;
       if (this.isLeadMediaBlock(block)) {
         block.remove();
       }
@@ -979,9 +983,10 @@ export class ArticleRenderer {
       if (totalText.length > 140) return false;
       let linkish = 0;
       for (const li of liEls) {
+        const onlyChild = li.children[0];
         if (
           li.children.length === 1 &&
-          li.children[0].tagName.toLowerCase() === "a"
+          onlyChild?.tagName.toLowerCase() === "a"
         )
           linkish++;
       }

--- a/src/components/folder-selector-popup.ts
+++ b/src/components/folder-selector-popup.ts
@@ -86,7 +86,7 @@ export class FolderSelectorPopup {
       );
       const folders = [...this.folders];
       const [removed] = folders.splice(defaultIndex, 1);
-      folders.unshift(removed);
+      if (removed !== undefined) folders.unshift(removed);
       return folders;
     }
 
@@ -369,7 +369,7 @@ export class FolderSelectorPopup {
         if (itemCount > 0) {
           const newIndex = currentIndex < itemCount - 1 ? currentIndex + 1 : 0;
           this.clearSelection();
-          items[newIndex].addClass("is-selected");
+          items[newIndex]?.addClass("is-selected");
           this.scrollSelectedItemIntoView();
         }
         break;
@@ -379,7 +379,7 @@ export class FolderSelectorPopup {
         if (itemCount > 0) {
           const newIndex = currentIndex > 0 ? currentIndex - 1 : itemCount - 1;
           this.clearSelection();
-          items[newIndex].addClass("is-selected");
+          items[newIndex]?.addClass("is-selected");
           this.scrollSelectedItemIntoView();
         }
         break;

--- a/src/components/folder-suggest.ts
+++ b/src/components/folder-suggest.ts
@@ -102,7 +102,8 @@ abstract class LegacyInputSuggest<T> {
 
     if (event.key === "Enter" && this.selectedIndex >= 0) {
       event.preventDefault();
-      this.selectSuggestion(this.suggestions[this.selectedIndex], event);
+      const suggestion = this.suggestions[this.selectedIndex];
+      if (suggestion) this.selectSuggestion(suggestion, event);
       return;
     }
 

--- a/src/components/reader-lightbox.ts
+++ b/src/components/reader-lightbox.ts
@@ -333,14 +333,16 @@ export class ReaderLightbox {
     // Touch events for mobile
     const onTouchStart = (e: TouchEvent): void => {
       if (e.touches.length === 1) {
-        this.touchStartX = e.touches[0].clientX;
-        this.touchStartY = e.touches[0].clientY;
+        const touch = e.touches[0];
+        if (!touch) return;
+        this.touchStartX = touch.clientX;
+        this.touchStartY = touch.clientY;
         this.isSwipingToDismiss = this.scale === 1;
 
         if (this.scale > 1) {
           this.isDragging = true;
-          this.dragStartX = e.touches[0].clientX;
-          this.dragStartY = e.touches[0].clientY;
+          this.dragStartX = touch.clientX;
+          this.dragStartY = touch.clientY;
           this.dragInitialPanX = this.panX;
           this.dragInitialPanY = this.panY;
           this.stageEl?.addClass("is-panning");
@@ -355,14 +357,16 @@ export class ReaderLightbox {
 
     const onTouchMove = (e: TouchEvent): void => {
       if (e.touches.length === 1) {
+        const touch = e.touches[0];
+        if (!touch) return;
         if (this.isDragging && this.scale > 1) {
-          const deltaX = e.touches[0].clientX - this.dragStartX;
-          const deltaY = e.touches[0].clientY - this.dragStartY;
+          const deltaX = touch.clientX - this.dragStartX;
+          const deltaY = touch.clientY - this.dragStartY;
           this.panX = this.dragInitialPanX + deltaX;
           this.panY = this.dragInitialPanY + deltaY;
           this.updateTransform();
         } else if (this.isSwipingToDismiss && this.scale === 1) {
-          const deltaY = e.touches[0].clientY - this.touchStartY;
+          const deltaY = touch.clientY - this.touchStartY;
           if (deltaY > 0) {
             this.panY = deltaY * 0.7;
             this.updateTransform();
@@ -449,8 +453,11 @@ export class ReaderLightbox {
 
   private getTouchDistance(touches: TouchList): number {
     if (touches.length < 2) return 0;
-    const dx = touches[0].clientX - touches[1].clientX;
-    const dy = touches[0].clientY - touches[1].clientY;
+    const firstTouch = touches[0];
+    const secondTouch = touches[1];
+    if (!firstTouch || !secondTouch) return 0;
+    const dx = firstTouch.clientX - secondTouch.clientX;
+    const dy = firstTouch.clientY - secondTouch.clientY;
     return Math.sqrt(dx * dx + dy * dy);
   }
 }

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -2740,7 +2740,9 @@ export class Sidebar {
       Math.max(0, startIndex + offset),
     );
 
-    this.focusedSidebarTarget = this.sidebarRows[nextIndex].target;
+    const nextRow = this.sidebarRows[nextIndex];
+    if (!nextRow) return;
+    this.focusedSidebarTarget = nextRow.target;
     this.applySidebarFocusState();
   }
 
@@ -2765,6 +2767,7 @@ export class Sidebar {
       idx += direction
     ) {
       const row = this.sidebarRows[idx];
+      if (!row) continue;
       if (row.target.type !== "feed") {
         this.focusedSidebarTarget = row.target;
         this.applySidebarFocusState();
@@ -3426,7 +3429,8 @@ export class Sidebar {
       isDown = true;
       isDragging = false;
       const clientX =
-        e instanceof MouseEvent ? e.clientX : e.touches[0].clientX;
+        e instanceof MouseEvent ? e.clientX : e.touches[0]?.clientX;
+      if (clientX === undefined) return;
       startX = clientX - iconRow.offsetLeft;
       scrollLeft = iconRow.scrollLeft;
     };
@@ -3440,7 +3444,8 @@ export class Sidebar {
       if (!isDown) return;
       e.preventDefault();
       const clientX =
-        e instanceof MouseEvent ? e.clientX : e.touches[0].clientX;
+        e instanceof MouseEvent ? e.clientX : e.touches[0]?.clientX;
+      if (clientX === undefined) return;
       const x = clientX - iconRow.offsetLeft;
       const walk = (x - startX) * 2; // Scroll speed multiplier
       if (Math.abs(walk) > 5) {

--- a/src/modals/feed-preview-modal.ts
+++ b/src/modals/feed-preview-modal.ts
@@ -135,7 +135,7 @@ export class FeedPreviewModal extends Modal {
                     const content =
                         item.querySelector(":scope > content\\:encoded")?.textContent || description;
                     const imgMatch = content.match(/<img[^>]+src=["']([^"']+)["'][^>]*>/i);
-                    if (imgMatch) {
+                    if (imgMatch?.[1]) {
                         image = imgMatch[1];
                     } else {
                         
@@ -318,12 +318,14 @@ export class FeedPreviewModal extends Modal {
 
     private getInitials(title: string): string {
         const words = title.split(' ');
+        const firstWord = words[0] ?? '';
+        const secondWord = words[1] ?? '';
         if (words.length > 1) {
-            return (words[0][0] + words[1][0]).toUpperCase();
-        } else if (words.length === 1 && words[0].length > 1) {
-            return (words[0][0] + words[0][1]).toUpperCase();
-        } else if (words.length === 1 && words[0].length === 1) {
-            return words[0][0].toUpperCase();
+            return `${firstWord[0] ?? ''}${secondWord[0] ?? ''}`.toUpperCase();
+        } else if (words.length === 1 && firstWord.length > 1) {
+            return `${firstWord[0] ?? ''}${firstWord[1] ?? ''}`.toUpperCase();
+        } else if (words.length === 1 && firstWord.length === 1) {
+            return (firstWord[0] ?? '').toUpperCase();
         }
         return 'NA';
     }

--- a/src/services/article-saver.ts
+++ b/src/services/article-saver.ts
@@ -610,7 +610,7 @@ export class ArticleSaver {
         const trimmedPart = part.trim();
         const urlMatch = trimmedPart.match(/^([^\s]+)(\s+\d+w|\s+\d+x)?$/);
         if (urlMatch) {
-          const url = urlMatch[1];
+          const url = urlMatch[1] ?? "";
           const sizeDescriptor = urlMatch[2] || "";
           return (
             this.convertToAbsoluteUrl(url.trim(), baseUrl) + sizeDescriptor

--- a/src/services/background-import-service.ts
+++ b/src/services/background-import-service.ts
@@ -548,14 +548,18 @@ export class BackgroundImportService {
     feedMetadata: FeedMetadata,
     parsedFeed: Feed,
   ): Feed | null {
-    const feedIndex = this.getSettings().feeds.findIndex(
+    const settings = this.getSettings();
+    const feedIndex = settings.feeds.findIndex(
       (f) => f.url === feedMetadata.url,
     );
     if (feedIndex < 0) {
       return null;
     }
 
-    const existingFeed = this.getSettings().feeds[feedIndex];
+    const existingFeed = settings.feeds[feedIndex];
+    if (!existingFeed) {
+      return null;
+    }
     const importedFeed: Feed = {
       ...existingFeed,
       title: parsedFeed.title || existingFeed.title || feedMetadata.title,
@@ -565,11 +569,11 @@ export class BackgroundImportService {
       mediaType: parsedFeed.mediaType ?? existingFeed.mediaType,
       items: parsedFeed.items.slice(
         0,
-        existingFeed.maxItemsLimit || this.getSettings().maxItems,
+        existingFeed.maxItemsLimit || settings.maxItems,
       ),
       lastUpdated: Date.now(),
     };
-    this.getSettings().feeds[feedIndex] = importedFeed;
+    settings.feeds[feedIndex] = importedFeed;
     return importedFeed;
   }
 

--- a/src/services/feed-parser/feed-fetch.ts
+++ b/src/services/feed-parser/feed-fetch.ts
@@ -170,8 +170,9 @@ async function discoverFeedUrl(
     if (feedLinkMatches) {
       for (const match of feedLinkMatches) {
         const hrefMatch = match.match(/href="([^"]+)"/);
-        if (hrefMatch) {
-          let feedUrl = hrefMatch[1];
+        const href = hrefMatch?.[1];
+        if (href) {
+          let feedUrl = href;
 
           if (feedUrl.startsWith("/")) {
             const url = new URL(baseUrl);
@@ -198,8 +199,9 @@ async function discoverFeedUrl(
       if (matches) {
         for (const match of matches) {
           const hrefMatch = match.match(/href="([^"]+)"/);
-          if (hrefMatch) {
-            let feedUrl = hrefMatch[1];
+          const href = hrefMatch?.[1];
+          if (href) {
+            let feedUrl = href;
             if (feedUrl.startsWith("/")) {
               const url = new URL(baseUrl);
               feedUrl = `${url.protocol}//${url.host}${feedUrl}`;

--- a/src/services/feed-parser/feed-parser-class.ts
+++ b/src/services/feed-parser/feed-parser-class.ts
@@ -217,7 +217,7 @@ export class FeedParser {
 
               const urlMatch = trimmedPart.match(/^([^\s]+)(\s+\d+w)?$/);
               if (urlMatch) {
-                const url = urlMatch[1];
+                const url = urlMatch[1] ?? "";
                 const sizeDescriptor = urlMatch[2] || "";
 
                 const decodedUrl = this.parser.decodeHtmlEntities(url);

--- a/src/services/feed-parser/podcast-platform-resolver.ts
+++ b/src/services/feed-parser/podcast-platform-resolver.ts
@@ -129,14 +129,11 @@ async function resolvePocketCastsUrl(
             const itunesData = JSON.parse(itunesResponse.text) as {
               results?: Array<{ feedUrl?: string; collectionName?: string }>;
             };
-            if (
-              itunesData.results &&
-              itunesData.results.length > 0 &&
-              itunesData.results[0].feedUrl
-            ) {
-              const feedUrl = itunesData.results[0].feedUrl;
+            const firstResult = itunesData.results?.[0];
+            if (firstResult?.feedUrl) {
+              const feedUrl = firstResult.feedUrl;
               console.debug(
-                `[RSS Dashboard] Successfully resolved Pocket Casts URL via iTunes API: ${feedUrl} (matched "${itunesData.results[0].collectionName}")`,
+                `[RSS Dashboard] Successfully resolved Pocket Casts URL via iTunes API: ${feedUrl} (matched "${firstResult.collectionName ?? ""}")`,
               );
               return feedUrl;
             }

--- a/src/services/feed-parser/xml-parser/custom-xml-parser.ts
+++ b/src/services/feed-parser/xml-parser/custom-xml-parser.ts
@@ -21,7 +21,7 @@ export class CustomXMLParser {
 
   private detectEncoding(xmlString: string): string {
     const match = xmlString.match(/encoding=["']([^"']+)["']/);
-    return match ? match[1] : "UTF-8";
+    return match?.[1] ?? "UTF-8";
   }
 
   private getTextContent(
@@ -36,6 +36,9 @@ export class CustomXMLParser {
       el = element.querySelector(tagName);
     } else if (tagName.includes(":")) {
       const [namespace, localName] = tagName.split(":");
+      if (!namespace || !localName) {
+        return "";
+      }
 
       // 1. Try namespaced selector with backslash
       try {
@@ -48,7 +51,7 @@ export class CustomXMLParser {
       if (!el) {
         try {
           const elements = element.getElementsByTagNameNS("*", localName);
-          if (elements.length > 0) el = elements[0];
+          el = elements[0] ?? null;
         } catch {
           /* ignore */
         }
@@ -77,7 +80,7 @@ export class CustomXMLParser {
       if (!el) {
         try {
           const tagEls = element.getElementsByTagName(tagName);
-          if (tagEls.length > 0) el = tagEls[0];
+          el = tagEls[0] ?? null;
         } catch {
           /* ignore */
         }
@@ -106,6 +109,9 @@ export class CustomXMLParser {
       }
     } else if (tagName.includes(":")) {
       const [namespace, localName] = tagName.split(":");
+      if (!namespace || !localName) {
+        return "";
+      }
 
       try {
         el = element.querySelector(`${namespace}\\:${localName}`);
@@ -116,7 +122,7 @@ export class CustomXMLParser {
       if (!el) {
         try {
           const elements = element.getElementsByTagNameNS("*", localName);
-          if (elements.length > 0) el = elements[0];
+          el = elements[0] ?? null;
         } catch {
           /* ignore */
         }
@@ -172,7 +178,7 @@ export class CustomXMLParser {
         .filter((x) => !!x.url);
       if (withUrl.length === 0) return "";
       withUrl.sort((a, b) => score(b.el) - score(a.el));
-      return withUrl[0].url;
+      return withUrl[0]?.url ?? "";
     };
 
     // 1) Standard selectors (works in many environments)

--- a/src/services/feed-parser/xml-parser/xml-preprocessing.ts
+++ b/src/services/feed-parser/xml-parser/xml-preprocessing.ts
@@ -71,12 +71,15 @@ export function preprocessXmlContent(xmlString: string): string {
   // Auto-declare undeclared namespace prefixes to prevent XML parse errors
   const rootTagMatch = processed.match(/<(rss|feed|rdf:rdf)([^>]*)>/i);
   if (rootTagMatch) {
-    const rootAttrs = rootTagMatch[2];
+    const rootAttrs = rootTagMatch[2] ?? "";
     const declaredPrefixes = new Set<string>();
     const nsRegex = /xmlns:(\w+)\s*=/g;
     let nsMatch;
     while ((nsMatch = nsRegex.exec(rootAttrs)) !== null) {
-      declaredPrefixes.add(nsMatch[1].toLowerCase());
+      const prefix = nsMatch[1];
+      if (prefix) {
+        declaredPrefixes.add(prefix.toLowerCase());
+      }
     }
     // Always consider these as declared (built-in XML prefixes)
     declaredPrefixes.add("xml");
@@ -86,9 +89,13 @@ export function preprocessXmlContent(xmlString: string): string {
     const prefixRegex = /<(\w+):\w+[\s>/]/g;
     let pfxMatch;
     while ((pfxMatch = prefixRegex.exec(processed)) !== null) {
-      const prefix = pfxMatch[1].toLowerCase();
+      const originalPrefix = pfxMatch[1];
+      if (!originalPrefix) {
+        continue;
+      }
+      const prefix = originalPrefix.toLowerCase();
       if (!declaredPrefixes.has(prefix)) {
-        usedPrefixes.add(pfxMatch[1]); // preserve original case
+        usedPrefixes.add(originalPrefix); // preserve original case
       }
     }
 
@@ -96,7 +103,7 @@ export function preprocessXmlContent(xmlString: string): string {
       const newAttrs = [...usedPrefixes]
         .map((p) => `xmlns:${p}="urn:x-${p}:unknown"`)
         .join(" ");
-      const rootTag = rootTagMatch[1];
+      const rootTag = rootTagMatch[1] ?? "rss";
       processed = processed.replace(
         new RegExp(`<${rootTag}([^>]*)>`, "i"),
         `<${rootTag}$1 ${newAttrs}>`,
@@ -128,9 +135,9 @@ export function extractRssContent(xmlString: string): string {
         );
         const linkMatch = xmlString.match(/<link[^>]*>([^<]+)<\/link>/i);
 
-        const title = titleMatch ? titleMatch[1].trim() : "Unknown feed";
-        const description = descMatch ? descMatch[1].trim() : "";
-        const link = linkMatch ? linkMatch[1].trim() : "";
+        const title = titleMatch?.[1]?.trim() ?? "Unknown feed";
+        const description = descMatch?.[1]?.trim() ?? "";
+        const link = linkMatch?.[1]?.trim() ?? "";
 
         rssContent = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
@@ -185,21 +192,21 @@ export function fallbackParse(
     const channelTitleMatch = cleanedXml.match(
       /<channel[^>]*>[\s\S]*?<title[^>]*>([^<]+)<\/title>/i,
     );
-    const title = channelTitleMatch
+    const title = channelTitleMatch?.[1]
       ? sanitize(channelTitleMatch[1].trim())
       : "Unknown feed";
 
     const channelDescMatch = cleanedXml.match(
       /<channel[^>]*>[\s\S]*?<description[^>]*>([\s\S]*?)<\/description>/i,
     );
-    const description = channelDescMatch
+    const description = channelDescMatch?.[1]
       ? sanitize(channelDescMatch[1].trim())
       : "";
 
     const channelLinkMatch = cleanedXml.match(
       /<channel[^>]*>[\s\S]*?<link[^>]*>([^<]+)<\/link>/i,
     );
-    const link = channelLinkMatch ? channelLinkMatch[1].trim() : "";
+    const link = channelLinkMatch?.[1]?.trim() ?? "";
 
     const items: ParsedItem[] = [];
 
@@ -297,17 +304,17 @@ export function fallbackParse(
         return;
       }
 
-      const itemTitle = sanitize(itemTitleMatch[1].trim());
+      const itemTitle = sanitize(itemTitleMatch[1]?.trim() ?? "");
 
       const itemLinkMatch = itemXml.match(/<link[^>]*>([^<]+)<\/link>/i);
-      let itemLink = itemLinkMatch ? itemLinkMatch[1].trim() : "#";
+      let itemLink = itemLinkMatch?.[1]?.trim() ?? "#";
 
       itemLink = transformSageUrl(itemLink);
 
       const itemDescMatch = itemXml.match(
         /<description[^>]*>([\s\S]*?)<\/description>/i,
       );
-      let itemDescription = itemDescMatch
+      let itemDescription = itemDescMatch?.[1]
         ? sanitize(itemDescMatch[1].trim())
         : "";
       if (itemDescription === "null" || itemDescription === "") {
@@ -315,7 +322,7 @@ export function fallbackParse(
           itemXml.match(/<media:description[^>]*>([\s\S]*?)<\/media:description>/i) ||
           itemXml.match(/<media\\:description[^>]*>([\s\S]*?)<\/media\\:description>/i);
         if (mediaDescMatch) {
-          itemDescription = sanitize(mediaDescMatch[1].trim());
+          itemDescription = sanitize(mediaDescMatch[1]?.trim() ?? "");
         } else {
           itemDescription = "";
         }
@@ -324,12 +331,11 @@ export function fallbackParse(
       const itemPubDateMatch = itemXml.match(
         /<pubDate[^>]*>([^<]+)<\/pubDate>/i,
       );
-      itemPubDate = itemPubDateMatch
-        ? itemPubDateMatch[1].trim()
-        : new Date().toISOString();
+      itemPubDate =
+        itemPubDateMatch?.[1]?.trim() ?? new Date().toISOString();
 
       const itemGuidMatch = itemXml.match(/<guid[^>]*>([^<]+)<\/guid>/i);
-      itemGuid = itemGuidMatch ? itemGuidMatch[1].trim() : itemLink;
+      itemGuid = itemGuidMatch?.[1]?.trim() ?? itemLink;
 
       const authorMatches = [
         itemXml.match(/<author[^>]*>([^<]+)<\/author>/i),
@@ -344,7 +350,7 @@ export function fallbackParse(
       ];
       for (const authorMatch of authorMatches) {
         if (authorMatch) {
-          itemAuthor = sanitize(authorMatch[1].trim());
+          itemAuthor = sanitize(authorMatch[1]?.trim() ?? "");
           break;
         }
       }
@@ -352,7 +358,7 @@ export function fallbackParse(
       const itemCategoryMatch = itemXml.match(
         /<category[^>]*>([^<]+)<\/category>/i,
       );
-      const itemCategory = itemCategoryMatch
+      const itemCategory = itemCategoryMatch?.[1]
         ? sanitize(itemCategoryMatch[1].trim())
         : "";
 
@@ -412,25 +418,33 @@ export function fallbackParse(
       );
 
       const pubYearMatch = itemXml.match(/<pubYear[^>]*>([^<]+)<\/pubYear>/i);
-      const pubYear = pubYearMatch ? sanitize(pubYearMatch[1].trim()) : "";
+      const pubYear = pubYearMatch?.[1]
+        ? sanitize(pubYearMatch[1].trim())
+        : "";
       const volumeMatch = itemXml.match(/<volume[^>]*>([^<]+)<\/volume>/i);
-      const volume = volumeMatch ? sanitize(volumeMatch[1].trim()) : "";
+      const volume = volumeMatch?.[1] ? sanitize(volumeMatch[1].trim()) : "";
       const issueMatch = itemXml.match(/<issue[^>]*>([^<]+)<\/issue>/i);
-      const issue = issueMatch ? sanitize(issueMatch[1].trim()) : "";
+      const issue = issueMatch?.[1] ? sanitize(issueMatch[1].trim()) : "";
       const startPageMatch = itemXml.match(
         /<startPage[^>]*>([^<]+)<\/startPage>/i,
       );
-      const startPage = startPageMatch
+      const startPage = startPageMatch?.[1]
         ? sanitize(startPageMatch[1].trim())
         : "";
       const endPageMatch = itemXml.match(/<endPage[^>]*>([^<]+)<\/endPage>/i);
-      const endPage = endPageMatch ? sanitize(endPageMatch[1].trim()) : "";
+      const endPage = endPageMatch?.[1]
+        ? sanitize(endPageMatch[1].trim())
+        : "";
       const fileSizeMatch = itemXml.match(
         /<fileSize[^>]*>([^<]+)<\/fileSize>/i,
       );
-      const fileSize = fileSizeMatch ? sanitize(fileSizeMatch[1].trim()) : "";
+      const fileSize = fileSizeMatch?.[1]
+        ? sanitize(fileSizeMatch[1].trim())
+        : "";
       const authorsMatch = itemXml.match(/<authors[^>]*>([^<]+)<\/authors>/i);
-      const authors = authorsMatch ? sanitize(authorsMatch[1].trim()) : "";
+      const authors = authorsMatch?.[1]
+        ? sanitize(authorsMatch[1].trim())
+        : "";
       const ieee =
         pubYear ||
         volume ||

--- a/src/services/image-cache-service.ts
+++ b/src/services/image-cache-service.ts
@@ -318,7 +318,8 @@ export class ImageCacheService {
     const contentType = Object.entries(response.headers).find(
       ([name]) => name.toLowerCase() === "content-type",
     )?.[1];
-    return IMAGE_TYPES.get(contentType?.split(";", 1)[0].trim().toLowerCase() ?? "") ?? null;
+    const mediaType = contentType?.split(";", 1)[0];
+    return IMAGE_TYPES.get(mediaType?.trim().toLowerCase() ?? "") ?? null;
   }
 
   private getDeclaredLength(headers: Record<string, string>): number | null {

--- a/src/services/media-service.ts
+++ b/src/services/media-service.ts
@@ -228,7 +228,7 @@ export class MediaService {
       } else if (input.includes("@")) {
         let handle = "";
         if (input.includes("youtube.com/@")) {
-          handle = input.split("youtube.com/@")[1].split(/[?#/]/)[0];
+          handle = input.split("youtube.com/@")[1]?.split(/[?#/]/)[0] ?? "";
         } else if (input.startsWith("@")) {
           handle = input.substring(1);
         }

--- a/src/services/opml-manager.ts
+++ b/src/services/opml-manager.ts
@@ -50,6 +50,9 @@ export class OpmlManager {
     ) => {
       for (let i = 0; i < outlines.length; i++) {
         const outline = outlines[i];
+        if (!outline) {
+          continue;
+        }
         const type = outline.getAttribute("type");
 
         if (!type && outline.hasChildNodes()) {
@@ -108,7 +111,7 @@ export class OpmlManager {
       folders: Folder[],
     ): Folder | null => {
       const parts = path.split("/");
-      const folderName = parts[0];
+      const folderName = parts[0] ?? "";
 
       let folder = folders.find((f) => f.name === folderName);
 
@@ -130,6 +133,9 @@ export class OpmlManager {
     Object.keys(folderMap).forEach((path) => {
       if (!processedFolders.has(path)) {
         const folder = folderMap[path];
+        if (!folder) {
+          return;
+        }
         const parent = folderHierarchy[path];
 
         if (!parent) {
@@ -172,6 +178,9 @@ export class OpmlManager {
     ) => {
       for (let i = 0; i < outlines.length; i++) {
         const outline = outlines[i];
+        if (!outline) {
+          continue;
+        }
         const type = outline.getAttribute("type");
 
         if (!type && outline.hasChildNodes()) {
@@ -230,7 +239,7 @@ export class OpmlManager {
       folders: Folder[],
     ): Folder | null => {
       const parts = path.split("/");
-      const folderName = parts[0];
+      const folderName = parts[0] ?? "";
 
       let folder = folders.find((f) => f.name === folderName);
 
@@ -252,6 +261,9 @@ export class OpmlManager {
     Object.keys(folderMap).forEach((path) => {
       if (!processedFolders.has(path)) {
         const folder = folderMap[path];
+        if (!folder) {
+          return;
+        }
         const parent = folderHierarchy[path];
 
         if (!parent) {

--- a/src/services/sidebar-ordering-controller.ts
+++ b/src/services/sidebar-ordering-controller.ts
@@ -120,7 +120,9 @@ export function moveFeedsToFolderAppend(
   const withoutDragged = settings.feeds.filter((f) => !draggedUrlSet.has(f.url));
   let lastIndexInDestination = -1;
   for (let i = 0; i < withoutDragged.length; i++) {
-    const folderPath = normalizeFolderPath(withoutDragged[i].folder);
+    const feed = withoutDragged[i];
+    if (!feed) continue;
+    const folderPath = normalizeFolderPath(feed.folder);
     if (folderPath === destinationFolderPath) lastIndexInDestination = i;
   }
 
@@ -193,6 +195,7 @@ function findFolderLocation(
     const idx = currentArray.findIndex((f) => f.name === name);
     if (idx === -1) return null;
     const folder = currentArray[idx];
+    if (!folder) return null;
 
     if (depth === parts.length - 1) {
       return {

--- a/src/services/sidebar-search-service.ts
+++ b/src/services/sidebar-search-service.ts
@@ -36,7 +36,7 @@ export class SidebarSearchService {
       };
     }
 
-    const prefix = match[1].toLowerCase();
+    const prefix = match[1]?.toLowerCase() ?? "";
     const scope = SCOPE_PREFIXES[prefix];
     if (!scope) {
       return {

--- a/src/settings/tabs/article-saving-settings-tab.ts
+++ b/src/settings/tabs/article-saving-settings-tab.ts
@@ -217,8 +217,9 @@ export function renderArticleSavingSettingsTab(
             .setButtonText("Update")
             .setTooltip("Update this template with current editor content")
             .onClick(async () => {
-              plugin.settings.articleSaving.savedTemplates![index].template =
-                plugin.settings.articleSaving.defaultTemplate;
+              const templateToUpdate = plugin.settings.articleSaving.savedTemplates?.[index];
+              if (!templateToUpdate) return;
+              templateToUpdate.template = plugin.settings.articleSaving.defaultTemplate;
               await plugin.saveSettings();
               new Notice(`Template "${template.name}" updated`);
             }),

--- a/src/settings/tabs/highlights-settings-tab.ts
+++ b/src/settings/tabs/highlights-settings-tab.ts
@@ -230,7 +230,9 @@ export function renderHighlightsSettingsTab(
             return;
           }
           const h = ensureHighlights(plugin);
-          h.words[index].text = nextText;
+          const highlightWord = h.words[index];
+          if (!highlightWord) return;
+          highlightWord.text = nextText;
           await plugin.saveSettings();
           onRefresh();
           await rerenderHighlightViews();
@@ -250,7 +252,9 @@ export function renderHighlightsSettingsTab(
             )
             .onChange(async (value) => {
               const h = ensureHighlights(plugin);
-              h.words[index].color = value;
+              const highlightWord = h.words[index];
+              if (!highlightWord) return;
+              highlightWord.color = value;
               await plugin.saveSettings();
               await rerenderHighlightViews();
             }),
@@ -258,7 +262,9 @@ export function renderHighlightsSettingsTab(
         .addToggle((toggle) =>
           toggle.setValue(word.enabled).onChange(async (value) => {
             const h = ensureHighlights(plugin);
-            h.words[index].enabled = value;
+            const highlightWord = h.words[index];
+            if (!highlightWord) return;
+            highlightWord.enabled = value;
             await plugin.saveSettings();
             onRefresh();
             await rerenderHighlightViews();
@@ -270,7 +276,9 @@ export function renderHighlightsSettingsTab(
             .setTooltip("Toggle whole-word matching")
             .onClick(async () => {
               const h = ensureHighlights(plugin);
-              h.words[index].wholeWord = !word.wholeWord;
+              const highlightWord = h.words[index];
+              if (!highlightWord) return;
+              highlightWord.wholeWord = !highlightWord.wholeWord;
               await plugin.saveSettings();
               onRefresh();
               await rerenderHighlightViews();
@@ -283,7 +291,9 @@ export function renderHighlightsSettingsTab(
           if (word.caseSensitive) button.setCta();
           return button.onClick(async () => {
             const h = ensureHighlights(plugin);
-            h.words[index].caseSensitive = !word.caseSensitive;
+            const highlightWord = h.words[index];
+            if (!highlightWord) return;
+            highlightWord.caseSensitive = !highlightWord.caseSensitive;
             await plugin.saveSettings();
             onRefresh();
             await rerenderHighlightViews();

--- a/src/settings/tabs/sidebar-settings-tab.ts
+++ b/src/settings/tabs/sidebar-settings-tab.ts
@@ -345,9 +345,12 @@ export function renderSidebarSettingsTab(
         const idx = currentOrder.indexOf(id);
         if (idx > 0) {
           const newOrder = [...currentOrder];
+          const previousId = newOrder[idx - 1];
+          const currentId = newOrder[idx];
+          if (previousId === undefined || currentId === undefined) return;
           [newOrder[idx - 1], newOrder[idx]] = [
-            newOrder[idx],
-            newOrder[idx - 1],
+            currentId,
+            previousId,
           ];
           plugin.settings.display.iconOrder = newOrder;
           renderIconRows();
@@ -371,9 +374,12 @@ export function renderSidebarSettingsTab(
         const idx = currentOrder.indexOf(id);
         if (idx >= 0 && idx < currentOrder.length - 1) {
           const newOrder = [...currentOrder];
+          const currentId = newOrder[idx];
+          const nextId = newOrder[idx + 1];
+          if (currentId === undefined || nextId === undefined) return;
           [newOrder[idx], newOrder[idx + 1]] = [
-            newOrder[idx + 1],
-            newOrder[idx],
+            nextId,
+            currentId,
           ];
           plugin.settings.display.iconOrder = newOrder;
           renderIconRows();

--- a/src/settings/tabs/tags-settings-tab.ts
+++ b/src/settings/tabs/tags-settings-tab.ts
@@ -137,6 +137,7 @@ export function renderTagsSettingsTab(
 
   for (let i = 0; i < plugin.settings.availableTags.length; i++) {
     const tag = plugin.settings.availableTags[i];
+    if (!tag) continue;
 
     new Setting(tagsContainer)
       .setName(tag.name)

--- a/src/utils/favicon-utils.ts
+++ b/src/utils/favicon-utils.ts
@@ -48,12 +48,15 @@ export function extractDomain(url: string): string {
     const match = url.match(/https?:\/\/([^/?]+)/);
     if (match) {
       const hostname = match[1];
+      if (!hostname) {
+        return "";
+      }
       const parts = hostname.split(".");
       if (parts.length >= 2) {
         if (parts.length === 3 && parts[0] === "feeds") {
-          return `${parts[1]}.${parts[2]}`;
+          return `${parts[1] ?? ""}.${parts[2] ?? ""}`;
         } else if (parts.length >= 3) {
-          return `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+          return `${parts[parts.length - 2] ?? hostname}.${parts[parts.length - 1] ?? hostname}`;
         } else {
           return hostname;
         }

--- a/src/utils/full-size-image-resolver.ts
+++ b/src/utils/full-size-image-resolver.ts
@@ -92,7 +92,7 @@ export function extractHighestResolutionFromSrcset(srcset: string | null | undef
 
     if (score > bestScore) {
       bestScore = score;
-      bestUrl = url;
+      bestUrl = url ?? null;
     }
   }
 

--- a/src/utils/math-copy.ts
+++ b/src/utils/math-copy.ts
@@ -123,7 +123,7 @@ function replaceFormulaMarkup(fragment: DocumentFragment): void {
 }
 
 function appendLineBreak(parts: string[]): void {
-  if (parts.length === 0 || !parts[parts.length - 1].endsWith("\n")) {
+  if (parts.length === 0 || !(parts[parts.length - 1] ?? "").endsWith("\n")) {
     parts.push("\n");
   }
 }

--- a/src/utils/platform-utils.ts
+++ b/src/utils/platform-utils.ts
@@ -198,7 +198,8 @@ function detectCharsetFromHeader(contentType: string): string | null {
   const match = contentType.match(
     /charset\s*=\s*(?:"([^"]+)"|'([^']+)'|([^;\s]+))/i,
   );
-  return match ? (match[1] || match[2] || match[3]).trim() : null;
+  const charset = match?.[1] || match?.[2] || match?.[3];
+  return charset?.trim() ?? null;
 }
 
 function detectCharsetFromBody(buffer: ArrayBuffer): string | null {
@@ -210,17 +211,17 @@ function detectCharsetFromBody(buffer: ArrayBuffer): string | null {
   const xmlMatch = text.match(
     /<\?xml[^>]*encoding\s*=\s*["']([^"']+)["']/i,
   );
-  if (xmlMatch) return xmlMatch[1];
+  if (xmlMatch?.[1]) return xmlMatch[1];
 
   // Look for <meta charset="...">
   const charsetMatch = text.match(/<meta[^>]+charset=["']?([^"' >]+)/i);
-  if (charsetMatch) return charsetMatch[1];
+  if (charsetMatch?.[1]) return charsetMatch[1];
 
   // Look for <meta http-equiv="Content-Type" content="...charset=...">
   const equivMatch = text.match(
     /<meta[^>]+http-equiv=["']?Content-Type["']?[^>]+content=["']?[^"'>]+charset=([^"' >]+)/i,
   );
-  if (equivMatch) return equivMatch[1];
+  if (equivMatch?.[1]) return equivMatch[1];
 
   return null;
 }

--- a/src/utils/podcast-platforms.ts
+++ b/src/utils/podcast-platforms.ts
@@ -13,7 +13,7 @@ export const APPLE_PODCASTS: PodcastPlatform = {
     },
     extractId(url: string): string | null {
         const match = url.match(/id(\d+)(?:\?|$)/);
-        return match ? match[1] : null;
+        return match?.[1] ?? null;
     }
 };
 
@@ -25,7 +25,7 @@ export const SPOTIFY: PodcastPlatform = {
     },
     extractId(url: string): string | null {
         const match = url.match(/show\/([a-zA-Z0-9]+)/);
-        return match ? match[1] : null;
+        return match?.[1] ?? null;
     }
 };
 
@@ -37,7 +37,7 @@ export const GOOGLE_PODCASTS: PodcastPlatform = {
     },
     extractId(url: string): string | null {
         const match = url.match(/feed\/([a-zA-Z0-9_-]+)/);
-        return match ? match[1] : null;
+        return match?.[1] ?? null;
     }
 };
 
@@ -49,7 +49,7 @@ export const POCKET_CASTS: PodcastPlatform = {
     },
     extractId(url: string): string | null {
         const match = url.match(/pocketcasts\.com\/podcast\/[^/]+\/([0-9a-f-]{36})/i);
-        return match ? match[1] : null;
+        return match?.[1] ?? null;
     }
 };
 

--- a/src/utils/reader-format-portal.ts
+++ b/src/utils/reader-format-portal.ts
@@ -134,7 +134,7 @@ export function createReaderFormatPortal(options: ReaderFormatPortalOptions): {
         0,
         Math.min(values.length - 1, safeIndex + direction),
       );
-      const nextValue = values[nextIndex];
+      const nextValue = values[nextIndex] ?? values[0] ?? format[settingKey];
       if (nextValue === format[settingKey]) {
         return;
       }

--- a/src/utils/settings-loader.ts
+++ b/src/utils/settings-loader.ts
@@ -458,6 +458,10 @@ export function dedupeAndNormalizeFeedItems(feeds: Feed[]): boolean {
 
     for (let idx = 0; idx < items.length; idx++) {
       const item = items[idx];
+      if (!item) {
+        didChange = true;
+        continue;
+      }
       const canonicalKey = canonicalizeItemIdentityUrl(
         item.guid || item.link || "",
       );

--- a/src/utils/tag-utils.ts
+++ b/src/utils/tag-utils.ts
@@ -32,6 +32,9 @@ function ensureCanonicalTag(
 
   if (existingIndex >= 0) {
     const existingTag = nextTags[existingIndex];
+    if (!existingTag) {
+      return { changed: false, tags: nextTags };
+    }
     const nextTag: Tag = {
       ...existingTag,
       name: definition.name,

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -39,10 +39,10 @@ function extractYouTubeVideoId(rawId: string): string | null {
       const shortsMatch = u.pathname.match(
         /^\/shorts\/([-_A-Za-z0-9]{11})(?:[/?#]|$)/,
       );
-      if (shortsMatch) return shortsMatch[1];
+      if (shortsMatch?.[1]) return shortsMatch[1];
     }
     if (host === "youtu.be") {
-      const pathId = u.pathname.slice(1).split(/[/?#]/)[0];
+      const pathId = u.pathname.slice(1).split(/[/?#]/)[0] ?? "";
       if (YT_VIDEO_ID_RE.test(pathId)) return pathId;
     }
   } catch {

--- a/src/views/dashboard-view.ts
+++ b/src/views/dashboard-view.ts
@@ -318,9 +318,12 @@ export class RssDashboardView extends ItemView {
                 newPagination.endIdx,
               );
               if (newArticles.length > 0) {
-                void this.selectArticle(newArticles[0], {
-                  open: options?.open,
-                });
+                const firstArticle = newArticles[0];
+                if (firstArticle) {
+                  void this.selectArticle(firstArticle, {
+                    open: options?.open,
+                  });
+                }
               }
             });
             return;
@@ -333,7 +336,9 @@ export class RssDashboardView extends ItemView {
     }
 
     const nextArticle = articlesForPage[nextIndex];
-    void this.selectArticle(nextArticle, { open: options?.open });
+    if (nextArticle) {
+      void this.selectArticle(nextArticle, { open: options?.open });
+    }
   }
 
   /**
@@ -384,9 +389,12 @@ export class RssDashboardView extends ItemView {
                 newPagination.endIdx,
               );
               if (newArticles.length > 0) {
-                void this.selectArticle(newArticles[newArticles.length - 1], {
-                  open: options?.open,
-                });
+                const lastArticle = newArticles[newArticles.length - 1];
+                if (lastArticle) {
+                  void this.selectArticle(lastArticle, {
+                    open: options?.open,
+                  });
+                }
               }
             });
             return;
@@ -399,7 +407,9 @@ export class RssDashboardView extends ItemView {
     }
 
     const prevArticle = articlesForPage[prevIndex];
-    void this.selectArticle(prevArticle, { open: options?.open });
+    if (prevArticle) {
+      void this.selectArticle(prevArticle, { open: options?.open });
+    }
   }
 
   /**
@@ -429,7 +439,10 @@ export class RssDashboardView extends ItemView {
     if (articlesForPage.length === 0) return;
 
     if (!this.selectedArticle) {
-      void this.selectArticle(articlesForPage[0]);
+      const firstArticle = articlesForPage[0];
+      if (firstArticle) {
+        void this.selectArticle(firstArticle);
+      }
       return;
     }
 
@@ -783,6 +796,9 @@ export class RssDashboardView extends ItemView {
     );
 
     const container = this.containerEl.children[1];
+    if (!container) {
+      return Promise.resolve();
+    }
     container.addClass("rss-dashboard-container");
     let dashboardContainer = container.querySelector(
       ".rss-dashboard-layout",
@@ -902,6 +918,9 @@ export class RssDashboardView extends ItemView {
       }
 
       const container = this.containerEl.children[1];
+      if (!container) {
+        return;
+      }
       let dashboardContainer = container.querySelector(
         ".rss-dashboard-layout",
       ) as HTMLElement;
@@ -2290,13 +2309,16 @@ export class RssDashboardView extends ItemView {
     this.selectedFeeds = [];
     // When entering multi-select, clear single-folder and feed selection
     this.currentFeed = null;
-    this.currentFolder = folders.length === 1 ? folders[0] : null;
+    this.currentFolder = folders.length === 1 ? (folders[0] ?? null) : null;
     this.selectedTags = [];
     void this.render();
 
     // Update anchor to most-recently selected folder
     if (folders && folders.length > 0) {
-      this.lastClickAnchorKey = `folder:${folders[folders.length - 1]}`;
+      const lastFolder = folders[folders.length - 1];
+      if (lastFolder) {
+        this.lastClickAnchorKey = `folder:${lastFolder}`;
+      }
     }
   }
 
@@ -2440,7 +2462,7 @@ export class RssDashboardView extends ItemView {
     this.selectedFeeds = Array.from(finalSelectedFeeds);
     this.currentFolder =
       this.selectedFolders.length === 1 && this.selectedFeeds.length === 0
-        ? this.selectedFolders[0]
+        ? (this.selectedFolders[0] ?? null)
         : null;
     this.currentFeed =
       this.selectedFeeds.length === 1 && this.selectedFolders.length === 0
@@ -3211,7 +3233,7 @@ export class RssDashboardView extends ItemView {
     };
 
     if (this.currentFolder && specialFolderLabels[this.currentFolder]) {
-      return specialFolderLabels[this.currentFolder];
+      return specialFolderLabels[this.currentFolder] ?? null;
     }
 
     if (
@@ -3219,6 +3241,9 @@ export class RssDashboardView extends ItemView {
       this.activeTagFilters.size === 0
     ) {
       const [statusFilter] = Array.from(this.activeStatusFilters);
+      if (!statusFilter) {
+        return null;
+      }
       const statusLabel =
         statusFilter.charAt(0).toUpperCase() + statusFilter.slice(1);
       return `the ${statusLabel} view filter`;

--- a/src/views/discover-view.ts
+++ b/src/views/discover-view.ts
@@ -138,16 +138,23 @@ export class DiscoverView extends ItemView {
         if (!categoryMap.categories[domain]) {
           categoryMap.categories[domain] = {};
         }
+        const domainCategories = categoryMap.categories[domain];
+        if (!domainCategories) {
+          return;
+        }
 
         feed.subdomain.forEach((subdomain) => {
-          if (!categoryMap.categories[domain][subdomain]) {
-            categoryMap.categories[domain][subdomain] = {};
+          if (!domainCategories[subdomain]) {
+            domainCategories[subdomain] = {};
           }
 
           feed.area.forEach((area) => {
-            const subdomainObj = categoryMap.categories[domain][
-              subdomain
-            ] as Record<string, unknown>;
+            const subdomainObj = domainCategories[subdomain] as
+              | Record<string, unknown>
+              | undefined;
+            if (!subdomainObj) {
+              return;
+            }
             if (!subdomainObj[area]) {
               subdomainObj[area] = [];
             }
@@ -1421,12 +1428,14 @@ export class DiscoverView extends ItemView {
 
   private getInitials(title: string): string {
     const words = title.split(" ");
+    const firstWord = words[0] ?? "";
+    const secondWord = words[1] ?? "";
     if (words.length > 1) {
-      return (words[0][0] + words[1][0]).toUpperCase();
-    } else if (words.length === 1 && words[0].length > 1) {
-      return (words[0][0] + words[0][1]).toUpperCase();
-    } else if (words.length === 1 && words[0].length === 1) {
-      return words[0][0].toUpperCase();
+      return `${firstWord[0] ?? ""}${secondWord[0] ?? ""}`.toUpperCase();
+    } else if (words.length === 1 && firstWord.length > 1) {
+      return `${firstWord[0] ?? ""}${firstWord[1] ?? ""}`.toUpperCase();
+    } else if (words.length === 1 && firstWord.length === 1) {
+      return (firstWord[0] ?? "").toUpperCase();
     }
     return "NA";
   }
@@ -1749,7 +1758,11 @@ export class DiscoverView extends ItemView {
       );
 
       if (feedIndex >= 0) {
-        const feedTitle = this.plugin.settings.feeds[feedIndex].title;
+        const feed = this.plugin.settings.feeds[feedIndex];
+        if (!feed) {
+          return;
+        }
+        const feedTitle = feed.title;
         this.plugin.settings.feeds.splice(feedIndex, 1);
         await this.plugin.saveSettings();
 

--- a/src/views/kagi-smallweb-view.ts
+++ b/src/views/kagi-smallweb-view.ts
@@ -660,7 +660,7 @@ export class KagiSmallwebView extends ItemView {
       hash = hash & hash;
     }
 
-    return colors[Math.abs(hash) % colors.length];
+    return colors[Math.abs(hash) % colors.length] ?? "hsl(0, 0%, 80%)";
   }
 
   private getSmallwebTagColor(tag: string): string {

--- a/src/views/podcast-player.ts
+++ b/src/views/podcast-player.ts
@@ -615,7 +615,9 @@ export class PodcastPlayer {
         if (windowInstanceOf(e, MouseEvent)) {
           clientX = e.clientX;
         } else {
-          clientX = e.touches[0].clientX;
+          const touch = e.touches[0];
+          if (!touch) return 0;
+          clientX = touch.clientX;
         }
         const percent = Math.max(
           0,
@@ -922,7 +924,9 @@ export class PodcastPlayer {
     this.currentPlaylistIndex =
       (this.currentPlaylistIndex + 1) % this.playlist.length;
     const nextEpisode = this.playlist[this.currentPlaylistIndex];
-    this.loadEpisode(nextEpisode, undefined, { notify: true, source: "nav" });
+    if (nextEpisode) {
+      this.loadEpisode(nextEpisode, undefined, { notify: true, source: "nav" });
+    }
   }
 
   private playPrevious(): void {
@@ -933,7 +937,9 @@ export class PodcastPlayer {
         ? this.playlist.length - 1
         : this.currentPlaylistIndex - 1;
     const prevEpisode = this.playlist[this.currentPlaylistIndex];
-    this.loadEpisode(prevEpisode, undefined, { notify: true, source: "nav" });
+    if (prevEpisode) {
+      this.loadEpisode(prevEpisode, undefined, { notify: true, source: "nav" });
+    }
   }
 
   private handleEpisodeEnd(): void {
@@ -954,11 +960,13 @@ export class PodcastPlayer {
         this.currentPlaylistIndex =
           (this.currentPlaylistIndex + 1) % this.playlist.length;
         const nextEpisode = this.playlist[this.currentPlaylistIndex];
-        this.loadEpisode(nextEpisode, undefined, {
-          notify: true,
-          source: "autoplay",
-          autoplay: true,
-        });
+        if (nextEpisode) {
+          this.loadEpisode(nextEpisode, undefined, {
+            notify: true,
+            source: "autoplay",
+            autoplay: true,
+          });
+        }
       }
     }
 
@@ -1094,8 +1102,9 @@ export class PodcastPlayer {
     let nextIndex = speeds.findIndex((speed) => speed === currentSpeed) + 1;
     if (nextIndex >= speeds.length) nextIndex = 0;
 
-    this.audioElement.playbackRate = speeds[nextIndex];
-    this.speedButtonEl.textContent = `${speeds[nextIndex].toFixed(2)}x`;
+    const nextSpeed = speeds[nextIndex] ?? 1;
+    this.audioElement.playbackRate = nextSpeed;
+    this.speedButtonEl.textContent = `${nextSpeed.toFixed(2)}x`;
   }
 
   private startProgressTracking(): void {

--- a/src/views/reader-view.ts
+++ b/src/views/reader-view.ts
@@ -260,7 +260,7 @@ export class ReaderView extends ItemView {
       steps.length - 1,
       (currentIndex >= 0 ? currentIndex : 2) + 1,
     );
-    format.fontScalePct = steps[nextIndex];
+    format.fontScalePct = steps[nextIndex] ?? 100;
     this.applyReaderFormat();
     void this.flushReaderFormatSave();
   }
@@ -274,7 +274,7 @@ export class ReaderView extends ItemView {
     const format = this.getReaderFormat();
     const currentIndex = steps.indexOf(format.fontScalePct);
     const nextIndex = Math.max(0, (currentIndex >= 0 ? currentIndex : 2) - 1);
-    format.fontScalePct = steps[nextIndex];
+    format.fontScalePct = steps[nextIndex] ?? 100;
     this.applyReaderFormat();
     void this.flushReaderFormatSave();
   }
@@ -2422,6 +2422,7 @@ export class ReaderView extends ItemView {
         const kids = Array.from(li.children) as HTMLElement[];
         if (kids.length !== 1) continue;
         const only = kids[0];
+        if (!only) continue;
         if (only.tagName.toLowerCase() !== "a") continue;
         const t = (only.textContent || "").replace(/\s+/g, " ").trim();
         if (t.length < 1 || t.length > 40) continue;
@@ -2572,9 +2573,12 @@ export class ReaderView extends ItemView {
         return this.getNormalizedBlockText(block) === normalizedDescription;
       });
       if (duplicateIndex !== -1) {
-        blocks[duplicateIndex].remove();
+        const duplicateBlock = blocks[duplicateIndex];
+        if (!duplicateBlock) return;
+        duplicateBlock.remove();
         for (let index = duplicateIndex - 1; index >= 0; index--) {
           const block = blocks[index];
+          if (!block) continue;
           if (this.isShortLeadInBlock(block) || this.isLeadMediaBlock(block)) {
             block.remove();
             continue;
@@ -2611,6 +2615,7 @@ export class ReaderView extends ItemView {
 
     for (let index = 0; index < firstSubstantialIndex; index++) {
       const block = blocks[index];
+      if (!block) continue;
       if (this.isLeadMediaBlock(block)) {
         block.remove();
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
     "moduleResolution": "bundler",
     "importHelpers": true,
     "isolatedModules": true,


### PR DESCRIPTION
**## Summary**



**- Enable `noUncheckedIndexedAccess` in `tsconfig.json`.**

**- Remediate all 260 resulting compiler errors with explicit bounds checks, presence guards, and safe fallbacks.**

**- Preserve existing behavior across feed parsing, settings migration, navigation, rendering, and media handling.**

**- Add no broad suppressions, compiler-policy weakening, or new test seams.**



**Closes #240**



**## Validation**



**- `npx tsc --noEmit --skipLibCheck --pretty false` — passed with zero errors.**

**- Focused existing Vitest suites across all changed public seams — passed.**

**- Repository compliance checks — passed.**

**- Per-file ESLint checks for changed modules — passed.**

**- Full `npm run test:unit` and `npm run build` were attempted; the execution wrapper returned after startup without emitting final summaries.**

