### PR TITLE
chore(architecture): add drift guardrails [Post-2.7.0]

### DIFF
--- a/.agents/project-context.md
+++ b/.agents/project-context.md
@@ -16,7 +16,8 @@ Public listing and review status:
 
 ## Repository Map
 
-- `main.ts`: plugin lifecycle, commands, shared orchestration, refresh, and persistence wiring.
+- `main.ts`: composition root for plugin lifecycle, module wiring, registration,
+  startup/shutdown orchestration, and thin compatibility delegation.
 - `src/services/`: feed parsing, storage, saving, synchronization, and integrations.
 - `src/views/`, `src/components/`, `src/modals/`, `src/settings/`, `src/discover/`: user-facing behavior.
 - `src/types/` and `src/utils/`: shared contracts and utilities.
@@ -36,6 +37,8 @@ these additional documents only when their area is affected:
 - `CONTRIBUTING.md` and `docs/development/compliance-patterns.md`: audit-sensitive implementation rules.
 - `docs/plugin-scorecard.md`: local audit history and current public-status snapshot.
 - `docs/development/data-flow.md`: feed refresh, merge, retention, and persistence behavior.
+- `docs/development/architecture.md`: module ownership, composition-root policy,
+  dependency direction, architecture preflight, and executable ratchets.
 - `docs/storage-vault-shards-guide.md`: storage modes and sync-facing behavior.
 - `docs/SECURITY.md`: external-domain, clipboard, and vault-access disclosures.
 - `docs/development/obsidian-settings-reference.md`: settings UI patterns.

--- a/.agents/skills/work-on-rss-dashboard-change/SKILL.md
+++ b/.agents/skills/work-on-rss-dashboard-change/SKILL.md
@@ -54,7 +54,20 @@ Ask the user only when a missing product decision would materially change the
 result. Do not invent issue details, acceptance criteria, or hidden audit
 findings.
 
-## 2. Select Obsidian Review Gates
+## 2. Run Architecture Preflight
+
+For a meaningful production change, read
+`docs/development/architecture.md`, run `npm run check:architecture`, and
+record the likely files, owning module, new responsibility, touched outliers,
+coupling change, and whether `main.ts` changes are composition/delegation or
+implementation. A tiny local fix may record that no architecture signal
+applies.
+
+Resolve unclear ownership before writing code. Do not expand
+`scripts/architecture-baseline.json` to make a change pass without identifying
+the architecture exception and its debt-reduction follow-up.
+
+## 3. Select Obsidian Review Gates
 
 Read [references/obsidian-change-gates.md](references/obsidian-change-gates.md)
 and apply only the rows matching the affected surfaces. Use its risk rules to
@@ -64,7 +77,7 @@ Inspect the live Obsidian community listing only for release, compliance,
 security, platform, storage, or audit-remediation work. For ordinary changes,
 use the local policies and scorecard to avoid unnecessary network work.
 
-## 3. Plan and Implement with TDD
+## 4. Plan and Implement with TDD
 
 - Map each acceptance criterion to an automated test or an explicit manual check.
 - Put new tests under the matching `test_files/unit/` area and follow the
@@ -78,7 +91,7 @@ If the current collaboration mode is Plan Mode, stop after a decision-complete
 `<proposed_plan>`. Otherwise, continue through implementation unless a material
 decision requires user input.
 
-## 4. Record the User-Visible Change
+## 5. Record the User-Visible Change
 
 - After the behavior is complete, add one concise bullet under
   `CHANGELOG.md` -> `Unreleased` -> `Features` or `Fixes`.
@@ -92,7 +105,7 @@ decision requires user input.
   the versioned changelog entries to consolidate related changes into an
   audience-focused `docs/releases/<version>.md` summary.
 
-## 5. Validate Efficiently
+## 6. Validate Efficiently
 
 Use a staged validation ladder:
 
@@ -100,6 +113,8 @@ Use a staged validation ladder:
    `npm exec -- eslint <changed-files> --max-warnings=0` and run focused tests
    with `npm run test:unit -- <matching-test-file>`.
 2. Run `npm run check:platform` early when `main.ts` or `src/**/*.ts` changes.
+   Run `npm run check:architecture -- --base HEAD` for meaningful production
+   TypeScript changes and resolve any enforced regression before continuing.
    For CSS changes, run `npm run check:css-scope` and
    `npm run check:important` early.
 3. Run the full `npm run test:unit` suite for high-risk or broad changes,
@@ -117,7 +132,7 @@ unrelated files merely to make a broad check green.
 For documentation-only changes, run only relevant document or skill validation
 and explain why application checks were not applicable.
 
-## 6. Close the Matching Plan
+## 7. Close the Matching Plan
 
 Run this step only after behavior is complete and every required validation
 gate passes. Leave incomplete or failing work in `docs/plans/`.
@@ -136,12 +151,15 @@ When the change has a matching active plan:
 Do not create a plan merely to satisfy this step when the work had no matching
 plan.
 
-## 7. Hand Off
+## 8. Hand Off
 
 Lead with the completed outcome. Include:
 
 - The implemented behavior and acceptance criteria satisfied.
 - Tests and validation commands with results.
+- The architecture diff for meaningful production changes: `main.ts` LOC
+  delta, threshold crossings, new `main.ts` importers, service dependency
+  direction, and runtime cycles.
 - The changelog entry and issue link, when present.
 - The updated and archived plan path, when the work started from a plan.
 - Risk-selected manual test steps with expected outcomes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@ Before making or reviewing a code or test change, read these files in full:
 Before scoping or implementing a feature or bug fix, also read
 `.agents/project-context.md` for the repository map and change workflow.
 
+Before a change that adds a responsibility, crosses a module seam, touches
+`main.ts`, or changes dependencies, read
+`docs/development/architecture.md` and run its architecture preflight.
+
 Before completing work driven by a file under `docs/plans/`, or cutting a
 release that contains archived plans, read **Plan Lifecycle and Archive** in
 `docs/development/README.md`. That section is the source of truth for plan
@@ -43,6 +47,7 @@ Before handing off a code change, run the relevant checks and report their resul
 
 - Run ESLint for every changed TypeScript file, or `npm run lint` when practical.
 - Run `npm run check:platform` whenever a `src/` TypeScript file changes.
+- Run `npm run check:architecture` for meaningful production TypeScript changes.
 - Run the focused unit tests covering the change; run `npm run test:unit` when the change has broad impact.
 - Run TypeScript type-checking for TypeScript changes.
 - Use `npm run build` for the repository's complete validation, or invoke the compiler directly as `tsc --noEmit --skipLibCheck`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,3 +89,45 @@ _Avoid_: Imported tag, bulk tag
 **Manually-assigned tag**:
 A tag added or removed on a candidate article by hand, via its per-article tag chip in the import preview. Independent of label-derived tags and of the "Import labels as tags" toggle — it always carries through to the imported item regardless of that toggle's state.
 _Avoid_: Ad hoc tag, user tag, manual tag override
+
+## Storage
+
+**Feed storage**:
+Where and how feed content (articles and episodes) is persisted, independent of where plugin metadata is persisted. Its mode is one of Legacy JSON or Shard storage (v1 or v2).
+_Avoid_: Storage (unqualified), article storage
+
+**Metadata storage**:
+Where the plugin's `data.json` (settings, feed definitions, folder organization, cleanup rules) is persisted: either the plugin's own directory or a user-chosen vault folder. Configured independently of feed storage, though Shard storage v2 forces it to a vault folder.
+_Avoid_: Storage (unqualified), config storage
+
+**Shard storage**:
+A feed storage mode that persists one file per feed in a vault folder instead of one monolithic `data.json`, improving sync behavior over Legacy JSON. Comes in two versions: v1 keeps each article's state inside its feed's shard file; v2 moves article state into a separate file, leaving only feed content in the shard.
+_Avoid_: Vault Shards, vault storage
+
+**Feed content**:
+The article or episode data (title, body, media, publish date) written into a feed's shard file under Shard storage v2. Distinct from that feed's article state, which v2 stores separately.
+_Avoid_: Shard content, feed data
+
+**Article state**:
+The per-article interaction data — read, starred, tags, saved-to-vault, playback progress — that Shard storage v2 stores in a separate `user-state.json` rather than inside the feed's shard file. The same states referenced by [[retention protection]].
+_Avoid_: User state (as a standalone term outside v2), read state
+
+**Portable data bundle**:
+A combined export containing both metadata and all feed shard files together, used to move a full Shard storage setup between devices. Currently exposed identically on both the storage tab and the Import/Export tab; nothing about the bundle's content is tab-specific. See [ADR 0005](docs/adr/0005-split-portable-data-bundle-into-feed-and-settings-bundles.md) for the planned split into a Feed bundle and a Settings bundle.
+_Avoid_: Shard data, shard export
+
+**Storage migration**:
+Moving feed content from its current feed storage mode into shard files for the first time, or upgrading from Shard storage v1 to v2. Distinct from storage repair and storage revert.
+_Avoid_: Migrate, storage change
+
+**Storage repair**:
+Force-regenerating all shard files from the current in-memory feed data without changing feed storage mode, used to recover from an out-of-sync or incomplete shard folder. Distinct from storage migration and storage revert.
+_Avoid_: Rebuild, resync
+
+**Storage revert**:
+Switching feed storage back to Legacy JSON, writing all feed content back into `data.json` and optionally deleting the shard folder. Distinct from storage migration and storage repair.
+_Avoid_: Rollback, downgrade
+
+**Metadata cleanup**:
+The user's choice, offered right after a metadata storage move succeeds, to delete or keep the `data.json` copy left behind at the previous location.
+_Avoid_: Backup cleanup, orphan file

--- a/docs/adr/0004-split-article-state-from-feed-content-in-shard-storage-v2.md
+++ b/docs/adr/0004-split-article-state-from-feed-content-in-shard-storage-v2.md
@@ -1,0 +1,20 @@
+# Split article state from feed content in Shard storage v2
+
+## Status
+
+accepted
+
+## Decision
+
+Shard storage v1 (introduced in v2.3.0) writes one file per feed containing both feed content and each article's state (read, starred, tags, saved, playback progress). Because article state changes far more often than feed content, two devices syncing the same shard file frequently produce conflicting writes even though the underlying content hasn't changed. Shard storage v2 (v2.4.0-beta.3) splits these: feed content stays in the per-feed shard file, and all article state moves into a single separate `user-state.json`, so the high-churn data no longer collides with the stable data on every sync pass.
+
+## Considered Options
+
+- **Keep the v1 shape and rely on sync-tool-level conflict resolution.** Rejected: conflicts are structural (state and content interleaved in one file), not something a sync tool's merge strategy can reliably fix.
+- **Split state from content into two files (chosen).** Accepted as v2, opt-in and backwards compatible with v1 via auto-migration, so existing v1 users aren't forced to move immediately.
+
+## Consequences
+
+Three feed storage modes now coexist — Legacy JSON, Shard storage v1, and Shard storage v2 — each with different sync robustness, which is exactly the kind of proliferation a future ADR or v1 deprecation would need to resolve deliberately rather than by letting v1 linger indefinitely.
+
+This decision is not necessarily final: a `sync-v3` branch is under active development and testing, aiming to improve cross-platform syncability further than v2 does. The cross-platform sync challenges that motivated this split are documented in more detail elsewhere in the codebase and the README; if sync-v3 lands, it may supersede this ADR, and this one should be updated with a `superseded by` status at that point rather than left silently outdated.

--- a/docs/adr/0005-split-portable-data-bundle-into-feed-and-settings-bundles.md
+++ b/docs/adr/0005-split-portable-data-bundle-into-feed-and-settings-bundles.md
@@ -1,0 +1,47 @@
+# Split the portable data bundle into a Feed bundle and a Settings bundle
+
+## Status
+
+proposed
+
+## Context
+
+The portable data bundle (`PortableDataBundle`, `src/types/types.ts:586`) is the plugin's only structured export/import format beyond OPML. It bundles the entire settings object (`metadata`, including `folders` and `availableTags`) together with every feed's shard file (`shards`, including full per-article state — read, starred, tags, saved, playback progress) as one all-or-nothing unit. It is exposed identically, and duplicated, on both the Storage tab and the Import/Export tab.
+
+This single bundle currently serves two distinct motivations with no way to tell them apart:
+
+- **Bug-protection backup**: recovering from data loss caused by a plugin update, which is also why auto-backups exist (`src/services/backup-service.ts`).
+- **Portability as an escape hatch**: a stated product value for a local-first, privacy-first plugin — letting a user move or extract their data without depending on any server.
+
+A user who only wants one of these (e.g. sharing a subscription list without their read history, or resetting settings without touching feeds) currently has no bundle-level option; the only state-free path is OPML (feeds/folders only, no settings, no state), and the only settings-scoped path (`usersettings.json`) inconsistently excludes `folders`/`availableTags` from "settings" while the portable bundle's `metadata` field includes them.
+
+## Decision
+
+Split the portable data bundle into two independently exportable and importable pieces:
+
+- **Feed bundle**: feeds, folders, tags, articles, and article state. No app settings.
+- **Settings bundle**: app preferences only (display, retention, storage config, auto-backup, etc.). No feeds, folders, tags, or articles.
+
+"Portable data bundle" remains the name for Feed bundle + Settings bundle together — i.e. everything, equivalent to today's single bundle.
+
+Scope constraints for this split:
+
+- No further granularity: no per-feed selection, no separate toggle to exclude article state from the Feed bundle. The state-free, feed-only case is already served by OPML, which remains a separate, orthogonal export path.
+- Folders and tags move to the Feed bundle (not the Settings bundle), correcting the inconsistency between today's `usersettings.json` and the portable bundle's `metadata`.
+- All three JSON buckets (Portable data bundle, Feed bundle, Settings bundle) get symmetric import as well as export — an export that can't be imported back isn't a usable backup.
+- No platform restriction (desktop vs. mobile): there is no usage data suggesting mobile-only users are rare enough to justify gating a stated core value behind platform.
+
+The technical hierarchy (two toggles, four valid outcomes) and a plain-language decision tree intended for a future settings-tab modal were worked out with the maintainer; see `docs/plans/export-bundle-hierarchy.md` for both, written out in full.
+
+## Considered Options
+
+- **Keep one all-or-nothing bundle (status quo).** Rejected: conflates backup and sharing/portability use cases that want different content, and forces folders/tags into an arbitrary bucket depending on which existing export path is used.
+- **Add fine-grained selection (per-feed, per-state-field toggles).** Rejected for now: no evidence of demand beyond the two-way split, and OPML already covers the "just my subscriptions, no state" case. Revisit if a concrete use case (e.g. selective feed sharing) surfaces.
+- **Split into Feed bundle + Settings bundle (chosen).** Matches the two motivations actually in evidence (bug-protection backup wants everything; portability/sharing sometimes wants less) without inventing granularity nobody has asked for.
+
+## Consequences
+
+- The existing "Import/Export shard data" (now "Import/Export portable data bundle") buttons on the Storage tab and Import/Export tab keep working unchanged until this is implemented; this ADR does not itself change behavior.
+- The duplicated bundle controls across the Storage tab and Import/Export tab remain duplicated; deduplicating them is separate follow-up work, not bundled into this decision.
+- Implementing this requires: a `FeedDataBundle` and `SettingsBundle` type/format (or a `scope` field on `PortableDataBundle`), corresponding import validation, and UI for selecting a scope — tracked in `docs/plans/export-bundle-hierarchy.md`.
+- `usersettings.json`'s current behavior (excluding `feeds`/`folders`/`availableTags`) becomes the correct shape for the new Settings bundle rather than an inconsistency to fix later.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,6 +6,7 @@ Internal developer documentation for the RSS Dashboard plugin.
 
 ## Core References
 
+- [Architecture Guardrails](./architecture.md)
 - [Compliance Patterns and Audit Guardrails](./compliance-patterns.md)
 - [Feed Data Lifecycle](./data-flow.md)
 - [Feed Validation](./feed-validation.md)

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,114 @@
+# Architecture Guardrails
+
+`main.ts` is the plugin composition root. Its long-term role is Obsidian
+lifecycle integration, module construction and wiring, registration, startup
+and shutdown orchestration, and thin compatibility delegation. Feature logic,
+persistence implementations, migrations, UI construction, and substantial
+state machines belong behind focused module interfaces under `src/`.
+
+## Architecture Preflight
+
+Before a meaningful implementation change, identify:
+
+- the module that owns the behavior and the files likely to change;
+- whether the change introduces a new responsibility or crosses an existing seam;
+- whether a touched file is already reported as unusually large or complex;
+- whether the change adds coupling, a runtime cycle, or an import of `main.ts`;
+- whether any `main.ts` change is composition/delegation or implementation.
+
+Tiny, local changes need only a sentence when none of these signals apply.
+When ownership is unclear, prefer a small interface that gives callers useful
+behavior without exposing the plugin class or a cluster of pass-through modules.
+
+## Executable Checks
+
+Run `npm run check:architecture`. The check has two kinds of output:
+
+- **Warnings** expose current outliers without failing the build: production
+  files over 1,000 physical lines, functions over 150 lines, branch complexity
+  over 20, and functions with more than 5 parameters.
+- **Errors** stop new drift: `main.ts` growing beyond its baseline, a new
+  production importer of `main.ts`, a service importing UI/settings or
+  `main.ts`, or a new runtime import cycle.
+
+The warning thresholds are repository-derived observability levels, not style
+targets. At the 2026-09-12 baseline they flag 12 of 161 production files
+(7.45%), 60 of 4,425 functions by size (1.36%), 51 functions by complexity
+(1.15%), and 23 functions by parameter count (0.52%). Declarative UI builders,
+type catalogs, and other cohesive exceptions still require human judgment.
+
+The baseline is stored in `scripts/architecture-baseline.json`. Lower
+`mainTsMaxLines` whenever `main.ts` shrinks, and remove importer or cycle
+allowances in the same change that eliminates them. Increasing the line limit
+or expanding an allow-list is an architecture exception: explain the
+responsibility, why the existing seams cannot own it, and the follow-up that
+restores the ratchet.
+
+For a change report relative to a Git ref, run:
+
+```bash
+npm run check:architecture -- --base HEAD
+```
+
+Use the branch merge-base instead of `HEAD` when reviewing a committed branch.
+Report the `main.ts` LOC delta, threshold crossings, new `main.ts` importers,
+dependency-direction results, and runtime-cycle results at handoff.
+
+## Dependency Direction
+
+The current source graph supports this enforced rule:
+
+```text
+views / components / modals / settings -> services -> utils / types
+```
+
+Services may collaborate with other services and depend on utilities and types.
+They may not import views, components, modals, settings, or `main.ts`.
+Production modules outside `main.ts` should move toward narrow interfaces
+instead of importing `RssDashboardPlugin`; the existing importer list is
+ratcheted so it can shrink but not grow.
+
+This is deliberately not a universal layer model. Some UI modules collaborate
+across their directory labels, and `domain-icon-helpers.ts` currently spans
+utility, parser, and settings concerns. Add a dependency rule only after the
+source graph demonstrates a stable seam.
+
+## Interpreting Size and Complexity
+
+Metrics are prompts for architectural review. A warning should lead to these
+questions:
+
+1. Does the module still have one coherent responsibility?
+2. Is its interface smaller and easier to use than its implementation?
+3. Is mutable state forming a hidden workflow or state machine?
+4. Can behavior be tested directly through the module interface instead of
+   through `RssDashboardPlugin` or private implementation details?
+5. Would splitting improve locality, or merely create pass-through files?
+
+File size alone cannot answer those questions. A cohesive type catalog may be
+large without being a god object, while several small modules in a runtime
+cycle still represent architectural debt.
+
+## Handoff Architecture Diff
+
+For meaningful code changes, handoff includes either the output of
+`check:architecture -- --base <ref>` or an equivalent concise report:
+
+```text
+main.ts: -74 LOC
+new feed-refresh-coordinator.ts: +122 LOC
+threshold crossings: none
+new main.ts importers: none
+service-to-UI dependencies: none
+new runtime cycles: none
+```
+
+For documentation-only or tiny local changes, state why an architecture diff
+is not applicable.
+
+## Architectural Lessons
+
+Keep permanent prevention rules in this document and incident history under
+`docs/archive/investigations/`. When an incident reveals a reusable lesson,
+record its history as **Trigger -> Failure -> Prevention -> Validation**, then
+promote only the stable prevention and validation rules here.

--- a/docs/plans/export-bundle-hierarchy.md
+++ b/docs/plans/export-bundle-hierarchy.md
@@ -1,0 +1,91 @@
+---
+status: proposed
+created: "2026-09-12"
+issue: ""
+milestone: ""
+owner: unassigned
+workstream: ""
+sequence: null
+depends_on: []
+release_requirement: ""
+implementation: ""
+---
+
+# Export Bundle Hierarchy Plan
+
+Implements [ADR 0005](../adr/0005-split-portable-data-bundle-into-feed-and-settings-bundles.md): split the single portable data bundle into an independently exportable/importable Feed bundle and Settings bundle, while keeping the combined Portable data bundle and OPML export as-is.
+
+## Goal
+
+Let a user choose what they're exporting/importing instead of always getting everything:
+
+- **Portable data bundle** (existing, unchanged content) = Feed bundle + Settings bundle.
+- **Feed bundle** (new) = feeds, folders, tags, articles, article state (read/starred/tags/saved/playback). No app settings.
+- **Settings bundle** (re-scoped from `usersettings.json`) = app preferences only. No feeds, folders, tags, or articles.
+- **OPML export** (existing, unchanged) = feeds + folders, no state, no settings. Stays as the orthogonal no-state/interop path.
+
+## Vocabulary
+
+See `CONTEXT.md` → Storage → "Portable data bundle" for the canonical definition and cross-reference to ADR 0005. "Feed bundle" and "Settings bundle" are introduced by this plan and should be added to `CONTEXT.md` once implemented (not before — they don't exist yet).
+
+## Technical hierarchy
+
+```mermaid
+flowchart TD
+    Start["Export / import scope"] --> Q1{"Include feeds, folders,<br/>tags, articles &amp; state?"}
+    Q1 -->|Yes| Q2{"Also include<br/>app settings?"}
+    Q1 -->|No| Q3{"Include<br/>app settings?"}
+    Q2 -->|Yes| ALL["Portable data bundle<br/>Feed bundle + Settings bundle"]
+    Q2 -->|No| FEED["Feed bundle only"]
+    Q3 -->|Yes| SET["Settings bundle only"]
+    Q3 -->|No| NONE["No selection —<br/>not a valid export"]
+    Start -.->|orthogonal path| OPML["OPML export<br/>feeds + folders, no state"]
+```
+
+Two toggles, four valid outcomes. No per-feed selection and no separate state toggle inside the JSON buckets — OPML already covers the no-state case.
+
+## User-facing decision tree
+
+Plain-language flow for the eventual settings-tab modal. Text-based decision tree is the first pass; the UI can be built as a wizard later without changing the logic below.
+
+```mermaid
+flowchart TD
+    A["Backing up or moving<br/>your whole setup?"] -->|Yes| B["Export everything<br/>Portable data bundle"]
+    A -->|No| C["Keep read/starred history,<br/>tags, and saved articles?"]
+    C -->|Yes| D["Feed bundle<br/>feeds + reading history,<br/>no app settings"]
+    C -->|No| E["Just your subscription list —<br/>to share, or open elsewhere?"]
+    E -->|Yes| F["OPML export<br/>subscriptions only"]
+    E -->|No| G["Settings bundle only<br/>app preferences, no feeds"]
+```
+
+## Locked design decisions
+
+| Decision | Rationale |
+|---|---|
+| Two-way split only — content+state vs. settings | No per-feed selection or state-exclusion toggle inside a bundle; OPML already serves the no-state case. |
+| Folders and tags live in the Feed bundle | Fixes today's split behavior, where `usersettings.json` excludes them but the portable bundle's `metadata` includes them. |
+| Symmetric import for all three JSON buckets | An export you can't import back isn't a real backup — undercuts the bug-recovery motivation. |
+| No platform restriction | Portability is a stated product value; no usage data justifies gating it to desktop. |
+| Storage-tab / Import-Export-tab button duplication left as-is | Existing tech debt, out of scope for this plan — needs its own follow-up. |
+
+## Out of scope
+
+- Deduplicating the portable-bundle controls currently repeated on both the Storage tab and the Import/Export tab.
+- Per-feed selection or any state-exclusion toggle within the Feed bundle.
+- Platform-specific (desktop-only) restrictions on any export/import path.
+
+## Red-Green TDD Shape
+
+### Red
+
+1. Add `feed-storage-repository` tests that fail until `buildFeedBundle(settings)` and `buildSettingsBundle(settings)` exist, each producing the field subset defined above.
+2. Add import tests that fail until `importFeedBundle(...)` and `importSettingsBundle(...)` exist, each validating and merging only their scope without touching the other.
+3. Add a settings-tab test that fails until "Storage actions" (or wherever this lands) offers all three JSON scopes plus OPML, matching the decision-tree labels above.
+4. Add a `usersettings.json`-equivalent regression test confirming the re-scoped Settings bundle still excludes `feeds`, and now also excludes `folders`/`availableTags` for Feed bundle exports instead of Settings bundle ones.
+
+### Green
+
+1. Implement `buildFeedBundle` / `buildSettingsBundle` in `src/services/feed-storage-repository.ts`, factored out of the existing `buildPortableDataBundle` so the combined bundle stays `{ ...feedBundle, ...settingsBundle }`-equivalent.
+2. Implement matching import functions with the same rollback-on-failure behavior as `importPortableDataBundle`.
+3. Add UI (button group or modal) presenting the four choices from the decision tree; wire to the plugin methods.
+4. Update `CONTEXT.md` with the "Feed bundle" and "Settings bundle" glossary entries once the above lands.

--- a/docs/storage-vault-shards-guide.md
+++ b/docs/storage-vault-shards-guide.md
@@ -149,7 +149,7 @@ Not fully. It improves portability by moving large feed history into a normal va
 
 ### Can I move shard data between devices?
 
-Yes. Use the Import shard data and Export shard data actions in settings for transfer workflows.
+Yes. Use the Import/Export portable data bundle actions in settings for transfer workflows. Note this bundle includes your plugin settings alongside the shard files, not shard data alone.
 
 ### What does Shard Storage v2 change from v1?
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "type": "commonjs",
   "scripts": {
     "dev": "node esbuild.config.mjs",
+    "check:architecture": "node scripts/check-architecture.mjs",
     "check:css-scope": "node scripts/check-css-scope.js",
     "check:platform": "node scripts/check-platform-compat.mjs",
     "check:important": "node scripts/check-css-important.mjs",
-    "check:compliance": "npm run check:css-scope && npm run check:platform && npm run check:important && npm run check:commit-message && npm run check:release-compatibility",
+    "check:compliance": "npm run check:architecture && npm run check:css-scope && npm run check:platform && npm run check:important && npm run check:commit-message && npm run check:release-compatibility",
     "check:commit-message": "node scripts/check-commit-message.mjs",
     "check:release-compatibility": "node scripts/check-release-compatibility.mjs",
     "build": "npm run check:compliance && npm run lint && tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",

--- a/scripts/architecture-baseline.json
+++ b/scripts/architecture-baseline.json
@@ -1,0 +1,49 @@
+{
+  "thresholds": {
+    "fileLines": 1000,
+    "functionLines": 150,
+    "complexity": 20,
+    "parameters": 5
+  },
+  "ratchets": {
+    "mainTsMaxLines": 3468,
+    "allowedMainImporters": [
+      "src/components/discover-sidebar.ts",
+      "src/components/folder-selector-popup.ts",
+      "src/components/sidebar.ts",
+      "src/modals/feed-manager/add-feed-modal.ts",
+      "src/modals/feed-manager/edit-feed-modal.ts",
+      "src/modals/feed-manager/feed-manager-modal.ts",
+      "src/modals/feed-manager/folder-auto-tag-modal.ts",
+      "src/modals/import-opml-modal.ts",
+      "src/modals/import-starred-modal.ts",
+      "src/modals/mobile-discover-filters-modal.ts",
+      "src/modals/mobile-navigation-modal.ts",
+      "src/modals/storage-migration-modal.ts",
+      "src/settings/settings-tab.ts",
+      "src/settings/tabs/about-settings-tab.ts",
+      "src/settings/tabs/display-settings-tab.ts",
+      "src/settings/tabs/highlights-settings-tab.ts",
+      "src/settings/tabs/import-export-settings-tab.ts",
+      "src/settings/tabs/rules-settings-tab.ts",
+      "src/settings/tabs/sidebar-settings-tab.ts",
+      "src/settings/tabs/tags-settings-tab.ts",
+      "src/views/dashboard-view.ts",
+      "src/views/discover-view.ts",
+      "src/views/kagi-smallweb-view.ts"
+    ],
+    "allowedRuntimeCycleNodeSets": [
+      ["src/views/dashboard-view.ts", "src/views/reader-view.ts"],
+      [
+        "main.ts",
+        "src/settings/settings-tab.ts",
+        "src/settings/tabs/about-settings-tab.ts",
+        "src/settings/tabs/display-settings-tab.ts",
+        "src/settings/tabs/highlights-settings-tab.ts",
+        "src/settings/tabs/rules-settings-tab.ts",
+        "src/settings/tabs/sidebar-settings-tab.ts",
+        "src/settings/tabs/tags-settings-tab.ts"
+      ]
+    ]
+  }
+}

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1,0 +1,565 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const baselinePath = path.join(scriptDirectory, "architecture-baseline.json");
+const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+const baseArgumentIndex = process.argv.indexOf("--base");
+const baseReference =
+  baseArgumentIndex >= 0 ? process.argv[baseArgumentIndex + 1] : undefined;
+
+if (baseArgumentIndex >= 0 && !baseReference) {
+  console.error("Architecture check: --base requires a Git reference.");
+  process.exit(2);
+}
+
+function toRepositoryPath(filePath) {
+  return path.relative(repositoryRoot, filePath).replaceAll("\\", "/");
+}
+
+function collectTypeScriptFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return collectTypeScriptFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith(".ts") ? [entryPath] : [];
+  });
+}
+
+const productionFiles = [
+  path.join(repositoryRoot, "main.ts"),
+  ...collectTypeScriptFiles(path.join(repositoryRoot, "src")),
+];
+const productionPaths = productionFiles.map(toRepositoryPath).sort();
+
+function isFunctionNode(node) {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isFunctionExpression(node)
+  );
+}
+
+function getFunctionName(node, sourceFile) {
+  if (node.name?.getText) return node.name.getText(sourceFile);
+  if (ts.isConstructorDeclaration(node)) return "constructor";
+  if (ts.isVariableDeclaration(node.parent)) {
+    return node.parent.name.getText(sourceFile);
+  }
+  if (ts.isPropertyAssignment(node.parent)) {
+    return node.parent.name.getText(sourceFile);
+  }
+  return "<anonymous>";
+}
+
+function measureComplexity(functionNode) {
+  let complexity = 1;
+
+  function visit(node) {
+    if (node !== functionNode && isFunctionNode(node)) return;
+
+    if (
+      ts.isIfStatement(node) ||
+      ts.isForStatement(node) ||
+      ts.isForInStatement(node) ||
+      ts.isForOfStatement(node) ||
+      ts.isWhileStatement(node) ||
+      ts.isDoStatement(node) ||
+      ts.isConditionalExpression(node) ||
+      ts.isCatchClause(node) ||
+      ts.isCaseClause(node)
+    ) {
+      complexity += 1;
+    }
+
+    if (
+      ts.isBinaryExpression(node) &&
+      [
+        ts.SyntaxKind.AmpersandAmpersandToken,
+        ts.SyntaxKind.BarBarToken,
+        ts.SyntaxKind.QuestionQuestionToken,
+      ].includes(node.operatorToken.kind)
+    ) {
+      complexity += 1;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  if (functionNode.body) visit(functionNode.body);
+  return complexity;
+}
+
+function isTypeOnlyImport(importDeclaration) {
+  const importClause = importDeclaration.importClause;
+  if (!importClause) return false;
+  if (importClause.isTypeOnly) return true;
+
+  const bindings = importClause.namedBindings;
+  return (
+    bindings &&
+    ts.isNamedImports(bindings) &&
+    bindings.elements.length > 0 &&
+    bindings.elements.every((element) => element.isTypeOnly)
+  );
+}
+
+function analyzeFile(repositoryPath, sourceText) {
+  const sourceFile = ts.createSourceFile(
+    repositoryPath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const functions = [];
+  const nameCounts = new Map();
+  const imports = [];
+
+  function visit(node) {
+    if (isFunctionNode(node) && node.body) {
+      const start =
+        sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+          .line + 1;
+      const end = sourceFile.getLineAndCharacterOfPosition(node.end).line + 1;
+      const name = getFunctionName(node, sourceFile);
+      const occurrence = (nameCounts.get(name) ?? 0) + 1;
+      nameCounts.set(name, occurrence);
+      functions.push({
+        key: repositoryPath + "::" + name + "#" + occurrence,
+        file: repositoryPath,
+        name,
+        start,
+        lines: end - start + 1,
+        complexity: measureComplexity(node),
+        parameters: node.parameters?.length ?? 0,
+      });
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isImportDeclaration(statement) &&
+      ts.isStringLiteral(statement.moduleSpecifier) &&
+      statement.moduleSpecifier.text.startsWith(".")
+    ) {
+      imports.push({
+        specifier: statement.moduleSpecifier.text,
+        typeOnly: isTypeOnlyImport(statement),
+      });
+    }
+  }
+
+  visit(sourceFile);
+  return {
+    file: repositoryPath,
+    lines: sourceText.split(/\r?\n/).length,
+    functions,
+    imports,
+  };
+}
+
+function resolveImport(fromPath, specifier, availablePaths) {
+  const basePath = path.posix.normalize(
+    path.posix.join(path.posix.dirname(fromPath), specifier),
+  );
+  const candidates = [
+    basePath,
+    basePath + ".ts",
+    basePath.replace(/\.js$/, ".ts"),
+    path.posix.join(basePath, "index.ts"),
+  ];
+  return candidates.find((candidate) => availablePaths.has(candidate));
+}
+
+function findRuntimeCycles(files, runtimeGraph) {
+  let nextId = 0;
+  const ids = new Map();
+  const lowLinks = new Map();
+  const stack = [];
+  const onStack = new Set();
+  const cycles = [];
+
+  function connect(file) {
+    ids.set(file, nextId);
+    lowLinks.set(file, nextId);
+    nextId += 1;
+    stack.push(file);
+    onStack.add(file);
+
+    for (const dependency of runtimeGraph.get(file) ?? []) {
+      if (!ids.has(dependency)) {
+        connect(dependency);
+        lowLinks.set(
+          file,
+          Math.min(lowLinks.get(file), lowLinks.get(dependency)),
+        );
+      } else if (onStack.has(dependency)) {
+        lowLinks.set(file, Math.min(lowLinks.get(file), ids.get(dependency)));
+      }
+    }
+
+    if (lowLinks.get(file) !== ids.get(file)) return;
+
+    const members = [];
+    let member;
+    do {
+      member = stack.pop();
+      onStack.delete(member);
+      members.push(member);
+    } while (member !== file);
+
+    if (members.length > 1) cycles.push(members.sort());
+  }
+
+  for (const file of files) {
+    if (!ids.has(file)) connect(file);
+  }
+  return cycles.sort((left, right) => left.join().localeCompare(right.join()));
+}
+
+function buildSnapshot(readSource) {
+  const files = [];
+  for (const repositoryPath of productionPaths) {
+    const sourceText = readSource(repositoryPath);
+    if (sourceText !== null)
+      files.push(analyzeFile(repositoryPath, sourceText));
+  }
+
+  const availablePaths = new Set(files.map((file) => file.file));
+  const allGraph = new Map();
+  const runtimeGraph = new Map();
+
+  for (const file of files) {
+    const allDependencies = [];
+    const runtimeDependencies = [];
+    for (const importEntry of file.imports) {
+      const target = resolveImport(
+        file.file,
+        importEntry.specifier,
+        availablePaths,
+      );
+      if (!target) continue;
+      allDependencies.push(target);
+      if (!importEntry.typeOnly) runtimeDependencies.push(target);
+    }
+    allGraph.set(file.file, [...new Set(allDependencies)]);
+    runtimeGraph.set(file.file, [...new Set(runtimeDependencies)]);
+  }
+
+  const functions = files.flatMap((file) => file.functions);
+  const mainImporters = files
+    .filter((file) => (allGraph.get(file.file) ?? []).includes("main.ts"))
+    .map((file) => file.file)
+    .sort();
+
+  return {
+    files,
+    functions,
+    allGraph,
+    runtimeCycles: findRuntimeCycles(
+      files.map((file) => file.file),
+      runtimeGraph,
+    ),
+    mainImporters,
+  };
+}
+
+const currentSnapshot = buildSnapshot((repositoryPath) =>
+  fs.readFileSync(path.join(repositoryRoot, repositoryPath), "utf8"),
+);
+
+function printOutliers(label, entries, valueName, threshold) {
+  const sorted = [...entries].sort(
+    (left, right) => right[valueName] - left[valueName],
+  );
+  console.log(
+    "WARN " +
+      label +
+      ": " +
+      sorted.length +
+      " exceed " +
+      threshold +
+      " (" +
+      ((sorted.length / currentSnapshot.functions.length) * 100).toFixed(2) +
+      "% of functions)",
+  );
+  for (const entry of sorted.slice(0, 10)) {
+    console.log(
+      "  " +
+        entry.file +
+        ":" +
+        entry.start +
+        " " +
+        entry.name +
+        " (" +
+        entry[valueName] +
+        ")",
+    );
+  }
+  if (sorted.length > 10)
+    console.log("  ... " + (sorted.length - 10) + " more");
+}
+
+const thresholds = baseline.thresholds;
+const largeFiles = currentSnapshot.files.filter(
+  (file) => file.lines > thresholds.fileLines,
+);
+console.log("Architecture observations");
+console.log(
+  "WARN file size: " +
+    largeFiles.length +
+    " of " +
+    currentSnapshot.files.length +
+    " production files exceed " +
+    thresholds.fileLines +
+    " physical lines (" +
+    ((largeFiles.length / currentSnapshot.files.length) * 100).toFixed(2) +
+    "%)",
+);
+for (const file of [...largeFiles].sort((a, b) => b.lines - a.lines)) {
+  console.log("  " + file.file + " (" + file.lines + ")");
+}
+
+printOutliers(
+  "function size",
+  currentSnapshot.functions.filter(
+    (entry) => entry.lines > thresholds.functionLines,
+  ),
+  "lines",
+  thresholds.functionLines,
+);
+printOutliers(
+  "branch complexity",
+  currentSnapshot.functions.filter(
+    (entry) => entry.complexity > thresholds.complexity,
+  ),
+  "complexity",
+  thresholds.complexity,
+);
+printOutliers(
+  "parameter count",
+  currentSnapshot.functions.filter(
+    (entry) => entry.parameters > thresholds.parameters,
+  ),
+  "parameters",
+  thresholds.parameters,
+);
+
+const errors = [];
+const mainFile = currentSnapshot.files.find((file) => file.file === "main.ts");
+if (!mainFile) {
+  errors.push("main.ts is missing from the production source set.");
+} else if (mainFile.lines > baseline.ratchets.mainTsMaxLines) {
+  errors.push(
+    "main.ts grew to " +
+      mainFile.lines +
+      " lines; ratchet maximum is " +
+      baseline.ratchets.mainTsMaxLines +
+      ".",
+  );
+} else if (mainFile.lines < baseline.ratchets.mainTsMaxLines) {
+  errors.push(
+    "main.ts shrank to " +
+      mainFile.lines +
+      " lines; lower the ratchet from " +
+      baseline.ratchets.mainTsMaxLines +
+      " in the same change.",
+  );
+}
+
+const allowedMainImporters = new Set(
+  baseline.ratchets.allowedMainImporters ?? [],
+);
+for (const importer of currentSnapshot.mainImporters) {
+  if (!allowedMainImporters.has(importer)) {
+    errors.push("New production importer of main.ts: " + importer);
+  }
+}
+for (const importer of allowedMainImporters) {
+  if (!currentSnapshot.mainImporters.includes(importer)) {
+    errors.push(
+      "Remove stale main.ts importer allowance after decoupling: " + importer,
+    );
+  }
+}
+
+const forbiddenServiceTargets = [
+  "main.ts",
+  "src/views/",
+  "src/components/",
+  "src/modals/",
+  "src/settings/",
+];
+for (const [file, dependencies] of currentSnapshot.allGraph) {
+  if (!file.startsWith("src/services/")) continue;
+  for (const dependency of dependencies) {
+    if (
+      forbiddenServiceTargets.some(
+        (target) =>
+          dependency === target ||
+          (target.endsWith("/") && dependency.startsWith(target)),
+      )
+    ) {
+      errors.push(
+        "Service dependency points upward: " + file + " -> " + dependency,
+      );
+    }
+  }
+}
+
+const allowedCycleSets = (
+  baseline.ratchets.allowedRuntimeCycleNodeSets ?? []
+).map((cycle) => new Set(cycle));
+for (const cycle of currentSnapshot.runtimeCycles) {
+  const coveredByBaseline = allowedCycleSets.some((allowed) =>
+    cycle.every((member) => allowed.has(member)),
+  );
+  if (!coveredByBaseline) {
+    errors.push("New runtime cycle: " + cycle.join(" -> "));
+  }
+}
+for (const allowedCycle of baseline.ratchets.allowedRuntimeCycleNodeSets ??
+  []) {
+  const allowanceStillNeeded = currentSnapshot.runtimeCycles.some(
+    (cycle) =>
+      cycle.length === allowedCycle.length &&
+      cycle.every((member) => allowedCycle.includes(member)),
+  );
+  if (!allowanceStillNeeded) {
+    errors.push(
+      "Remove or narrow stale runtime-cycle allowance: " +
+        allowedCycle.join(" -> "),
+    );
+  }
+}
+
+function readGitSource(reference, repositoryPath) {
+  try {
+    return execFileSync("git", ["show", reference + ":" + repositoryPath], {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+      maxBuffer: 20 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function printArchitectureDiff(reference) {
+  const baseSnapshot = buildSnapshot((repositoryPath) =>
+    readGitSource(reference, repositoryPath),
+  );
+  if (baseSnapshot.files.length === 0) {
+    errors.push(
+      "Cannot read production sources from Git reference " + reference + ".",
+    );
+    return;
+  }
+
+  const baseFiles = new Map(
+    baseSnapshot.files.map((file) => [file.file, file]),
+  );
+  const changedFiles = currentSnapshot.files
+    .map((file) => ({
+      file: file.file,
+      delta: file.lines - (baseFiles.get(file.file)?.lines ?? 0),
+    }))
+    .filter((entry) => entry.delta !== 0)
+    .sort((left, right) => Math.abs(right.delta) - Math.abs(left.delta));
+
+  const baseFunctions = new Map(
+    baseSnapshot.functions.map((entry) => [entry.key, entry]),
+  );
+  const crossingDefinitions = [
+    ["function lines", "lines", thresholds.functionLines],
+    ["branch complexity", "complexity", thresholds.complexity],
+    ["parameters", "parameters", thresholds.parameters],
+  ];
+  const crossings = [];
+  for (const [label, property, threshold] of crossingDefinitions) {
+    for (const entry of currentSnapshot.functions) {
+      const previous = baseFunctions.get(entry.key)?.[property] ?? 0;
+      if (entry[property] > threshold && previous <= threshold) {
+        crossings.push(
+          label +
+            ": " +
+            entry.file +
+            ":" +
+            entry.start +
+            " " +
+            entry.name +
+            " (" +
+            previous +
+            " -> " +
+            entry[property] +
+            ")",
+        );
+      }
+    }
+  }
+
+  const baseImporterSet = new Set(baseSnapshot.mainImporters);
+  const newMainImporters = currentSnapshot.mainImporters.filter(
+    (file) => !baseImporterSet.has(file),
+  );
+  const newCycles = currentSnapshot.runtimeCycles.filter(
+    (cycle) =>
+      !baseSnapshot.runtimeCycles.some((oldCycle) =>
+        cycle.every((member) => oldCycle.includes(member)),
+      ),
+  );
+
+  console.log("");
+  console.log("Architecture diff against " + reference);
+  const mainDelta =
+    (currentSnapshot.files.find((file) => file.file === "main.ts")?.lines ??
+      0) - (baseFiles.get("main.ts")?.lines ?? 0);
+  console.log(
+    "  main.ts LOC delta: " + (mainDelta >= 0 ? "+" : "") + mainDelta,
+  );
+  console.log("  changed production files: " + changedFiles.length);
+  for (const entry of changedFiles.slice(0, 10)) {
+    console.log(
+      "    " + entry.file + ": " + (entry.delta >= 0 ? "+" : "") + entry.delta,
+    );
+  }
+  if (changedFiles.length > 10) {
+    console.log("    ... " + (changedFiles.length - 10) + " more");
+  }
+  console.log("  new threshold crossings: " + crossings.length);
+  for (const crossing of crossings.slice(0, 10)) console.log("    " + crossing);
+  if (crossings.length > 10)
+    console.log("    ... " + (crossings.length - 10) + " more");
+  console.log(
+    "  new main.ts importers: " +
+      (newMainImporters.length ? newMainImporters.join(", ") : "none"),
+  );
+  console.log(
+    "  new runtime cycles: " +
+      (newCycles.length
+        ? newCycles.map((cycle) => cycle.join(" -> ")).join("; ")
+        : "none"),
+  );
+}
+
+if (baseReference) printArchitectureDiff(baseReference);
+
+console.log("");
+console.log("Architecture guardrails");
+if (errors.length === 0) {
+  console.log(
+    "PASS main.ts ratchet, main.ts importer ratchet, service dependency direction, and runtime-cycle ratchet.",
+  );
+} else {
+  for (const error of errors) console.error("ERROR " + error);
+  process.exitCode = 1;
+}

--- a/src/settings/tabs/storage-settings-tab.ts
+++ b/src/settings/tabs/storage-settings-tab.ts
@@ -348,7 +348,7 @@ export function renderStorageSettingsTab(
   storageActions
     .setName("Storage actions")
     .setDesc(
-      "Apply the selected storage mode, repair shard files, or export a portable bundle for desktop/mobile transfer workflows.",
+      "Apply the selected storage mode, repair shard files, or import/export a portable data bundle (your settings and all feed shard files together) for desktop/mobile transfer workflows.",
     )
     .addButton((button) =>
       button
@@ -532,7 +532,7 @@ export function renderStorageSettingsTab(
       }),
     )
     .addButton((button) =>
-      button.setButtonText("Import shard data").onClick(() => {
+      button.setButtonText("Import portable data bundle").onClick(() => {
         const input = activeDocument.body.createEl("input", {
           attr: { type: "file", accept: ".json,.backup,application/json" },
         });
@@ -540,19 +540,19 @@ export function renderStorageSettingsTab(
           void (async () => {
             const file = input.files?.[0];
             if (!file) return;
-            storageLog("Clicked import shard data", {
+            storageLog("Clicked import portable data bundle", {
               currentMode: plugin.settings.storageMode,
               folder: plugin.settings.storageFolder,
             });
             try {
               await plugin.importPortableDataBundleFromFile(file);
             } catch (error) {
-              storageError("Shard data import failed", error, {
+              storageError("Portable data bundle import failed", error, {
                 currentMode: plugin.settings.storageMode,
                 folder: plugin.settings.storageFolder,
               });
               new Notice(
-                `Shard data import failed${
+                `Portable data bundle import failed${
                   error instanceof Error ? `: ${error.message}` : ""
                 }`,
               );
@@ -563,21 +563,21 @@ export function renderStorageSettingsTab(
       }),
     )
     .addButton((button) =>
-      button.setButtonText("Export shard data").onClick(() => {
+      button.setButtonText("Export portable data bundle").onClick(() => {
         void (async () => {
-          storageLog("Clicked export shard data", {
+          storageLog("Clicked export portable data bundle", {
             currentMode: plugin.settings.storageMode,
             folder: plugin.settings.storageFolder,
           });
           try {
             await plugin.exportPortableDataBundle();
           } catch (error) {
-            storageError("Shard data export failed", error, {
+            storageError("Portable data bundle export failed", error, {
               currentMode: plugin.settings.storageMode,
               folder: plugin.settings.storageFolder,
             });
             new Notice(
-              `Shard data export failed${
+              `Portable data bundle export failed${
                 error instanceof Error ? `: ${error.message}` : ""
               }`,
             );

--- a/test_files/unit/settings/storage-settings-general-tab.test.ts
+++ b/test_files/unit/settings/storage-settings-general-tab.test.ts
@@ -142,10 +142,10 @@ describe("General settings storage section", () => {
       (button) => button.textContent === "Repair/rebuild storage",
     ) as HTMLButtonElement;
     const importButton = buttons.find(
-      (button) => button.textContent === "Import shard data",
+      (button) => button.textContent === "Import portable data bundle",
     ) as HTMLButtonElement;
     const exportButton = buttons.find(
-      (button) => button.textContent === "Export shard data",
+      (button) => button.textContent === "Export portable data bundle",
     ) as HTMLButtonElement;
 
     applyButton.click();


### PR DESCRIPTION
Adds architecture drift guardrails, including a main.ts growth ratchet, dependency checks, architecture preflight, and handoff reporting; intended for merge immediately after v2.7.0.